### PR TITLE
feat: make proxy sidecar optional via Docker Compose profiles

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -69,7 +69,6 @@
   "postStartCommand": "bash /workspace/.devcontainer/scripts/post-start.sh",
 
   "containerEnv": {
-    "ANTHROPIC_BASE_URL": "http://proxy:8082",
     "EDITOR": "vim"
   }
 }

--- a/.devcontainer/scripts/post-start.sh
+++ b/.devcontainer/scripts/post-start.sh
@@ -1,14 +1,23 @@
 #!/bin/bash
 set -e
 
-echo "🚀 Running post-start checks..."
+echo "Running post-start checks..."
 
-# Verify proxy
-echo -n "  Checking AI proxy (proxy:8082)... "
-if curl -sf --connect-timeout 5 http://proxy:8082/ >/dev/null 2>&1; then
-  echo "✅ reachable"
+# Check AI provider mode
+if [ -n "$ANTHROPIC_BASE_URL" ]; then
+  echo -n "  Checking AI proxy ($ANTHROPIC_BASE_URL)... "
+  if curl -sf --connect-timeout 5 "$ANTHROPIC_BASE_URL/" >/dev/null 2>&1; then
+    echo "reachable"
+  else
+    echo "not reachable (check proxy logs: docker compose logs proxy)"
+  fi
 else
-  echo "⚠️  Not reachable (start proxy with: docker compose up -d proxy)"
+  echo "  Mode: direct API (no proxy)"
+  if [ -n "$ANTHROPIC_API_KEY" ]; then
+    echo "  ANTHROPIC_API_KEY is set"
+  else
+    echo "  ANTHROPIC_API_KEY is not set — AI tools will not work"
+  fi
 fi
 
 # Check installed tools
@@ -19,9 +28,9 @@ for cmd in node python3 go rustc javac git gh docker kubectl helm terraform \
   aws az pwsh devcontainer; do
   if command -v $cmd &>/dev/null; then
     ver=$($cmd --version 2>&1 | head -1 | sed 's/^[[:space:]]*//')
-    printf "    ✅ %-20s %s\n" "$cmd" "$ver"
+    printf "    %-20s %s\n" "$cmd" "$ver"
   fi
 done
 
 echo ""
-echo "✅ Ready! Start coding in /workspace"
+echo "Ready! Start coding in /workspace"

--- a/.env.example
+++ b/.env.example
@@ -1,19 +1,30 @@
 # =============================================================================
-# AI Proxy — REQUIRED
+# AI Provider — REQUIRED
 # =============================================================================
-# Your OpenAI-compatible API endpoint and key.
+# Your Anthropic API key. Used by Claude Code and other AI tools.
 
-OPENAI_API_KEY=sk-your-api-key-here
-OPENAI_BASE_URL=https://your-api-endpoint.example.com/v1
+ANTHROPIC_API_KEY=sk-ant-your-api-key-here
 
 # =============================================================================
-# Model Mapping
+# AI Proxy — OPTIONAL
 # =============================================================================
-# Map AI tool requests to your backend model names.
+# Uncomment the lines below to route AI traffic through the proxy sidecar
+# instead of connecting directly to your AI provider.
 
-BIG_MODEL=gpt-4o
-MIDDLE_MODEL=gpt-4o
-SMALL_MODEL=gpt-4o-mini
+# COMPOSE_PROFILES=proxy
+# ANTHROPIC_BASE_URL=http://proxy:8082
+# OPENAI_API_KEY=sk-your-api-key-here
+# OPENAI_BASE_URL=https://your-api-endpoint.example.com/v1
+
+# --- Model mapping (proxy mode only) ---
+# BIG_MODEL=gpt-4o
+# MIDDLE_MODEL=gpt-4o
+# SMALL_MODEL=gpt-4o-mini
+
+# --- Proxy tuning (proxy mode only) ---
+# LOG_LEVEL=WARNING
+# MAX_TOKENS_LIMIT=64000
+# REQUEST_TIMEOUT=120
 
 # =============================================================================
 # Host User Mapping
@@ -41,12 +52,3 @@ GIT_AUTHOR_NAME="Your Name"
 #   echo "SSH_PRIVATE_KEY=$(base64 < ~/.ssh/id_ed25519)" >> .env
 
 # SSH_PRIVATE_KEY=
-
-# =============================================================================
-# Optional
-# =============================================================================
-
-# ANTHROPIC_API_KEY=changeme
-# LOG_LEVEL=WARNING
-# MAX_TOKENS_LIMIT=64000
-# REQUEST_TIMEOUT=120

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,15 +9,12 @@ services:
         USERNAME: ${USERNAME:-vscode}
     container_name: devcontainer
     hostname: devcontainer
-    depends_on:
-      proxy:
-        condition: service_healthy
     volumes:
       - workspace:/workspace
       - home:/home/${USERNAME:-vscode}
     environment:
-      - ANTHROPIC_BASE_URL=http://proxy:8082
-      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-changeme}
+      - ANTHROPIC_BASE_URL=${ANTHROPIC_BASE_URL:-}
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
       - GIT_AUTHOR_NAME=${GIT_AUTHOR_NAME:-}
       - GIT_AUTHOR_EMAIL=${GIT_AUTHOR_EMAIL:-}
       - GIT_COMMITTER_NAME=${GIT_AUTHOR_NAME:-}
@@ -33,9 +30,11 @@ services:
       dockerfile: Dockerfile.proxy
     container_name: devcontainer-proxy
     hostname: proxy
+    profiles:
+      - proxy
     environment:
-      - OPENAI_API_KEY=${OPENAI_API_KEY:?Set OPENAI_API_KEY in .env}
-      - OPENAI_BASE_URL=${OPENAI_BASE_URL:?Set OPENAI_BASE_URL in .env}
+      - OPENAI_API_KEY=${OPENAI_API_KEY:-}
+      - OPENAI_BASE_URL=${OPENAI_BASE_URL:-}
       - BIG_MODEL=${BIG_MODEL:-gpt-4o}
       - MIDDLE_MODEL=${MIDDLE_MODEL:-gpt-4o}
       - SMALL_MODEL=${SMALL_MODEL:-gpt-4o-mini}

--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -11,12 +11,42 @@ All configuration lives in the `.env` file at the project root. This file is git
 
 ## Environment Variables
 
-### Required
+### AI Provider
 
 | Variable | Description | Example |
 |----------|-------------|---------|
-| `OPENAI_API_KEY` | API key for your AI provider | `sk-abc123...` |
-| `OPENAI_BASE_URL` | Base URL of your API endpoint | `https://api.openai.com/v1` |
+| `ANTHROPIC_API_KEY` | API key for your AI provider | `sk-ant-abc123...` |
+
+This is the only variable required for AI tools to work. The dev container connects directly to your provider by default.
+
+### AI Proxy (Optional)
+
+To route AI traffic through the built-in proxy sidecar, add these to `.env`:
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `COMPOSE_PROFILES` | Set to `proxy` to enable the sidecar | `proxy` |
+| `ANTHROPIC_BASE_URL` | Proxy URL seen by AI tools | `http://proxy:8082` |
+| `OPENAI_API_KEY` | API key for the upstream provider | `sk-abc123...` |
+| `OPENAI_BASE_URL` | Upstream API endpoint | `https://api.openai.com/v1` |
+
+#### Model Mapping (proxy mode only)
+
+The proxy maps generic model names to your backend's model identifiers:
+
+| Variable | Default | Used For |
+|----------|---------|----------|
+| `BIG_MODEL` | `gpt-4o` | Primary model for complex tasks |
+| `MIDDLE_MODEL` | `gpt-4o` | General-purpose model |
+| `SMALL_MODEL` | `gpt-4o-mini` | Fast model for simple tasks |
+
+#### Proxy Tuning (proxy mode only)
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `LOG_LEVEL` | `WARNING` | Proxy log verbosity (`DEBUG`, `INFO`, `WARNING`, `ERROR`) |
+| `MAX_TOKENS_LIMIT` | `64000` | Maximum tokens per request |
+| `REQUEST_TIMEOUT` | `120` | Request timeout in seconds |
 
 ### User Identity
 
@@ -40,25 +70,6 @@ These ensure files created inside the container have correct ownership:
 | Variable | Description | How to Set |
 |----------|-------------|------------|
 | `SSH_PRIVATE_KEY` | Base64-encoded private key | `base64 < ~/.ssh/id_ed25519` |
-
-### Model Mapping
-
-The proxy maps generic model names to your backend's model identifiers:
-
-| Variable | Default | Used For |
-|----------|---------|----------|
-| `BIG_MODEL` | `gpt-4o` | Primary model for complex tasks |
-| `MIDDLE_MODEL` | `gpt-4o` | General-purpose model |
-| `SMALL_MODEL` | `gpt-4o-mini` | Fast model for simple tasks |
-
-### Proxy Tuning
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `LOG_LEVEL` | `WARNING` | Proxy log verbosity (`DEBUG`, `INFO`, `WARNING`, `ERROR`) |
-| `MAX_TOKENS_LIMIT` | `64000` | Maximum tokens per request |
-| `REQUEST_TIMEOUT` | `120` | Request timeout in seconds |
-| `ANTHROPIC_API_KEY` | `changeme` | Key passed from dev container to proxy |
 
 ## How Tools Are Installed
 
@@ -99,7 +110,7 @@ Edit `.devcontainer/devcontainer.json` and add entries to the `features` object:
 }
 ```
 
-Browse available features at [containers.dev/features](https://containers.dev/features). Rebuild after adding: `docker compose up -d --build` (or in VS Code: **Dev Containers → Rebuild Container**).
+Browse available features at [containers.dev/features](https://containers.dev/features). Rebuild after adding: `docker compose up -d --build` (or in VS Code: **Dev Containers &rarr; Rebuild Container**).
 
 ### System Packages
 
@@ -144,8 +155,10 @@ Both persist across container restarts and rebuilds.
 
 ## Port Mapping
 
+When running in proxy mode (`COMPOSE_PROFILES=proxy`):
+
 | Host | Container | Service |
 |------|-----------|---------|
 | `127.0.0.1:18082` | `8082` | API proxy (localhost only) |
 
-The proxy is bound to `127.0.0.1` so it's only accessible from your machine, not the network.
+The proxy is bound to `127.0.0.1` so it's only accessible from your machine, not the network. In direct mode, no ports are published.

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -34,7 +34,7 @@ git --version
 
 ### An API Key
 
-The AI coding tools need an API endpoint. You'll need an **API key** and the **base URL** for your provider (OpenAI, Anthropic via proxy, Azure OpenAI, or any OpenAI-compatible API).
+You need an **API key** from your AI provider (Anthropic, OpenAI, or any compatible API). By default the devcontainer connects directly to your provider — no proxy required.
 
 ### System Resources
 
@@ -44,7 +44,7 @@ The AI coding tools need an API endpoint. You'll need an **API key** and the **b
 | RAM | 4 GB allocated to Docker | 8 GB+ |
 | CPU | 2 cores | 4+ cores |
 
-Adjust Docker resource limits in Docker Desktop → Settings → Resources.
+Adjust Docker resource limits in Docker Desktop &rarr; Settings &rarr; Resources.
 
 ## 1. Clone the Repository
 
@@ -68,14 +68,30 @@ GIT_AUTHOR_EMAIL=$(git config user.email)
 EOF
 ```
 
-## 3. Set Your API Keys
+## 3. Set Your API Key
 
-Open `.env` and set the two required fields:
+### Direct mode (default)
+
+Open `.env` and set your API key:
 
 ```ini
+ANTHROPIC_API_KEY=sk-ant-your-api-key-here
+```
+
+That's it — the dev container will connect directly to your AI provider.
+
+### Proxy mode (optional)
+
+If you need to route traffic through the built-in proxy sidecar (for example, to remap model names or target an OpenAI-compatible endpoint), uncomment the proxy block in `.env`:
+
+```ini
+COMPOSE_PROFILES=proxy
+ANTHROPIC_BASE_URL=http://proxy:8082
 OPENAI_API_KEY=sk-your-api-key-here
 OPENAI_BASE_URL=https://your-api-endpoint.example.com/v1
 ```
+
+See [Configuration — AI Proxy](./configuration#ai-proxy-optional) for model mapping and tuning options.
 
 ## 4. (Optional) Add Your SSH Key
 
@@ -137,9 +153,14 @@ az --version
 terraform --version
 ```
 
-Test the AI proxy connection:
+Test the AI connection:
 
 ```bash
+# Direct mode — connects to your provider
+claude -p "Say hello"
+
+# Proxy mode — verify proxy is reachable first
+curl http://proxy:8082/
 claude -p "Say hello"
 ```
 

--- a/docs/security.mdx
+++ b/docs/security.mdx
@@ -18,29 +18,29 @@ Many corporate security teams now require that AI coding tools run only inside d
 ## Isolation Model
 
 ```
-┌────────────────────────────────────────────────┐
-│  Host Machine (corporate endpoint)             │
-│                                                │
-│  ● No AI tool binaries installed               │
-│  ● No AI tool extensions or plugins            │
-│  ● Only Docker is required                     │
-│                                                │
-│  ┌──────────────────────────────────────────┐  │
-│  │  Docker Container (isolated)             │  │
-│  │                                          │  │
-│  │  AI tools run here:                      │  │
-│  │  ├── Claude Code CLI                     │  │
-│  │  ├── OpenCode                            │  │
-│  │  └── Codex                               │  │
-│  │                                          │  │
-│  │  No access to:                           │  │
-│  │  ✗ Host filesystem                       │  │
-│  │  ✗ Host keychain / credential store      │  │
-│  │  ✗ Host clipboard                        │  │
-│  │  ✗ Host network interfaces               │  │
-│  │  ✗ Other host applications               │  │
-│  └──────────────────────────────────────────┘  │
-└────────────────────────────────────────────────┘
++------------------------------------------------+
+|  Host Machine (corporate endpoint)             |
+|                                                |
+|  - No AI tool binaries installed               |
+|  - No AI tool extensions or plugins            |
+|  - Only Docker is required                     |
+|                                                |
+|  +------------------------------------------+  |
+|  |  Docker Container (isolated)             |  |
+|  |                                          |  |
+|  |  AI tools run here:                      |  |
+|  |  - Claude Code CLI                       |  |
+|  |  - OpenCode                              |  |
+|  |  - Codex                                 |  |
+|  |                                          |  |
+|  |  No access to:                           |  |
+|  |  x Host filesystem                       |  |
+|  |  x Host keychain / credential store      |  |
+|  |  x Host clipboard                        |  |
+|  |  x Host network interfaces               |  |
+|  |  x Other host applications               |  |
+|  +------------------------------------------+  |
++------------------------------------------------+
 ```
 
 ## Security Controls
@@ -59,12 +59,12 @@ Docker containers do not share clipboard state with the host. Data cannot leak t
 
 ### Network Isolation
 
-The container communicates only with:
+The container communicates with the outside world in one of two modes:
 
-1. **The API proxy sidecar** — via the internal Docker network
-2. **Your configured API endpoint** — outbound HTTPS through Docker's NAT
+- **Direct mode (default)** — outbound HTTPS to your AI provider through Docker's NAT. No sidecar proxy is involved.
+- **Proxy mode (optional)** — traffic routes through an in-container proxy sidecar on the internal Docker network, which then connects outbound to your API endpoint.
 
-It has no access to VPN tunnels, corporate network interfaces, or other services on the host.
+In both modes, the container has no access to VPN tunnels, corporate network interfaces, or other services on the host.
 
 ### Ephemeral by Design
 
@@ -78,14 +78,14 @@ This environment runs AI tools as **command-line interfaces only**. No desktop a
 
 | Requirement | Status |
 |---|---|
-| AI tools not installed on host endpoint | ✅ |
-| Runs in isolated VM or container | ✅ |
-| No access to host file shares | ✅ |
-| No clipboard sync | ✅ |
-| No shared credential stores | ✅ |
-| No VPN split tunneling into prod networks | ✅ |
-| Environment is disposable | ✅ |
-| No desktop extensions or plugins | ✅ |
+| AI tools not installed on host endpoint | Yes |
+| Runs in isolated VM or container | Yes |
+| No access to host file shares | Yes |
+| No clipboard sync | Yes |
+| No shared credential stores | Yes |
+| No VPN split tunneling into prod networks | Yes |
+| Environment is disposable | Yes |
+| No desktop extensions or plugins | Yes |
 
 ## Best Practices
 
@@ -94,7 +94,7 @@ This environment runs AI tools as **command-line interfaces only**. No desktop a
 3. **Rotate SSH keys** used inside the container periodically.
 4. **Review `.env` before sharing.** It contains API keys and may contain SSH private keys.
 5. **Rebuild periodically** to pick up security patches: `docker compose up -d --build`
-6. **Do not expose the proxy port** to anything other than localhost. The default binds to `127.0.0.1:18082` only.
+6. **Do not expose the proxy port** to anything other than localhost. The default binds to `127.0.0.1:18082` only (proxy mode).
 
 ## References
 

--- a/docs/troubleshooting.mdx
+++ b/docs/troubleshooting.mdx
@@ -18,10 +18,12 @@ docker compose up -d
 
 ### Proxy fails health check
 
+This only applies if you are running in **proxy mode** (`COMPOSE_PROFILES=proxy` in `.env`). If you are using direct mode, the proxy is not running and health check messages can be ignored.
+
 Check proxy logs:
 
 ```bash
-docker compose logs proxy
+docker compose --profile proxy logs proxy
 ```
 
 Common causes:
@@ -50,16 +52,26 @@ echo '{"hasCompletedOnboarding": true}' > ~/.claude.json
 
 ### API requests fail with 401
 
-Check that the proxy is running and configured:
+**Direct mode** — Check that your API key is set correctly:
+
+```bash
+echo "$ANTHROPIC_API_KEY"
+```
+
+Verify it works by making a direct call to your provider.
+
+**Proxy mode** — Check that the proxy is running and configured:
 
 ```bash
 curl http://proxy:8082/
-docker compose exec proxy env | grep -E 'OPENAI|MODEL'
+docker compose --profile proxy exec proxy env | grep -E 'OPENAI|MODEL'
 ```
 
 ### Claude says "model not found"
 
-Check `BIG_MODEL`, `MIDDLE_MODEL`, and `SMALL_MODEL` in `.env` — these must match model names your API provider accepts. See [Configuration — Model Mapping](./configuration#model-mapping).
+In proxy mode, check `BIG_MODEL`, `MIDDLE_MODEL`, and `SMALL_MODEL` in `.env` — these must match model names your API provider accepts. See [Configuration — Model Mapping](./configuration#model-mapping-proxy-mode-only).
+
+In direct mode, the model is determined by your provider and API key. Check your provider's documentation for available models.
 
 ## Permission Issues
 
@@ -118,7 +130,7 @@ Then restart Docker.
 
 ### Port 18082 already in use
 
-Change the port in `docker-compose.yml`:
+This only applies in proxy mode. Change the port in `docker-compose.yml`:
 
 ```yaml
 ports:
@@ -128,7 +140,7 @@ ports:
 ## Reset Everything
 
 ```bash
-docker compose down -v
+docker compose --profile proxy down -v
 docker rm -f devcontainer devcontainer-proxy 2>/dev/null
 docker compose up -d --build
 ```


### PR DESCRIPTION
## Summary

- Makes the proxy sidecar opt-in using Docker Compose profiles — the devcontainer now works without any proxy configuration
- Replaces `:?` fail-safe assertions with `:-` soft defaults so `docker compose up` succeeds without `OPENAI_API_KEY`/`OPENAI_BASE_URL`
- Makes `ANTHROPIC_BASE_URL` env-var driven (empty by default) instead of hardcoded to `http://proxy:8082`
- Updates all docs to document both direct mode (default) and proxy mode (optional)

## Migration

Existing users who were using the proxy need to add two lines to `.env`:
```ini
COMPOSE_PROFILES=proxy
ANTHROPIC_BASE_URL=http://proxy:8082
```

## Test plan

- [ ] Direct mode: `docker compose up -d --build` succeeds with only `ANTHROPIC_API_KEY` set
- [ ] Direct mode: `docker compose ps` shows only devcontainer running (no proxy)
- [ ] Direct mode: `docker compose exec dev bash -c 'echo $ANTHROPIC_BASE_URL'` returns empty
- [ ] Proxy mode: add `COMPOSE_PROFILES=proxy`, `ANTHROPIC_BASE_URL`, `OPENAI_API_KEY`, `OPENAI_BASE_URL` to `.env`
- [ ] Proxy mode: `docker compose up -d --build` starts both containers
- [ ] Proxy mode: `docker compose ps` shows both devcontainer and devcontainer-proxy
- [ ] Cleanup: `docker compose --profile proxy down -v` removes all containers and volumes

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)