### PR TITLE
fix: disable automatic Docker publish triggers

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,15 +2,16 @@
 name: Docker Publish
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - Dockerfile
-      - Dockerfile.proxy
-      - entrypoint.sh
-      - docker-compose.yml
-      - .devcontainer/**
-      - .github/workflows/docker-publish.yml
+  # TODO: re-enable push trigger once builds are stable
+  # push:
+  #   branches: [main]
+  #   paths:
+  #     - Dockerfile
+  #     - Dockerfile.proxy
+  #     - entrypoint.sh
+  #     - docker-compose.yml
+  #     - .devcontainer/**
+  #     - .github/workflows/docker-publish.yml
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

- Comment out the `push` trigger on `docker-publish.yml`, keeping only `workflow_dispatch` (manual)
- The workflow remains in the repo and can be triggered manually or re-enabled later

## Context

The Docker Publish workflow (#30) works — all 4 jobs passed on re-run — but the arm64 build hit a transient network error on first attempt (Apache CDN unreachable from GitHub arm64 runner). Local builds are faster for now during development.

## Test plan

- [ ] Super-linter passes (yamllint, actionlint)
- [ ] After merge, no Docker Publish workflow runs automatically
- [ ] `workflow_dispatch` still available for manual runs

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)