### PR TITLE
fix: re-enable push trigger on Docker Publish workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,16 +2,15 @@
 name: Docker Publish
 
 on:
-  # TODO: re-enable push trigger once builds are stable
-  # push:
-  #   branches: [main]
-  #   paths:
-  #     - Dockerfile
-  #     - Dockerfile.proxy
-  #     - entrypoint.sh
-  #     - docker-compose.yml
-  #     - .devcontainer/**
-  #     - .github/workflows/docker-publish.yml
+  push:
+    branches: [main]
+    paths:
+      - Dockerfile
+      - Dockerfile.proxy
+      - entrypoint.sh
+      - docker-compose.yml
+      - .devcontainer/**
+      - .github/workflows/docker-publish.yml
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

Re-enable the `push` trigger on the Docker Publish workflow so the container image is automatically rebuilt when relevant files change on `main`.

## Related Issue

Closes #48

## Changes

- Uncomment the `push` trigger block in `.github/workflows/docker-publish.yml`
- Remove the TODO comment (`re-enable push trigger once builds are stable`)

The trigger fires on pushes to `main` that modify: `Dockerfile`, `Dockerfile.proxy`, `entrypoint.sh`, `docker-compose.yml`, `.devcontainer/**`, or the workflow itself.

## Checklist

- [x] Linked to a GitHub issue (required — CI will block merge without it)
- [x] Tested locally
- [x] Follows project conventions