### PR TITLE
fix: downgrade Python 3.14 to 3.13 in Dockerfile.proxy

### DIFF
--- a/Dockerfile.proxy
+++ b/Dockerfile.proxy
@@ -1,4 +1,4 @@
-FROM python:3.14-slim
+FROM python:3.13-slim
 # OpenAI-compatible API proxy — translates between API formats
 WORKDIR /app
 
@@ -6,7 +6,7 @@ WORKDIR /app
 RUN pip install --no-cache-dir uv
 
 # Clone the proxy and install dependencies
-# Build tools are needed for C extensions (httptools, uvloop) on Python 3.14
+# Build tools are needed for C extensions (httptools, uvloop) on Python 3.13
 # hadolint ignore=DL3008
 RUN apt-get update && apt-get install -y --no-install-recommends \
         git build-essential \


### PR DESCRIPTION
## Summary

- Downgrade `Dockerfile.proxy` base image from `python:3.14-slim` to `python:3.13-slim`
- Update comment referencing Python version

`pydantic-core` v2.33.2 cannot build on Python 3.14 because its Rust bindings (PyO3 v0.24.1) only support up to 3.13. This reverts the Dependabot base-image bump until upstream adds 3.14 support.

## Test plan

- [x] `docker build -f Dockerfile.proxy -t proxy-test .` succeeds
- [ ] CI checks pass

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)