### PR TITLE
feat: add multi-arch Docker publish workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+*
+!entrypoint.sh

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,163 @@
+---
+name: Docker Publish
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - Dockerfile
+      - Dockerfile.proxy
+      - entrypoint.sh
+      - docker-compose.yml
+      - .devcontainer/**
+      - .github/workflows/docker-publish.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  MAIN_IMAGE: ghcr.io/f5xc-salesdemos/devcontainer
+  PROXY_IMAGE: ghcr.io/f5xc-salesdemos/devcontainer-proxy
+
+jobs:
+  # ── Main image: build each arch natively in parallel ──
+  build:
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+            cache-scope: linux-amd64
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            cache-scope: linux-arm64
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          platforms: ${{ matrix.platform }}
+          push: true
+          tags: ${{ env.MAIN_IMAGE }}
+          cache-from: type=gha,scope=${{ matrix.cache-scope }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.cache-scope }}
+          outputs: type=image,push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p ${{ runner.temp }}/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digest-${{ matrix.cache-scope }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # ── Merge per-arch digests into a multi-arch manifest ──
+  merge:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digest-*
+          merge-multiple: true
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Generate tags
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.MAIN_IMAGE }}
+          tags: |
+            type=raw,value=latest
+            type=sha,prefix=sha-,format=short
+            type=raw,value={{date 'YYYY.MM.DD'}}
+
+      - name: Create and push manifest
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          tags=$(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON")
+          sources=$(printf '${{ env.MAIN_IMAGE }}@sha256:%s ' *)
+          # shellcheck disable=SC2086
+          docker buildx imagetools create $tags $sources
+
+  # ── Proxy image: small enough for QEMU ──
+  build-proxy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate tags
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.PROXY_IMAGE }}
+          tags: |
+            type=raw,value=latest
+            type=sha,prefix=sha-,format=short
+            type=raw,value={{date 'YYYY.MM.DD'}}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.proxy
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=proxy
+          cache-to: type=gha,mode=max,scope=proxy


### PR DESCRIPTION
## Summary

- Add GitHub Actions workflow to build and push multi-arch Docker images (`linux/amd64` + `linux/arm64`) to GHCR
- Main image uses native runners with manifest merge (avoids 45-90 min QEMU builds)
- Proxy image uses QEMU (small base, fast under emulation)
- Add `.dockerignore` allowlist to minimize build context

## Changes

| File | Purpose |
|------|---------|
| `.github/workflows/docker-publish.yml` | 3-job workflow: build matrix → merge manifest → build-proxy |
| `.dockerignore` | Allowlist — only sends `entrypoint.sh` to build context |

## Image Details

| Image | Registry |
|-------|----------|
| Main devcontainer | `ghcr.io/f5xc-salesdemos/devcontainer` |
| Proxy sidecar | `ghcr.io/f5xc-salesdemos/devcontainer-proxy` |

**Tags**: `latest`, `sha-<7char>`, `YYYY.MM.DD`

**Triggers**: Push to `main` affecting `Dockerfile`, `Dockerfile.proxy`, `entrypoint.sh`, `docker-compose.yml`, `.devcontainer/**`, or the workflow file itself. Also `workflow_dispatch`.

## Design Decisions

- **Native arm64 runner** (`ubuntu-24.04-arm`) instead of QEMU for the main image — the Dockerfile installs 200+ tools with architecture-conditional logic, QEMU would take 45-90+ min
- **QEMU for proxy** — 30-line Python slim Dockerfile, emulation adds negligible time
- **Digest-based manifest merge** — standard pattern from docker/build-push-action docs for multi-platform builds on separate runners
- **GHA cache** scoped per platform to avoid cache collisions

## Post-Merge Note

New GHCR packages may default to private. After first successful push, verify visibility at `https://github.com/orgs/f5xc-salesdemos/packages` and set to public if needed.

## Test plan

- [ ] Super-linter passes on this PR (yamllint, actionlint, zizmor)
- [ ] After merge, `docker-publish` workflow triggers and all 3 jobs succeed
- [ ] `docker buildx imagetools inspect ghcr.io/f5xc-salesdemos/devcontainer:latest` shows both platforms
- [ ] `docker pull` works on both amd64 and arm64

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)