### PR TITLE
fix: proxy container crash-loop (uv cache permission denied)

### DIFF
--- a/Dockerfile.proxy
+++ b/Dockerfile.proxy
@@ -17,7 +17,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Create non-root user
-RUN groupadd -r proxyuser && useradd -r -g proxyuser proxyuser \
+RUN groupadd -r proxyuser && useradd -r -g proxyuser -m proxyuser \
     && chown -R proxyuser:proxyuser /app
 USER proxyuser
 


### PR DESCRIPTION
## Summary

- Add `-m` flag to `useradd` in `Dockerfile.proxy` so the proxyuser home directory is created at build time
- Fixes the uv cache permission error that causes the proxy sidecar to crash-loop

## What type of PR is this?

- [x] Bug fix

## Related issues

Closes #36

## Changes

| File | Change |
|------|--------|
| `Dockerfile.proxy:20` | `useradd -r -g proxyuser proxyuser` → `useradd -r -g proxyuser -m proxyuser` |

## Root cause

`useradd -r` (system user) does not create a home directory by default. When `uv run` executes as `proxyuser`, it tries to initialize its cache at `/home/proxyuser/.cache/uv` but the path doesn't exist, causing a permission denied error and container crash-loop.

## Test plan

- [ ] `docker compose build --no-cache proxy` — builds successfully
- [ ] `docker compose up -d && sleep 10 && docker compose ps` — proxy shows "Up", not "Restarting"
- [ ] `docker compose logs proxy --tail 5` — no permission errors
- [ ] Claude Code connects without ENOTFOUND

🤖 Generated with [Claude Code](https://claude.com/claude-code)