### PR TITLE
fix: remove duplicate H1 headings from docs pages

### DIFF
--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -5,8 +5,6 @@ sidebar:
   order: 2
 ---
 
-# Configuration
-
 All configuration lives in the `.env` file at the project root. This file is gitignored — it never gets committed.
 
 ## Environment Variables

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -5,8 +5,6 @@ sidebar:
   order: 1
 ---
 
-# Getting Started
-
 ## Prerequisites
 
 ### Docker

--- a/docs/security.mdx
+++ b/docs/security.mdx
@@ -5,8 +5,6 @@ sidebar:
   order: 3
 ---
 
-# Security
-
 ## Background
 
 In February 2025, LayerX Security Research disclosed a critical zero-click remote code execution vulnerability in Anthropic's Claude Desktop Extensions (DXT) framework. Extensions run unsandboxed with full system privileges, acting as execution bridges between the language model and the local operating system.

--- a/docs/troubleshooting.mdx
+++ b/docs/troubleshooting.mdx
@@ -5,8 +5,6 @@ sidebar:
   order: 4
 ---
 
-# Troubleshooting
-
 ## Container Won't Start
 
 ### "Conflict. The container name is already in use"


### PR DESCRIPTION
## What type of PR is this?

- [x] Bug fix

## What does this PR do?

Removes duplicate H1 headings from four docs pages. Starlight automatically renders the YAML frontmatter `title:` as the page's H1, so having an explicit `# Title` in the body causes the heading to appear twice.

### Affected files

| File | Removed line |
|------|-------------|
| `docs/getting-started.mdx` | `# Getting Started` |
| `docs/configuration.mdx` | `# Configuration` |
| `docs/security.mdx` | `# Security` |
| `docs/troubleshooting.mdx` | `# Troubleshooting` |

## How to verify

Build the docs site and confirm each page shows only one H1 heading (from frontmatter).

## Related issues

Closes #54