### PR TITLE
fix: set user-writable npm global prefix for runtime installs

### DIFF
--- a/docs/troubleshooting.mdx
+++ b/docs/troubleshooting.mdx
@@ -107,11 +107,12 @@ sudo chown -R $(id -u):$(id -g) /workspace ~
 
 ### npm install fails with EACCES
 
+The entrypoint automatically configures a user-writable npm global prefix at `~/.npm-global`, so runtime `npm install -g` commands should work without `sudo`. If you still see EACCES errors, re-apply the fix manually:
+
 ```bash
 mkdir -p ~/.npm-global
 npm config set prefix ~/.npm-global
-echo 'export PATH="$HOME/.npm-global/bin:$PATH"' >> ~/.zshrc
-source ~/.zshrc
+export PATH="$HOME/.npm-global/bin:$PATH"
 ```
 
 ## Build Issues

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,6 +11,14 @@ if [ ! -O "$HOME" ]; then
 fi
 
 # ============================================================
+# npm global prefix (user-writable for runtime installs)
+# ============================================================
+NPM_GLOBAL="$HOME/.npm-global"
+mkdir -p "$NPM_GLOBAL"
+npm config set prefix "$NPM_GLOBAL"
+export PATH="$NPM_GLOBAL/bin:$PATH"
+
+# ============================================================
 # Configure user environment
 # ============================================================
 


### PR DESCRIPTION
## Changes

### What
- Add `~/.npm-global` as the npm global prefix in `entrypoint.sh` so runtime `npm install -g` operations write to user-owned directories
- Update troubleshooting docs to note the automatic fix

### Why
When `openclaw configure` runs `npm install -g mcporter` at runtime, it fails with `EACCES: permission denied` because the default npm prefix (`/usr`) writes to root-owned `/usr/lib/node_modules/`. The container runs as a non-root user with no way to escalate privileges.

### How
The entrypoint now creates `~/.npm-global`, sets it as the npm prefix via `npm config set prefix`, and prepends its `bin/` directory to `PATH`. This only affects runtime installs — build-time packages (claude-code, codex, etc.) installed as root during the Docker build remain in `/usr/lib/node_modules/` and are unaffected.

### Testing
- Container starts normally
- `npm config get prefix` → `~/.npm-global`
- `npm install -g cowsay` succeeds without permission errors
- Build-time packages still work: `claude --version`, `openclaw --version`

## Linked Issues

Closes #52

## Checklist

- [x] Tested in running container
- [x] Follows conventional commit format
- [x] Does not modify managed files