### PR TITLE
fix: pre-create Homebrew prefix to avoid sudo permission error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -252,6 +252,10 @@ RUN if [ "$USER_GID" != "1000" ]; then \
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh
 
+# Pre-create Homebrew prefix so the installer skips the sudo check
+RUN mkdir -p /home/linuxbrew/.linuxbrew \
+    && chown -R $USERNAME:$USERNAME /home/linuxbrew/.linuxbrew
+
 USER $USERNAME
 WORKDIR /home/$USERNAME
 


### PR DESCRIPTION
## Summary
- Pre-create `/home/linuxbrew/.linuxbrew` as root and chown it to the build user **before** `USER $USERNAME` in the Dockerfile
- The Homebrew installer has a fast path: if the prefix directory already exists and is writable, it skips the `sudo` check entirely
- This fixes the Docker build failure at step 21/22 where the installer aborts with "Insufficient permissions"

## Test plan
- [ ] `docker compose build --no-cache dev` completes all steps without error
- [ ] `docker compose exec dev brew --version` returns a valid Homebrew version

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)