### PR TITLE
fix: add locale and TERM to containerEnv in devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -26,6 +26,9 @@
   "postStartCommand": "bash /workspace/.devcontainer/scripts/post-start.sh",
 
   "containerEnv": {
-    "EDITOR": "vim"
+    "EDITOR": "vim",
+    "TERM": "xterm-256color",
+    "LANG": "en_US.UTF-8",
+    "LC_ALL": "en_US.UTF-8"
   }
 }


### PR DESCRIPTION
## Summary

Fix locale and TERM environment variables not being applied inside devcontainer sessions.

## Problem

PR #41 added locale generation and ENV variables to the Dockerfile and docker-compose.yml, but the variables (`LANG`, `LC_ALL`, `TERM`) were not reaching the interactive shell. Running `locale` inside the container showed everything falling back to POSIX.

## Root Cause

The devcontainer runtime uses `containerEnv` from `devcontainer.json` as the authoritative source for the shell environment. The Dockerfile `ENV` directives and docker-compose `environment` entries bake defaults into the image, but the devcontainer runtime doesn't necessarily propagate them to the interactive session.

## Fix

Add `TERM`, `LANG`, and `LC_ALL` to `containerEnv` in `.devcontainer/devcontainer.json`.

## Testing

After rebuilding the container:
- `locale` should show `en_US.UTF-8` for LANG and LC_ALL
- `echo $TERM` should show `xterm-256color`
- `python3 -c "print('✓ UTF-8 works')"` should render correctly

Closes #42