### PR TITLE
fix: add SearXNG sidecar for web search in proxy mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,7 @@ ANTHROPIC_API_KEY=sk-ant-your-api-key-here
 # will cause "Invalid API key" errors.
 
 # COMPOSE_PROFILES=proxy
+# COMPOSE_PROFILES=proxy,search          # proxy + SearXNG web search
 # ANTHROPIC_BASE_URL=http://proxy:8082
 # OPENAI_API_KEY=sk-your-api-key-here
 # OPENAI_BASE_URL=https://your-api-endpoint.example.com/v1

--- a/claude-config/CLAUDE.md
+++ b/claude-config/CLAUDE.md
@@ -20,10 +20,33 @@ All Claude Code tools use PascalCase. NEVER use snake_case.
 | `WebFetch` | `web_fetch`, `fetch`, `curl` | Fetch a URL and return its contents |
 | `WebSearch` | `web_search`, `search_web` | Search the web and return results |
 
-**Note:** `WebSearch` may not return results when running through a
-proxy. Use `WebFetch` or `Bash` with `curl` as alternatives.
+**Note:** `WebSearch` requires a direct Anthropic API connection — it is
+a server-side tool executed by the Anthropic backend. Through a proxy, the
+tool is silently dropped and returns 0 results. Use the SearXNG fallback
+below or `WebFetch` for direct URL retrieval.
 `MultiEdit` is not available through all proxy configurations — use
 sequential `Edit` calls instead.
+
+## Web Search
+
+The built-in `WebSearch` tool only works with a direct Anthropic API
+connection. When running through a proxy, use these alternatives:
+
+### SearXNG (self-hosted, no API key needed)
+
+If the search profile is enabled (`COMPOSE_PROFILES=proxy,search`),
+a SearXNG metasearch engine is available inside the Docker network:
+
+```bash
+curl -s "http://searxng:8080/search?q=your+query&format=json" | jq '.results[:5]'
+```
+
+Use `Bash` with `curl` to query SearXNG and parse the JSON results.
+
+### WebFetch (built-in, works through proxy)
+
+Use `WebFetch` to retrieve content from a specific URL when you already
+know where to look.
 
 ## Task Tool Requirements
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,6 +62,21 @@ services:
       start_period: 10s
     restart: unless-stopped
 
+  searxng:
+    image: searxng/searxng:latest
+    container_name: devcontainer-searxng
+    hostname: searxng
+    profiles:
+      - search
+    ports:
+      - "127.0.0.1:8888:8080"
+    environment:
+      - SEARXNG_BASE_URL=http://searxng:8080
+    volumes:
+      - searxng-data:/etc/searxng
+    restart: unless-stopped
+
 volumes:
   workspace:
   home:
+  searxng-data:

--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -46,6 +46,30 @@ The proxy maps generic model names to your backend's model identifiers:
 | `MAX_TOKENS_LIMIT` | `64000` | Maximum tokens per request |
 | `REQUEST_TIMEOUT` | `120` | Request timeout in seconds |
 
+### Web Search (SearXNG)
+
+The built-in `WebSearch` tool is a server-side tool executed by the Anthropic backend. It only works with a direct Anthropic API connection — through a proxy, it is silently dropped and returns no results.
+
+To restore web search capability in proxy mode, enable the **search** profile to add a [SearXNG](https://docs.searxng.org/) sidecar — a self-hosted metasearch engine that aggregates results from Google, Bing, DuckDuckGo, and others with no API key required.
+
+Add `search` to your `COMPOSE_PROFILES`:
+
+```ini
+COMPOSE_PROFILES=proxy,search
+```
+
+SearXNG is available inside the Docker network at `http://searxng:8080`. Claude Code can query it via `Bash` + `curl`:
+
+```bash
+curl -s "http://searxng:8080/search?q=your+query&format=json" | jq '.results[:5]'
+```
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `SEARXNG_BASE_URL` | `http://searxng:8080` | Base URL used by SearXNG internally |
+
+SearXNG configuration is persisted in the `searxng-data` volume. Customize settings by editing `/etc/searxng/settings.yml` inside the container.
+
 ### Remote Display (noVNC)
 
 The container runs a virtual display stack so you can watch and interact with headed browsers (e.g., Chromium controlled by `@playwright/mcp`).
@@ -172,6 +196,7 @@ All data lives in Docker named volumes — no host directories are mounted:
 |--------|-------------|----------|
 | `workspace` | `/workspace` | Your cloned repositories and project files |
 | `home` | `/home/vscode` | Shell history, tool configs, caches, SSH keys |
+| `searxng-data` | `/etc/searxng` | SearXNG configuration and settings (search profile only) |
 
 Both persist across container restarts and rebuilds. Run `docker compose pull` to fetch the latest pre-built image before restarting.
 
@@ -187,5 +212,6 @@ Both persist across container restarts and rebuilds. Run `docker compose pull` t
 |------|-----------|---------|
 | `127.0.0.1:${NOVNC_HOST_PORT:-6080}` | `6080` | noVNC remote display (localhost only, override with `NOVNC_HOST_PORT`) |
 | `127.0.0.1:18082` | `8082` | API proxy (localhost only, proxy mode) |
+| `127.0.0.1:8888` | `8080` | SearXNG search engine (localhost only, search profile) |
 
-Both ports are bound to `127.0.0.1` so they are only accessible from your machine, not the network. The proxy port is only active when running in proxy mode (`COMPOSE_PROFILES=proxy`).
+Both ports are bound to `127.0.0.1` so they are only accessible from your machine, not the network. The proxy port is only active when running in proxy mode (`COMPOSE_PROFILES=proxy`). The SearXNG port is only active when the search profile is enabled.


### PR DESCRIPTION
## Summary

Adds a self-hosted SearXNG metasearch engine as an opt-in sidecar container to restore web search capability when running through the proxy.

## Problem

`WebSearch` is an Anthropic server-side tool (`web_search_20250305`) that only works with a direct API connection. Through the proxy:
- The tool has a different structure (`type` field instead of standard `name`/`description`/`input_schema`)
- The proxy silently drops it during Anthropic→OpenAI format conversion
- Open WebUI's built-in web search is a UI-level feature, not triggered by the API

## Solution

Add SearXNG as an opt-in sidecar (enabled via `COMPOSE_PROFILES=proxy,search`) that Claude Code can query via `Bash` + `curl`:

```bash
curl -s "http://searxng:8080/search?q=your+query&format=json" | jq '.results[:5]'
```

## Changes

| File | Change |
|------|--------|
| `docker-compose.yml` | Add `searxng` service with `search` profile and `searxng-data` volume |
| `.env.example` | Document `COMPOSE_PROFILES=proxy,search` option |
| `claude-config/CLAUDE.md` | Add web search section explaining limitation and SearXNG fallback |
| `docs/configuration.mdx` | Document SearXNG service, port mapping, and data persistence |

## Testing

1. Set `COMPOSE_PROFILES=proxy,search` in `.env`
2. `docker compose up -d` — SearXNG container starts
3. Enter dev container: `docker exec -it devcontainer zsh`
4. Test: `curl -s "http://searxng:8080/search?q=test&format=json" | jq '.results[:3]'`

Closes #87