### PR TITLE
feat: add enforce-repo-settings workflow for ecosystem bootstrap

### DIFF
--- a/.github/workflows/enforce-repo-settings.yml
+++ b/.github/workflows/enforce-repo-settings.yml
@@ -1,0 +1,486 @@
+---
+name: Enforce Repository Settings
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/config/repo-settings.json'
+  workflow_call:
+    secrets:
+      repo-settings-token:
+        description: 'PAT with admin permissions for repository settings'
+        required: true
+      REPO_SETTINGS_TOKEN:
+        description: 'Repo-level fallback used by push trigger context'
+        required: false
+
+permissions:
+  contents: read
+
+jobs:
+  enforce:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout calling repo
+        uses: actions/checkout@v6
+
+      - name: Enforce repository settings
+        env:
+          GH_TOKEN: ${{ secrets.repo-settings-token || secrets.REPO_SETTINGS_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          # ─── Retry helpers ─────────────────────────────────────────────────
+          # Retry with exponential backoff (for commands without stdin)
+          # Usage: retry <max_attempts> <command> [args...]
+          retry() {
+            local max="$1"; shift
+            local attempt=1
+            local delay=2
+            while true; do
+              if "$@"; then return 0; fi
+              if [ "$attempt" -ge "$max" ]; then
+                echo "[ERROR] Failed after ${max} attempts: $*" >&2
+                return 1
+              fi
+              echo "[WARN] Attempt ${attempt}/${max} failed — retrying in ${delay}s..." >&2
+              sleep "$delay"
+              attempt=$((attempt + 1))
+              delay=$((delay * 2))
+            done
+          }
+
+          # Retry with JSON body (for gh api --input - calls)
+          # Usage: retry_json <max_attempts> <json_string> <gh api args...>
+          retry_json() {
+            local max="$1"; shift
+            local json="$1"; shift
+            local attempt=1
+            local delay=2
+            while true; do
+              if echo "$json" | gh api "$@" --input -; then return 0; fi
+              if [ "$attempt" -ge "$max" ]; then
+                echo "[ERROR] Failed after ${max} attempts: gh api $*" >&2
+                return 1
+              fi
+              echo "[WARN] Attempt ${attempt}/${max} failed — retrying in ${delay}s..." >&2
+              sleep "$delay"
+              attempt=$((attempt + 1))
+              delay=$((delay * 2))
+            done
+          }
+
+          OWNER="${GITHUB_REPOSITORY%/*}"
+          REPO="${GITHUB_REPOSITORY#*/}"
+          CONFIG_REPO="f5xc-salesdemos/docs-control"
+          CONFIG_PATH=".github/config/repo-settings.json"
+
+          # ─── Phase 1: Validate ─────────────────────────────────────────────
+          echo "=== Phase 1: Validate ==="
+
+          if ! command -v jq &>/dev/null; then
+            echo "[ERROR] jq is not installed" >&2; exit 1
+          fi
+          if ! command -v gh &>/dev/null; then
+            echo "[ERROR] gh CLI is not installed" >&2; exit 1
+          fi
+          if ! gh auth status &>/dev/null; then
+            echo "[ERROR] gh is not authenticated" >&2; exit 1
+          fi
+
+          # Fetch central config from docs-control
+          echo "[INFO] Fetching config from ${CONFIG_REPO}/${CONFIG_PATH}..."
+          CONFIG_B64=$(retry 5 gh api "repos/${CONFIG_REPO}/contents/${CONFIG_PATH}" --jq '.content')
+          CONFIG=$(echo "$CONFIG_B64" | base64 -d)
+          if ! echo "$CONFIG" | jq empty 2>/dev/null; then
+            echo "[ERROR] Failed to fetch or parse config from ${CONFIG_REPO}" >&2; exit 1
+          fi
+          echo "[OK] Fetched config from ${CONFIG_REPO}"
+
+          # Auto-compute homepage if empty
+          HOMEPAGE=$(echo "$CONFIG" | jq -r '.repository.homepage // empty')
+          if [ -z "$HOMEPAGE" ]; then
+            HOMEPAGE="https://f5xc-salesdemos.github.io/${REPO}/"
+            CONFIG=$(echo "$CONFIG" | jq --arg hp "$HOMEPAGE" '.repository.homepage = $hp')
+            echo "[INFO] Auto-computed homepage: $HOMEPAGE"
+          fi
+
+          echo "[OK] Config validated for ${OWNER}/${REPO}"
+
+          # ─── Self-detection ──────────────────────────────────────────────────
+          SOURCE_REPO=$(echo "$CONFIG" | jq -r '.managed_files.source_repo // empty')
+          IS_SELF=false
+          if [ "$SOURCE_REPO" = "${{ github.repository }}" ]; then
+            IS_SELF=true
+            echo "[INFO] Running on source repo — will use self_contexts if present"
+          fi
+
+          # ─── Phase 2: Apply repo settings ────────────────────────────────────
+          echo ""
+          echo "=== Phase 2: Apply repo settings ==="
+
+          DESIRED_REPO=$(echo "$CONFIG" | jq -c '.repository')
+          CURRENT_REPO=$(retry 3 gh api "repos/${OWNER}/${REPO}")
+
+          REPO_DRIFT=false
+          REPO_PATCH="{}"
+
+          for key in $(echo "$DESIRED_REPO" | jq -r 'keys[]'); do
+            desired_val=$(echo "$DESIRED_REPO" | jq -c ".[\"$key\"]")
+            current_val=$(echo "$CURRENT_REPO" | jq -c ".[\"$key\"]")
+            if [ "$desired_val" != "$current_val" ]; then
+              echo "[WARN] Drift in repo.$key: current=$current_val desired=$desired_val"
+              REPO_PATCH=$(echo "$REPO_PATCH" | jq --argjson v "$desired_val" ". + {\"$key\": \$v}")
+              REPO_DRIFT=true
+            fi
+          done
+
+          if [ "$REPO_DRIFT" = true ]; then
+            echo "[INFO] Patching repository settings..."
+            retry_json 3 "$REPO_PATCH" "repos/${OWNER}/${REPO}" --method PATCH >/dev/null
+            echo "[OK] Repository settings updated"
+          else
+            echo "[OK] Repository settings match — no changes needed"
+          fi
+
+          # ─── Phase 3: Apply Actions permissions ──────────────────────────────
+          echo ""
+          echo "=== Phase 3: Apply Actions permissions ==="
+
+          DESIRED_ACTIONS=$(echo "$CONFIG" | jq -c '.actions_permissions // empty')
+
+          if [ -n "$DESIRED_ACTIONS" ]; then
+            CURRENT_ACTIONS=$(retry 3 gh api "repos/${OWNER}/${REPO}/actions/permissions/workflow")
+            ACTIONS_DRIFT=false
+
+            for key in $(echo "$DESIRED_ACTIONS" | jq -r 'keys[]'); do
+              desired_val=$(echo "$DESIRED_ACTIONS" | jq -c ".[\"$key\"]")
+              current_val=$(echo "$CURRENT_ACTIONS" | jq -c ".[\"$key\"]")
+              if [ "$desired_val" != "$current_val" ]; then
+                echo "[WARN] Drift in actions.$key: current=$current_val desired=$desired_val"
+                ACTIONS_DRIFT=true
+              fi
+            done
+
+            if [ "$ACTIONS_DRIFT" = true ]; then
+              echo "[INFO] Updating Actions workflow permissions..."
+              retry_json 3 "$DESIRED_ACTIONS" "repos/${OWNER}/${REPO}/actions/permissions/workflow" \
+                --method PUT >/dev/null
+              echo "[OK] Actions permissions updated"
+            else
+              echo "[OK] Actions permissions match — no changes needed"
+            fi
+          else
+            echo "[SKIP] No actions_permissions in config"
+          fi
+
+          # ─── Phase 4: Apply branch protection ────────────────────────────────
+          echo ""
+          echo "=== Phase 4: Apply branch protection ==="
+
+          BRANCH_COUNT=$(echo "$CONFIG" | jq '.branch_protection | length')
+
+          for i in $(seq 0 $((BRANCH_COUNT - 1))); do
+            BRANCH=$(echo "$CONFIG" | jq -r ".branch_protection[$i].branch")
+            echo "--- Branch: $BRANCH ---"
+
+            DESIRED_PAYLOAD=$(echo "$CONFIG" | jq -c ".branch_protection[$i] | del(.branch)")
+
+            # self_contexts override: use self_contexts instead of contexts for source repo
+            if [ "$IS_SELF" = true ]; then
+              SELF_CTX=$(echo "$DESIRED_PAYLOAD" | jq -c '.required_status_checks.self_contexts // empty')
+              if [ -n "$SELF_CTX" ] && [ "$SELF_CTX" != "null" ]; then
+                DESIRED_PAYLOAD=$(echo "$DESIRED_PAYLOAD" | jq -c \
+                  '.required_status_checks.contexts = .required_status_checks.self_contexts')
+                echo "[INFO] Overriding contexts with self_contexts for source repo"
+              fi
+            fi
+            # Strip self_contexts from payload (not part of GitHub API)
+            DESIRED_PAYLOAD=$(echo "$DESIRED_PAYLOAD" | jq -c \
+              'if .required_status_checks then
+                .required_status_checks |= del(.self_contexts)
+              else . end')
+
+            # Merge per-repo additional contexts from repo_overrides
+            REPO_OVERRIDES=$(echo "$CONFIG" | jq -c ".repo_overrides[\"${REPO}\"] // empty")
+            if [ -n "$REPO_OVERRIDES" ] && [ "$REPO_OVERRIDES" != "null" ]; then
+              if [ "$IS_SELF" = true ]; then
+                EXTRA_CTX=$(echo "$REPO_OVERRIDES" | jq -c '.additional_self_contexts // []')
+              else
+                EXTRA_CTX=$(echo "$REPO_OVERRIDES" | jq -c '.additional_contexts // []')
+              fi
+              if [ "$EXTRA_CTX" != "[]" ]; then
+                DESIRED_PAYLOAD=$(echo "$DESIRED_PAYLOAD" | jq -c \
+                  --argjson extra "$EXTRA_CTX" \
+                  '.required_status_checks.contexts = (.required_status_checks.contexts + $extra | unique)')
+                echo "[INFO] Merged additional contexts for ${REPO}: $EXTRA_CTX"
+              fi
+            fi
+
+            HTTP_CODE=$(retry 3 gh api "repos/${OWNER}/${REPO}/branches/${BRANCH}/protection" \
+              --include 2>/dev/null | head -1 | awk '{print $2}') || true
+            CURRENT_PROTECTION=$(retry 3 gh api "repos/${OWNER}/${REPO}/branches/${BRANCH}/protection" 2>/dev/null) || true
+
+            PROTECTION_DRIFT=false
+
+            if [ "$HTTP_CODE" = "404" ] || [ -z "$CURRENT_PROTECTION" ]; then
+              echo "[WARN] No branch protection found — will create"
+              PROTECTION_DRIFT=true
+            else
+              desired_enforce=$(echo "$DESIRED_PAYLOAD" | jq '.enforce_admins')
+              current_enforce=$(echo "$CURRENT_PROTECTION" | jq '.enforce_admins.enabled')
+              if [ "$desired_enforce" != "$current_enforce" ]; then
+                echo "[WARN] Drift in enforce_admins: current=$current_enforce desired=$desired_enforce"
+                PROTECTION_DRIFT=true
+              fi
+
+              desired_checks=$(echo "$DESIRED_PAYLOAD" | jq -c '.required_status_checks')
+              current_checks_raw=$(echo "$CURRENT_PROTECTION" | jq -c '.required_status_checks')
+              if [ "$current_checks_raw" != "null" ]; then
+                current_checks=$(echo "$current_checks_raw" | jq -c '{strict: .strict, contexts: (.contexts | sort)}')
+              else
+                current_checks="null"
+              fi
+              if [ "$desired_checks" != "null" ]; then
+                desired_checks_norm=$(echo "$desired_checks" | jq -c '{strict: .strict, contexts: (.contexts | sort)}')
+              else
+                desired_checks_norm="null"
+              fi
+              if [ "$desired_checks_norm" != "$current_checks" ]; then
+                echo "[WARN] Drift in required_status_checks"
+                PROTECTION_DRIFT=true
+              fi
+
+              desired_reviews=$(echo "$DESIRED_PAYLOAD" | jq -c '.required_pull_request_reviews')
+              if [ "$desired_reviews" != "null" ]; then
+                for review_key in required_approving_review_count dismiss_stale_reviews require_code_owner_reviews require_last_push_approval; do
+                  desired_val=$(echo "$desired_reviews" | jq ".$review_key")
+                  current_val=$(echo "$CURRENT_PROTECTION" | jq ".required_pull_request_reviews.$review_key // false")
+                  if [ "$desired_val" != "$current_val" ]; then
+                    echo "[WARN] Drift in $review_key: current=$current_val desired=$desired_val"
+                    PROTECTION_DRIFT=true
+                  fi
+                done
+              fi
+
+              desired_restrictions=$(echo "$DESIRED_PAYLOAD" | jq -c '.restrictions')
+              if [ "$desired_restrictions" = "null" ]; then
+                current_restrictions=$(echo "$CURRENT_PROTECTION" | jq -c '.restrictions')
+                if [ "$current_restrictions" != "null" ]; then
+                  echo "[WARN] Drift in restrictions"
+                  PROTECTION_DRIFT=true
+                fi
+              fi
+
+              for flag in required_linear_history allow_force_pushes allow_deletions block_creations required_conversation_resolution lock_branch allow_fork_syncing; do
+                desired_flag=$(echo "$DESIRED_PAYLOAD" | jq ".$flag")
+                current_flag=$(echo "$CURRENT_PROTECTION" | jq ".$flag.enabled // false")
+                if [ "$desired_flag" != "$current_flag" ]; then
+                  echo "[WARN] Drift in $flag: current=$current_flag desired=$desired_flag"
+                  PROTECTION_DRIFT=true
+                fi
+              done
+            fi
+
+            if [ "$PROTECTION_DRIFT" = true ]; then
+              echo "[INFO] Applying branch protection for $BRANCH..."
+
+              PUT_PAYLOAD=$(jq -n \
+                --argjson desired "$DESIRED_PAYLOAD" \
+                '{
+                  enforce_admins: $desired.enforce_admins,
+                  required_status_checks: $desired.required_status_checks,
+                  required_pull_request_reviews: (
+                    if $desired.required_pull_request_reviews == null then null
+                    else {
+                      required_approving_review_count: $desired.required_pull_request_reviews.required_approving_review_count,
+                      dismiss_stale_reviews: $desired.required_pull_request_reviews.dismiss_stale_reviews,
+                      require_code_owner_reviews: $desired.required_pull_request_reviews.require_code_owner_reviews,
+                      require_last_push_approval: $desired.required_pull_request_reviews.require_last_push_approval
+                    }
+                    end
+                  ),
+                  restrictions: $desired.restrictions,
+                  required_linear_history: $desired.required_linear_history,
+                  allow_force_pushes: $desired.allow_force_pushes,
+                  allow_deletions: $desired.allow_deletions,
+                  block_creations: $desired.block_creations,
+                  required_conversation_resolution: $desired.required_conversation_resolution,
+                  lock_branch: $desired.lock_branch,
+                  allow_fork_syncing: $desired.allow_fork_syncing
+                }')
+
+              retry_json 3 "$PUT_PAYLOAD" "repos/${OWNER}/${REPO}/branches/${BRANCH}/protection" \
+                --method PUT >/dev/null
+              echo "[OK] Branch protection updated for $BRANCH"
+            else
+              echo "[OK] Branch protection matches — no changes needed"
+            fi
+          done
+
+          # ─── Phase 5: Apply topics ────────────────────────────────────────────
+          echo ""
+          echo "=== Phase 5: Apply topics ==="
+
+          DESIRED_TOPICS=$(echo "$CONFIG" | jq -c '.topics // []')
+          if [ "$DESIRED_TOPICS" != "[]" ]; then
+            CURRENT_TOPICS=$(retry 3 gh api "repos/${OWNER}/${REPO}/topics" | jq -c '.names // []')
+            if [ "$DESIRED_TOPICS" != "$CURRENT_TOPICS" ]; then
+              echo "[WARN] Drift in topics: current=$CURRENT_TOPICS desired=$DESIRED_TOPICS"
+              echo "[INFO] Updating topics..."
+              TOPICS_JSON=$(jq -n --argjson names "$DESIRED_TOPICS" '{"names": $names}')
+              retry_json 3 "$TOPICS_JSON" "repos/${OWNER}/${REPO}/topics" --method PUT >/dev/null
+              echo "[OK] Topics updated"
+            else
+              echo "[OK] Topics match — no changes needed"
+            fi
+          else
+            echo "[SKIP] No topics specified"
+          fi
+
+          # ─── Phase 6: Apply Pages ─────────────────────────────────────────────
+          echo ""
+          echo "=== Phase 6: Apply Pages ==="
+
+          PAGES_ENABLED=$(echo "$CONFIG" | jq -r '.pages.enabled // false')
+          DESIRED_BUILD_TYPE=$(echo "$CONFIG" | jq -r '.pages.build_type // "workflow"')
+          if [ "$PAGES_ENABLED" = "true" ]; then
+            PAGES_HTTP_CODE=$(retry 3 gh api "repos/${OWNER}/${REPO}/pages" --include 2>/dev/null | head -1 | awk '{print $2}') || true
+            PAGES_JSON=$(jq -n --arg bt "$DESIRED_BUILD_TYPE" '{"build_type": $bt, "source": {"branch": "main", "path": "/"}}')
+            if [ "$PAGES_HTTP_CODE" = "404" ]; then
+              echo "[INFO] Enabling GitHub Pages with ${DESIRED_BUILD_TYPE} source..."
+              retry_json 3 "$PAGES_JSON" "repos/${OWNER}/${REPO}/pages" --method POST >/dev/null 2>&1 || true
+              echo "[OK] Pages enabled with build_type=${DESIRED_BUILD_TYPE}"
+            else
+              PAGES_RESPONSE=$(retry 3 gh api "repos/${OWNER}/${REPO}/pages" 2>/dev/null) || true
+              CURRENT_BUILD_TYPE=$(echo "$PAGES_RESPONSE" | jq -r '.build_type // empty')
+              if [ "$CURRENT_BUILD_TYPE" != "$DESIRED_BUILD_TYPE" ]; then
+                echo "[WARN] Drift in pages.build_type: current=$CURRENT_BUILD_TYPE desired=$DESIRED_BUILD_TYPE"
+                echo "[INFO] Updating Pages build_type to ${DESIRED_BUILD_TYPE}..."
+                retry_json 3 "$PAGES_JSON" "repos/${OWNER}/${REPO}/pages" --method PUT >/dev/null 2>&1
+                echo "[OK] Pages build_type updated to ${DESIRED_BUILD_TYPE}"
+              else
+                echo "[OK] Pages build_type matches (${CURRENT_BUILD_TYPE}) — no changes needed"
+              fi
+            fi
+          else
+            echo "[SKIP] Pages not enabled in config"
+          fi
+
+          # ─── Phase 7: Verify ──────────────────────────────────────────────────
+          echo ""
+          echo "=== Phase 7: Verify ==="
+
+          VERIFY_FAILED=false
+
+          VERIFY_REPO=$(retry 3 gh api "repos/${OWNER}/${REPO}")
+          for key in $(echo "$DESIRED_REPO" | jq -r 'keys[]'); do
+            desired_val=$(echo "$DESIRED_REPO" | jq -c ".[\"$key\"]")
+            actual_val=$(echo "$VERIFY_REPO" | jq -c ".[\"$key\"]")
+            if [ "$desired_val" != "$actual_val" ]; then
+              echo "[FAIL] repo.$key: expected=$desired_val actual=$actual_val"
+              VERIFY_FAILED=true
+            fi
+          done
+
+          if [ -n "$DESIRED_ACTIONS" ]; then
+            VERIFY_ACTIONS=$(retry 3 gh api "repos/${OWNER}/${REPO}/actions/permissions/workflow")
+            for key in $(echo "$DESIRED_ACTIONS" | jq -r 'keys[]'); do
+              desired_val=$(echo "$DESIRED_ACTIONS" | jq -c ".[\"$key\"]")
+              actual_val=$(echo "$VERIFY_ACTIONS" | jq -c ".[\"$key\"]")
+              if [ "$desired_val" != "$actual_val" ]; then
+                echo "[FAIL] actions.$key: expected=$desired_val actual=$actual_val"
+                VERIFY_FAILED=true
+              fi
+            done
+          fi
+
+          for i in $(seq 0 $((BRANCH_COUNT - 1))); do
+            BRANCH=$(echo "$CONFIG" | jq -r ".branch_protection[$i].branch")
+            DESIRED_PAYLOAD=$(echo "$CONFIG" | jq -c ".branch_protection[$i] | del(.branch)")
+
+            # self_contexts override (same as Phase 4)
+            if [ "$IS_SELF" = true ]; then
+              SELF_CTX=$(echo "$DESIRED_PAYLOAD" | jq -c '.required_status_checks.self_contexts // empty')
+              if [ -n "$SELF_CTX" ] && [ "$SELF_CTX" != "null" ]; then
+                DESIRED_PAYLOAD=$(echo "$DESIRED_PAYLOAD" | jq -c \
+                  '.required_status_checks.contexts = .required_status_checks.self_contexts')
+              fi
+            fi
+            DESIRED_PAYLOAD=$(echo "$DESIRED_PAYLOAD" | jq -c \
+              'if .required_status_checks then
+                .required_status_checks |= del(.self_contexts)
+              else . end')
+
+            # Merge per-repo additional contexts (same as Phase 4)
+            REPO_OVERRIDES=$(echo "$CONFIG" | jq -c ".repo_overrides[\"${REPO}\"] // empty")
+            if [ -n "$REPO_OVERRIDES" ] && [ "$REPO_OVERRIDES" != "null" ]; then
+              if [ "$IS_SELF" = true ]; then
+                EXTRA_CTX=$(echo "$REPO_OVERRIDES" | jq -c '.additional_self_contexts // []')
+              else
+                EXTRA_CTX=$(echo "$REPO_OVERRIDES" | jq -c '.additional_contexts // []')
+              fi
+              if [ "$EXTRA_CTX" != "[]" ]; then
+                DESIRED_PAYLOAD=$(echo "$DESIRED_PAYLOAD" | jq -c \
+                  --argjson extra "$EXTRA_CTX" \
+                  '.required_status_checks.contexts = (.required_status_checks.contexts + $extra | unique)')
+              fi
+            fi
+
+            VERIFY_PROTECTION=$(retry 3 gh api "repos/${OWNER}/${REPO}/branches/${BRANCH}/protection" 2>/dev/null) || true
+
+            if [ -z "$VERIFY_PROTECTION" ]; then
+              echo "[FAIL] Branch protection for $BRANCH not found after apply"
+              VERIFY_FAILED=true
+              continue
+            fi
+
+            desired_enforce=$(echo "$DESIRED_PAYLOAD" | jq '.enforce_admins')
+            actual_enforce=$(echo "$VERIFY_PROTECTION" | jq '.enforce_admins.enabled')
+            if [ "$desired_enforce" != "$actual_enforce" ]; then
+              echo "[FAIL] $BRANCH enforce_admins: expected=$desired_enforce actual=$actual_enforce"
+              VERIFY_FAILED=true
+            fi
+
+            desired_reviews=$(echo "$DESIRED_PAYLOAD" | jq -c '.required_pull_request_reviews')
+            if [ "$desired_reviews" != "null" ]; then
+              desired_approvals=$(echo "$desired_reviews" | jq '.required_approving_review_count')
+              actual_approvals=$(echo "$VERIFY_PROTECTION" | jq '.required_pull_request_reviews.required_approving_review_count // empty')
+              if [ "$desired_approvals" != "$actual_approvals" ]; then
+                echo "[FAIL] $BRANCH required_approving_review_count: expected=$desired_approvals actual=$actual_approvals"
+                VERIFY_FAILED=true
+              fi
+            fi
+
+            for flag in required_linear_history allow_force_pushes allow_deletions block_creations required_conversation_resolution lock_branch allow_fork_syncing; do
+              desired_flag=$(echo "$DESIRED_PAYLOAD" | jq ".$flag")
+              actual_flag=$(echo "$VERIFY_PROTECTION" | jq ".$flag.enabled // false")
+              if [ "$desired_flag" != "$actual_flag" ]; then
+                echo "[FAIL] $BRANCH $flag: expected=$desired_flag actual=$actual_flag"
+                VERIFY_FAILED=true
+              fi
+            done
+          done
+
+          if [ "$PAGES_ENABLED" = "true" ]; then
+            VERIFY_PAGES_CODE=$(retry 3 gh api "repos/${OWNER}/${REPO}/pages" --include 2>/dev/null | head -1 | awk '{print $2}') || true
+            if [ "$VERIFY_PAGES_CODE" = "404" ]; then
+              echo "[WARN] Pages not found after apply — repo may lack a deploy workflow"
+            else
+              VERIFY_PAGES=$(retry 3 gh api "repos/${OWNER}/${REPO}/pages" 2>/dev/null) || true
+              ACTUAL_BUILD_TYPE=$(echo "$VERIFY_PAGES" | jq -r '.build_type // empty')
+              if [ "$ACTUAL_BUILD_TYPE" != "$DESIRED_BUILD_TYPE" ]; then
+                echo "[FAIL] pages.build_type: expected=$DESIRED_BUILD_TYPE actual=$ACTUAL_BUILD_TYPE"
+                VERIFY_FAILED=true
+              fi
+            fi
+          fi
+
+          if [ "$VERIFY_FAILED" = true ]; then
+            echo ""
+            echo "[ERROR] Verification failed — settings do not match desired state"
+            exit 1
+          fi
+
+          echo "[OK] All settings verified successfully"


### PR DESCRIPTION
## Summary

Add the `enforce-repo-settings.yml` workflow from docs-control to bootstrap this repo into the f5xc-salesdemos ecosystem.

## Changes

- `.github/workflows/enforce-repo-settings.yml` — Copy from docs-control (source of truth)

## Context

This is a bootstrap step. The devcontainer repo has been registered in `docs-control/downstream-repos.json`. This workflow file must exist before the enforcement dispatch can sync all 26 managed files to this repo.

After merge, trigger the enforcement workflow to sync all managed files.

Closes #3