### PR TITLE
feat: bake npm global prefix setup and ZSH compinit cache into build time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ ARG OC_VERSION=4.18.4
 ARG YQ_VERSION=4.52.4
 ARG TERRAGRUNT_VERSION=0.71.2
 ARG IBMCLOUD_VERSION=2.31.0
+ARG NERD_FONTS_VERSION=3.3.0
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -105,6 +106,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     dos2unix \
     eza \
     fontconfig \
+    fonts-noto-color-emoji \
     fonts-powerline \
     google-cloud-cli \
     graphviz \
@@ -114,6 +116,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     mtr-tiny \
     shellcheck \
     unzip \
+    xz-utils \
     yelp-tools \
     && sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen \
     && locale-gen en_US.UTF-8 \
@@ -340,6 +343,23 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     fluxbox \
     x11-utils \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# ============================================================
+# 14. Nerd Fonts (JetBrainsMono, Hack, FiraCode)
+# ============================================================
+# hadolint ignore=DL3059
+RUN mkdir -p /usr/local/share/fonts/nerd-fonts \
+    && curl ${CURL_RETRY} -fsSL \
+      "https://github.com/ryanoasis/nerd-fonts/releases/download/v${NERD_FONTS_VERSION}/JetBrainsMono.tar.xz" \
+      | tar -xJ -C /usr/local/share/fonts/nerd-fonts \
+    && curl ${CURL_RETRY} -fsSL \
+      "https://github.com/ryanoasis/nerd-fonts/releases/download/v${NERD_FONTS_VERSION}/Hack.tar.xz" \
+      | tar -xJ -C /usr/local/share/fonts/nerd-fonts \
+    && curl ${CURL_RETRY} -fsSL \
+      "https://github.com/ryanoasis/nerd-fonts/releases/download/v${NERD_FONTS_VERSION}/FiraCode.tar.xz" \
+      | tar -xJ -C /usr/local/share/fonts/nerd-fonts \
+    && fc-cache -fv
+
 USER $USERNAME
 
 # ============================================================
@@ -361,7 +381,16 @@ RUN ZSH_CUSTOM="${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}" \
     && git clone --depth=1 https://github.com/yuhonas/zsh-aliases-lsd.git \
       "${ZSH_CUSTOM}/plugins/zsh-aliases-lsd" \
     && sed -i 's/^plugins=(.*/plugins=(zsh-syntax-highlighting zsh-autosuggestions zsh-interactive-cd ubuntu jsontools gh common-aliases zsh-aliases-lsd zsh-tfenv conda-zsh-completion z pip terraform fluxcd azure git-auto-fetch helm istioctl iterm2 kube-ps1 kubectl sudo vscode aws fzf)/' \
-      "$HOME/.zshrc"
+      "$HOME/.zshrc" \
+    && echo 'export PATH="$HOME/.npm-global/bin:$PATH"' >> "$HOME/.zshrc"
+
+# ============================================================
+# 16. User shell bootstrap (baked in — eliminates runtime setup)
+# ============================================================
+# hadolint ignore=DL3059
+RUN mkdir -p "$HOME/.npm-global" \
+    && npm config set prefix "$HOME/.npm-global" \
+    && zsh -c "autoload -U compinit && compinit" 2>/dev/null || true
 
 ENV SHELL=/bin/zsh
 WORKDIR /workspace

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,14 +11,6 @@ if [ ! -O "$HOME" ]; then
 fi
 
 # ============================================================
-# npm global prefix (user-writable for runtime installs)
-# ============================================================
-NPM_GLOBAL="$HOME/.npm-global"
-mkdir -p "$NPM_GLOBAL"
-npm config set prefix "$NPM_GLOBAL"
-export PATH="$NPM_GLOBAL/bin:$PATH"
-
-# ============================================================
 # Configure user environment
 # ============================================================
 


### PR DESCRIPTION
## Summary

- Move `npm config set prefix` and `mkdir ~/.npm-global` from `entrypoint.sh` into a new Dockerfile section 16, so containers start with no npm invocation at boot
- Append `export PATH="$HOME/.npm-global/bin:$PATH"` to `.zshrc` in section 15 so `docker exec -it devcontainer zsh` correctly picks up npm-global binaries (fixes a pre-existing bug where the PATH export only affected the entrypoint shell process)
- Pre-generate `~/.zcompdump` via `zsh compinit` at build time so first interactive ZSH shell starts faster
- Remove the 7-line npm global prefix block from `entrypoint.sh`
- Also includes previously uncommitted Dockerfile additions: Nerd Fonts section 14 (JetBrainsMono, Hack, FiraCode), `fonts-noto-color-emoji`, and `xz-utils`

Closes #70

## Test plan

- [ ] Rebuild image and confirm `cat /home/vscode/.npmrc` contains `prefix=/home/vscode/.npm-global`
- [ ] Confirm `grep npm-global /home/vscode/.zshrc` returns the PATH export line
- [ ] Confirm `ls /home/vscode/.zcompdump*` shows a pre-generated cache file
- [ ] Confirm `zsh -ic "echo $PATH"` in a new container includes `npm-global`
- [ ] Confirm boot time is not increased (no npm invocation in entrypoint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)