### PR TITLE
feat: install tool awareness at Managed policy tier for bulletproof loading

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -315,6 +315,16 @@ RUN chmod +x /opt/claude-config/self-test.sh \
     && ln -s /opt/claude-config/self-test.sh /usr/local/bin/claude-self-test
 
 # ============================================================
+# 10c. Managed policy — tool awareness at highest priority tier
+# ============================================================
+# The Managed policy tier (/etc/claude-code/) is the highest priority in
+# Claude Code's memory hierarchy and is always loaded, even when a project
+# CLAUDE.md exists in the working directory. This prevents tool awareness
+# from being deprioritized by large project-level instructions.
+RUN mkdir -p /etc/claude-code/.claude/rules \
+    && cp /opt/claude-config/CLAUDE.md /etc/claude-code/CLAUDE.md
+
+# ============================================================
 # 11. Playwright browsers (Chromium + system deps)
 # ============================================================
 # hadolint ignore=DL3059

--- a/claude-config/self-test.sh
+++ b/claude-config/self-test.sh
@@ -50,6 +50,13 @@ else
 fi
 
 echo ""
+echo "3b. Tool Awareness (Managed policy)"
+MANAGED_CLAUDE="/etc/claude-code/CLAUDE.md"
+check "$MANAGED_CLAUDE exists" test -f "$MANAGED_CLAUDE"
+check "Managed policy contains PascalCase reference" grep -q "PascalCase" "$MANAGED_CLAUDE"
+check "Managed policy contains tool table" grep -q "Read file contents" "$MANAGED_CLAUDE"
+
+echo ""
 echo "4. Container Environment"
 check "workspace directory exists" test -d /workspace
 check "home directory writable" test -w "$HOME"

--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -120,15 +120,28 @@ The Dockerfile is organized into numbered sections for Docker layer caching:
 | 9. npm global tools | claude-code, codex, prettier, markdownlint-cli2, openclaw, devcontainers-cli, playwright |
 | 10. pip tools | pre-commit, ansible, black, pylint, yamllint, playwright |
 | 10b. Claude Code config | Tool awareness memory, project rules, self-test script |
+| 10c. Managed policy | Tool awareness installed to `/etc/claude-code/` (highest priority tier) |
 | 11. Playwright browsers | Chromium + system deps via `playwright install --with-deps` |
 | 12. Homebrew | Linuxbrew (needed by openclaw configure) |
 | 13. VNC stack | Xvfb, x11vnc, noVNC, fluxbox — remote display via browser |
 
 ## Claude Code Tool Awareness
 
-The container includes baked-in configuration that prevents Claude Code from confusing tool names. On first startup, the entrypoint seeds:
+The container includes baked-in configuration that prevents Claude Code from confusing tool names. Tool awareness is installed at **two** memory tiers for defense-in-depth:
 
-- **User-level CLAUDE.md** (`~/.claude/CLAUDE.md`) — a tool name reference loaded in every Claude Code session, regardless of which project directory you're working in
+- **Managed policy** (`/etc/claude-code/CLAUDE.md`) — installed at Docker build time. This is the highest-priority tier in Claude Code's memory hierarchy and is always loaded, even when a large project `CLAUDE.md` exists in the working directory.
+- **User memory** (`~/.claude/CLAUDE.md`) — seeded by the entrypoint on first startup. Provides a backup layer and a visible, customizable copy for users.
+
+### Memory Tier Priority
+
+Claude Code loads instructions from multiple memory tiers (highest to lowest priority):
+
+1. **Managed policy** (`/etc/claude-code/`) — Always loaded, cannot be excluded
+2. **Project memory** (`./CLAUDE.md`) — Loaded per project directory
+3. **User memory** (`~/.claude/CLAUDE.md`) — Loaded globally for all sessions
+4. **Local memory** (`./CLAUDE.local.md`) — Personal per-project overrides
+
+Without the Managed policy tier, tool awareness in User memory can be deprioritized when competing with a large project-level `CLAUDE.md`, causing Claude to lose awareness of its PascalCase tool names. The Managed tier guarantees tool awareness is always loaded at the highest priority.
 
 ### Self-Test
 


### PR DESCRIPTION
## Summary

Install tool awareness at the **Managed policy** tier (`/etc/claude-code/CLAUDE.md`) for defense-in-depth. This is the highest-priority memory tier in Claude Code and is always loaded, even when a large project `CLAUDE.md` exists.

Closes #91

## Changes

| File | Change |
|------|--------|
| `Dockerfile` | Add step 10c: copy `CLAUDE.md` to `/etc/claude-code/CLAUDE.md` |
| `claude-config/self-test.sh` | Add Managed policy verification (3 checks) |
| `docs/configuration.mdx` | Document memory tier strategy; add 10c to layer table |

## Problem

Issue #81 moved tool awareness to User memory (`~/.claude/CLAUDE.md`). This works in isolation, but when Claude Code starts in a directory with its own `CLAUDE.md` (e.g., `/workspace/devcontainer/` with a 654-line project CLAUDE.md), the User memory content is deprioritized — Claude loses tool awareness and claims it has no tools.

## Solution

**Belt and suspenders** — install tool awareness at two tiers:

1. **Managed policy** (`/etc/claude-code/CLAUDE.md`) — highest priority, cannot be excluded. Installed at Docker build time.
2. **User memory** (`~/.claude/CLAUDE.md`) — backup layer, seeded by entrypoint (unchanged).

## Testing

- [ ] `docker compose up -d --build` succeeds
- [ ] `claude-self-test` passes all checks including new "3b. Managed policy" section
- [ ] Starting `claude` in `/workspace/devcontainer/` (with project CLAUDE.md) → Claude knows PascalCase tools
- [ ] Starting `claude` in `/workspace/` (no project CLAUDE.md) → Claude knows PascalCase tools
- [ ] `/memory` in Claude Code shows `/etc/claude-code/CLAUDE.md` as Managed type