### PR TITLE
feat: add locale support and TERM=xterm-256color to devcontainer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -86,7 +86,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     docker-ce-cli docker-buildx-plugin docker-compose-plugin \
     # Azure CLI
     azure-cli \
+    # Locale
+    locales \
+    && sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen \
+    && locale-gen en_US.UTF-8 \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+ENV LANG=en_US.UTF-8
+ENV LC_ALL=en_US.UTF-8
+ENV TERM=xterm-256color
 
 # PowerShell — Microsoft only publishes amd64 .deb packages;
 # arm64 uses the official tar.gz from GitHub releases.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,8 +22,12 @@ services:
       - GIT_COMMITTER_NAME=${GIT_AUTHOR_NAME:-}
       - GIT_COMMITTER_EMAIL=${GIT_AUTHOR_EMAIL:-}
       - SSH_PRIVATE_KEY=${SSH_PRIVATE_KEY:-}
+      - TERM=xterm-256color
+      - LANG=en_US.UTF-8
+      - LC_ALL=en_US.UTF-8
     stdin_open: true
     tty: true
+    init: true
     restart: unless-stopped
 
   proxy:

--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -82,7 +82,7 @@ The Dockerfile is organized into numbered sections for Docker layer caching:
 | Section | Contents |
 |---------|----------|
 | 1. APT repos | NodeSource, deadsnakes, HashiCorp, GitHub, Docker, Microsoft |
-| 2. APT packages | System tools, Node.js, Python, Java, Terraform, GitHub CLI, Docker CLI, Azure CLI, PowerShell |
+| 2. APT packages | System tools, Node.js, Python, Java, Terraform, GitHub CLI, Docker CLI, Azure CLI, PowerShell, locales |
 | 3. Python bootstrap | Symlinks + pip via get-pip.py |
 | 4. Go | Official tarball |
 | 5. Rust | rustup (system-wide) |


### PR DESCRIPTION
## Summary

Add proper locale configuration and terminal type to the devcontainer.

## Changes

### Dockerfile
- Added `locales` package to the section 2 APT install block
- Generate `en_US.UTF-8` locale via `sed` + `locale-gen`
- Set `ENV LANG=en_US.UTF-8`, `ENV LC_ALL=en_US.UTF-8`, `ENV TERM=xterm-256color`

### docker-compose.yml
- Added `TERM=xterm-256color`, `LANG=en_US.UTF-8`, `LC_ALL=en_US.UTF-8` to environment
- Added `init: true` for proper PID 1 signal handling

### docs/configuration.mdx
- Updated section 2 description to include `locales`

## Why

The devcontainer currently falls back to POSIX locale, which breaks UTF-8 characters, sorting, and many tools. `TERM` was not explicitly set, causing issues with color output and terminal capabilities. `init: true` ensures proper signal forwarding and zombie process reaping.

## Testing

1. Build: `docker compose build dev`
2. `docker compose exec dev locale` → `en_US.UTF-8` for LANG and LC_ALL
3. `docker compose exec dev echo $TERM` → `xterm-256color`
4. `docker compose exec dev python3 -c "print('✓ UTF-8 works')"` → renders correctly
5. `docker compose exec dev cat /proc/1/cmdline | tr '\0' ' '` → shows init process

Closes #40