### PR TITLE
fix: enable SearXNG JSON API with custom settings.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,10 +73,9 @@ services:
     environment:
       - SEARXNG_BASE_URL=http://searxng:8080
     volumes:
-      - searxng-data:/etc/searxng
+      - ./searxng/settings.yml:/etc/searxng/settings.yml:ro
     restart: unless-stopped
 
 volumes:
   workspace:
   home:
-  searxng-data:

--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -68,7 +68,12 @@ curl -s "http://searxng:8080/search?q=your+query&format=json" | jq '.results[:5]
 |----------|---------|-------------|
 | `SEARXNG_BASE_URL` | `http://searxng:8080` | Base URL used by SearXNG internally |
 
-SearXNG configuration is persisted in the `searxng-data` volume. Customize settings by editing `/etc/searxng/settings.yml` inside the container.
+A custom `searxng/settings.yml` is bind-mounted into the container. It extends the SearXNG defaults with two changes required for API access:
+
+- **`search.formats`** includes `json` (the default only allows `html`, which causes `format=json` requests to return 403)
+- **`server.limiter`** is set to `false` (the default rate limiter blocks automated requests from Claude Code)
+
+To customize SearXNG further, edit `searxng/settings.yml` in the project root.
 
 ### Remote Display (noVNC)
 
@@ -196,7 +201,6 @@ All data lives in Docker named volumes — no host directories are mounted:
 |--------|-------------|----------|
 | `workspace` | `/workspace` | Your cloned repositories and project files |
 | `home` | `/home/vscode` | Shell history, tool configs, caches, SSH keys |
-| `searxng-data` | `/etc/searxng` | SearXNG configuration and settings (search profile only) |
 
 Both persist across container restarts and rebuilds. Run `docker compose pull` to fetch the latest pre-built image before restarting.
 

--- a/searxng/settings.yml
+++ b/searxng/settings.yml
@@ -1,0 +1,19 @@
+# SearXNG settings for devcontainer sidecar
+# This is an internal-only service — not exposed to the public internet.
+# JSON API access and limiter are configured for automated tool usage.
+
+use_default_settings: true
+
+server:
+  # Disable rate limiter — this instance is private, accessed only by
+  # Claude Code inside the Docker network.
+  limiter: false
+  # Disable public instance features not needed for private use
+  public_instance: false
+
+search:
+  # Enable JSON format so Claude Code can query via:
+  #   curl -s "http://searxng:8080/search?q=...&format=json"
+  formats:
+    - html
+    - json


### PR DESCRIPTION
## Summary

The SearXNG sidecar added in #88 uses the default configuration, which blocks JSON API access — causing `format=json` requests to return **403 Forbidden**.

## Problem

SearXNG's default `settings.yml`:
1. Only lists `html` in `search.formats` — `json` is not permitted
2. Enables `server.limiter: true` — blocks automated/non-browser requests

This means Claude Code's `curl -s "http://searxng:8080/search?q=...&format=json"` always returns 403.

## Changes

| File | Change |
|------|--------|
| `searxng/settings.yml` | New custom config extending defaults: enables `json` format, disables rate limiter |
| `docker-compose.yml` | Bind-mount `settings.yml` (read-only) instead of named volume with auto-generated defaults; remove unused `searxng-data` volume |
| `docs/configuration.mdx` | Document the custom settings file; remove stale `searxng-data` volume reference |

## Testing

After recreating the SearXNG container:
```bash
docker compose down
docker compose up -d
curl -s "http://searxng:8080/search?q=test&format=json" | jq '.results | length'
# Should return a number > 0 instead of 403
```

Closes #89