### PR TITLE
fix: add ripgrep and binary symlinks for Claude Code tool compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,7 +74,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     # Network tools
     dnsutils net-tools iputils-ping traceroute tcpdump nmap \
     # Shell tools
-    bat fd-find neovim htop tree fzf tmux file \
+    bat fd-find ripgrep neovim htop tree fzf tmux file \
     # Node.js
     nodejs \
     # Python
@@ -94,6 +94,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen \
     && locale-gen en_US.UTF-8 \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Create expected binary names for tools Ubuntu renames
+RUN ln -sf /usr/bin/fdfind /usr/local/bin/fd \
+    && ln -sf /usr/bin/batcat /usr/local/bin/bat
 
 ENV LANG=en_US.UTF-8
 ENV LC_ALL=en_US.UTF-8


### PR DESCRIPTION
## Summary

- Add `ripgrep` to apt-get install block so Claude Code's built-in Grep tool has the `rg` binary it requires
- Add `fd → /usr/bin/fdfind` symlink (Ubuntu installs `fd-find` as `fdfind`)
- Add `bat → /usr/bin/batcat` symlink (Ubuntu installs `bat` as `batcat`)

## Test plan

- [ ] Rebuild image: `docker compose build dev`
- [ ] Verify binaries: `docker exec devcontainer rg --version && fd --version && bat --version`
- [ ] Start Claude Code inside container and confirm Grep tool works (search for a pattern in files)

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)