### PR TITLE
feat: install missing tools and configure ZSH plugins

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -345,6 +345,7 @@ USER $USERNAME
 # 15. ZSH plugins (oh-my-zsh is pre-installed by devcontainers base)
 # ============================================================
 # hadolint ignore=DL3059
+# checkov:skip=CKV2_DOCKER_1:sudo here is a zsh plugin name in a sed argument, not a system call
 RUN ZSH_CUSTOM="${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}" \
     && git clone --depth=1 https://github.com/zsh-users/zsh-autosuggestions.git \
       "${ZSH_CUSTOM}/plugins/zsh-autosuggestions" \


### PR DESCRIPTION
## Summary

- Adds Google Cloud CLI apt repository and installs `google-cloud-cli` along with 13 other missing apt packages (`dos2unix`, `eza`, `fontconfig`, `fonts-powerline`, `graphviz`, `imagemagick`, `jq`, `locales-all`, `lsd`, `mtr-tiny`, `shellcheck`, `unzip`, `yelp-tools`)
- Adds section 8b with 6 new binary tool downloads: VS Code CLI (`code`), OpenShift CLI (`oc` 4.18.4), `yq`/`yq4` v4.52.4, `yq3` v3.4.1 (EOL), `terragrunt` 0.71.2, IBM Cloud CLI 2.31.0
- Adds 3 pip packages: `markitdown[all]`, `progressbar2`, `checkov`
- Adds section 15 (as USER vscode): clones 6 oh-my-zsh external plugins and activates full plugin list in `~/.zshrc`

Closes #66

## Test plan

- [ ] `docker compose build dev` completes without errors
- [ ] `docker exec devcontainer jq --version` — prints version
- [ ] `docker exec devcontainer shellcheck --version` — prints version
- [ ] `docker exec devcontainer gcloud version` — prints version
- [ ] `docker exec devcontainer eza --version` — prints version
- [ ] `docker exec devcontainer lsd --version` — prints version
- [ ] `docker exec devcontainer code --version` — prints version
- [ ] `docker exec devcontainer oc version --client` — prints version
- [ ] `docker exec devcontainer yq --version` and `yq4 --version` — same yq4 binary
- [ ] `docker exec devcontainer yq3 --version` — prints v3.4.1
- [ ] `docker exec devcontainer terragrunt --version` — prints version
- [ ] `docker exec devcontainer ibmcloud version` — prints version
- [ ] `docker exec devcontainer checkov --version` — prints version
- [ ] `docker exec devcontainer python3 -c "import markitdown; print('ok')"` — prints ok
- [ ] `docker exec devcontainer zsh -c "source ~/.zshrc && echo plugins: $plugins"` — lists all plugins
- [ ] Existing deployments: `docker compose down -v && docker compose up` required for ZSH changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)