### PR TITLE
fix: change proxy placeholder API key from "not-used" to "proxyconfig"

### DIFF
--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -80,7 +80,7 @@ That's it — the dev container will connect directly to your AI provider.
 If you need to route traffic through the built-in proxy sidecar (for example, to remap model names or target an OpenAI-compatible endpoint), uncomment the proxy block in `.env`:
 
 ```ini
-ANTHROPIC_API_KEY=not-used
+ANTHROPIC_API_KEY=proxyconfig
 COMPOSE_PROFILES=proxy
 ANTHROPIC_BASE_URL=http://proxy:8082
 OPENAI_API_KEY=sk-your-api-key-here


### PR DESCRIPTION
## Summary

Changes the `ANTHROPIC_API_KEY` placeholder value in the proxy mode example from `not-used` to `proxyconfig`.

## Changes

- `docs/getting-started.mdx`: `ANTHROPIC_API_KEY=not-used` → `ANTHROPIC_API_KEY=proxyconfig`

## Testing

Documentation-only change — no functional impact.

Closes #60