### PR TITLE
fix: add claude-config/ to .dockerignore whitelist

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 *
 !entrypoint.sh
+!claude-config/


### PR DESCRIPTION
## Summary

Add `!claude-config/` to `.dockerignore` whitelist so the Docker build context includes the directory added in #78.

## Related Issue

Closes #79

## Changes

- Add `!claude-config/` to `.dockerignore` — the file uses a whitelist pattern (`*` then `!` exceptions), so the new directory must be explicitly included

## Checklist

- [x] Linked to a GitHub issue (required — CI will block merge without it)
- [x] Tested locally
- [x] Follows project conventions