### PR TITLE
fix: clarify API key documentation for direct vs proxy mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,11 @@
 # =============================================================================
-# AI Provider — REQUIRED
+# AI Provider — REQUIRED (direct mode)
 # =============================================================================
-# REQUIRED: Replace the placeholder below with your real Anthropic API key.
-# Get a key at https://console.anthropic.com/
-# Keys start with "sk-ant-". Without a valid key, Claude Code will fail.
+# Direct mode: Set your Anthropic API key below.
+# Get a key at https://console.anthropic.com/ (keys start with "sk-ant-").
+#
+# Proxy mode: If using the proxy sidecar (see AI Proxy section below),
+# this can be any non-empty value — the proxy authenticates with OPENAI_API_KEY.
 
 ANTHROPIC_API_KEY=sk-ant-your-api-key-here
 
@@ -11,9 +13,10 @@ ANTHROPIC_API_KEY=sk-ant-your-api-key-here
 # AI Proxy — OPTIONAL
 # =============================================================================
 # To route AI traffic through the proxy sidecar (e.g. for OpenAI-compatible
-# providers), uncomment ALL of the following lines. You must enable BOTH
-# the proxy profile AND the base URL — setting only OPENAI_* vars without
-# COMPOSE_PROFILES=proxy will cause "Invalid API key" errors.
+# providers), uncomment ALL of the following lines and set ANTHROPIC_API_KEY
+# above to any non-empty value. You must enable BOTH the proxy profile AND
+# the base URL — setting only OPENAI_* vars without COMPOSE_PROFILES=proxy
+# will cause "Invalid API key" errors.
 
 # COMPOSE_PROFILES=proxy
 # ANTHROPIC_BASE_URL=http://proxy:8082

--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -13,9 +13,9 @@ All configuration lives in the `.env` file at the project root. This file is git
 
 | Variable | Description | Example |
 |----------|-------------|---------|
-| `ANTHROPIC_API_KEY` | API key for your AI provider | `sk-ant-abc123...` |
+| `ANTHROPIC_API_KEY` | API key passed to Claude Code | `sk-ant-abc123...` |
 
-This is the only variable required for AI tools to work. The dev container connects directly to your provider by default.
+In **direct mode** (default), set this to your Anthropic API key (`sk-ant-...`). In **proxy mode**, this can be any non-empty value — the proxy authenticates upstream with `OPENAI_API_KEY` instead.
 
 ### AI Proxy (Optional)
 

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -80,11 +80,14 @@ That's it — the dev container will connect directly to your AI provider.
 If you need to route traffic through the built-in proxy sidecar (for example, to remap model names or target an OpenAI-compatible endpoint), uncomment the proxy block in `.env`:
 
 ```ini
+ANTHROPIC_API_KEY=not-used
 COMPOSE_PROFILES=proxy
 ANTHROPIC_BASE_URL=http://proxy:8082
 OPENAI_API_KEY=sk-your-api-key-here
 OPENAI_BASE_URL=https://your-api-endpoint.example.com/v1
 ```
+
+In proxy mode, `ANTHROPIC_API_KEY` can be any non-empty value — Claude Code requires it to be set, but the proxy authenticates upstream with `OPENAI_API_KEY`.
 
 See [Configuration — AI Proxy](./configuration#ai-proxy-optional) for model mapping and tuning options.
 


### PR DESCRIPTION
## Summary

Clarifies API key documentation to distinguish between direct mode (real Anthropic key required) and proxy mode (`ANTHROPIC_API_KEY` can be any non-empty string since the proxy authenticates with `OPENAI_API_KEY`).

## Changes

### `.env.example`
- Reworded the AI Provider header from "REQUIRED" to "REQUIRED (direct mode)" and explained both modes
- Added note in the proxy section telling users to set `ANTHROPIC_API_KEY` to any non-empty value

### `docs/getting-started.mdx`
- Added `ANTHROPIC_API_KEY=not-used` to the proxy mode code block
- Added explanatory paragraph about why `ANTHROPIC_API_KEY` can be any value in proxy mode

### `docs/configuration.mdx`
- Changed table description from "API key for your AI provider" to "API key passed to Claude Code"
- Replaced generic description with mode-specific explanation (direct vs proxy)

## What Didn't Change
- `docker-compose.yml` — variable names are correct as-is
- `entrypoint.sh` — doesn't reference API keys
- `docs/troubleshooting.mdx` — already handles both modes well
- `docs/security.mdx` — doesn't discuss API key setup

## Testing
- Reviewed all three files for consistency
- No code changes — documentation only

Closes #58