### PR TITLE
feat: add Homebrew, Playwright + Chromium to devcontainer

### DIFF
--- a/.devcontainer/scripts/post-start.sh
+++ b/.devcontainer/scripts/post-start.sh
@@ -43,7 +43,7 @@ echo "  Installed tools:"
 for cmd in node python3 go rustc javac git gh docker kubectl helm terraform \
   pre-commit uv claude opencode codex openclaw prettier markdownlint-cli2 \
   actionlint act terraform-docs ansible black pylint yamllint yt-dlp \
-  aws az pwsh devcontainer; do
+  aws az pwsh devcontainer brew playwright; do
   if command -v $cmd &>/dev/null; then
     ver=$($cmd --version 2>&1 | head -1 | sed 's/^[[:space:]]*//')
     printf "    %-20s %s\n" "$cmd" "$ver"

--- a/Dockerfile
+++ b/Dockerfile
@@ -202,7 +202,8 @@ RUN npm install -g \
     prettier \
     markdownlint-cli2 \
     openclaw \
-    @devcontainers/cli
+    @devcontainers/cli \
+    playwright
 
 # ============================================================
 # 10. pip tools
@@ -213,7 +214,14 @@ RUN pip install --no-cache-dir --break-system-packages \
     ansible \
     black \
     pylint \
-    yamllint
+    yamllint \
+    playwright
+
+# ============================================================
+# 11. Playwright browsers (Chromium + system deps)
+# ============================================================
+# hadolint ignore=DL3059
+RUN npx playwright install --with-deps chromium
 
 # ============================================================
 # User setup
@@ -241,6 +249,14 @@ WORKDIR /home/$USERNAME
 
 RUN mkdir -p ~/.cache ~/.local/bin ~/.claude \
     && echo '{"hasCompletedOnboarding": true}' > ~/.claude.json.default
+
+# ============================================================
+# 12. Homebrew (needed by openclaw configure)
+# ============================================================
+RUN NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+ENV HOMEBREW_NO_AUTO_UPDATE=1
+ENV PATH="/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:${PATH}"
 
 ENV SHELL=/bin/zsh
 WORKDIR /workspace

--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -89,8 +89,10 @@ The Dockerfile is organized into numbered sections for Docker layer caching:
 | 6. Maven + Gradle | Binary downloads to `/opt` |
 | 7. AWS CLI v2 | Official installer |
 | 8. Binary tools | kubectl, helm, tflint, terraform-docs, act, actionlint, yt-dlp, uv, opencode |
-| 9. npm global tools | claude-code, codex, prettier, markdownlint-cli2, openclaw, devcontainers-cli |
-| 10. pip tools | pre-commit, ansible, black, pylint, yamllint |
+| 9. npm global tools | claude-code, codex, prettier, markdownlint-cli2, openclaw, devcontainers-cli, playwright |
+| 10. pip tools | pre-commit, ansible, black, pylint, yamllint, playwright |
+| 11. Playwright browsers | Chromium + system deps via `playwright install --with-deps` |
+| 12. Homebrew | Linuxbrew (needed by openclaw configure) |
 
 ## Adding Tools
 


### PR DESCRIPTION
## Summary

Add Homebrew and Playwright + Chromium to the devcontainer image.

## Changes

### Dockerfile
- Add `playwright` to npm global tools (section 9) and pip tools (section 10)
- New section 11: install Chromium + system deps via `npx playwright install --with-deps chromium` (as root)
- New section 12: install Homebrew as `vscode` user (after `USER` directive), with `HOMEBREW_NO_AUTO_UPDATE=1` and linuxbrew in PATH

### .devcontainer/scripts/post-start.sh
- Add `brew` and `playwright` to tool check loop

### docs/configuration.mdx
- Update section table with new tools in sections 9/10
- Add rows for new sections 11 (Playwright browsers) and 12 (Homebrew)

## Motivation

- **Homebrew** is required at runtime by `openclaw configure`
- **Playwright + Chromium** enables browser automation and testing from both Node.js and Python

## Testing

- `docker compose build dev`
- `brew --version` — Homebrew installed and on PATH
- `npx playwright --version` — npm playwright available
- `python -m playwright --version` — Python playwright available
- `npx playwright install --dry-run chromium` — Chromium pre-installed

Closes #38