### PR TITLE
fix: add WebFetch and WebSearch to tool awareness CLAUDE.md

### DIFF
--- a/claude-config/CLAUDE.md
+++ b/claude-config/CLAUDE.md
@@ -18,6 +18,8 @@ All Claude Code tools use PascalCase. NEVER use snake_case.
 | `Glob` | `glob`, `find_files`, `list_files` | Find files by pattern |
 | `Grep` | `grep`, `search`, `search_files` | Search file contents |
 | `Task` | `task`, `run_task`, `agent` | Launch subagent tasks |
+| `WebFetch` | `web_fetch`, `fetch`, `curl` | Fetch a URL and return its contents |
+| `WebSearch` | `web_search`, `search_web` | Search the web and return results |
 
 ## Task Tool Requirements
 


### PR DESCRIPTION
## Summary

Add `WebFetch` and `WebSearch` to the tool reference table in the User-level CLAUDE.md. Without these entries, Claude Code instances incorrectly tell users these tools are not available.

## Related Issue

Closes #83

## Changes

- Add `WebFetch` and `WebSearch` rows to the tool table in `claude-config/CLAUDE.md`

## Checklist

- [x] Linked to a GitHub issue (required — CI will block merge without it)
- [x] Tested locally
- [x] Follows project conventions