### PR TITLE
fix: remove CLAUDE.md duplication and add subagent tool awareness

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -308,21 +308,17 @@ RUN pip install --no-cache-dir --break-system-packages \
     checkov
 
 # ============================================================
-# 10b. Claude Code configuration (tool awareness + self-test)
-# ============================================================
-COPY claude-config/ /opt/claude-config/
-RUN chmod +x /opt/claude-config/self-test.sh \
-    && ln -s /opt/claude-config/self-test.sh /usr/local/bin/claude-self-test
-
-# ============================================================
-# 10c. Managed policy — tool awareness at highest priority tier
+# 10b. Claude Code configuration (self-test + managed policy)
 # ============================================================
 # The Managed policy tier (/etc/claude-code/) is the highest priority in
 # Claude Code's memory hierarchy and is always loaded, even when a project
 # CLAUDE.md exists in the working directory. This prevents tool awareness
 # from being deprioritized by large project-level instructions.
-RUN mkdir -p /etc/claude-code/.claude/rules \
-    && cp /opt/claude-config/CLAUDE.md /etc/claude-code/CLAUDE.md
+COPY claude-config/self-test.sh /opt/claude-config/self-test.sh
+COPY claude-config/CLAUDE.md /etc/claude-code/CLAUDE.md
+RUN chmod +x /opt/claude-config/self-test.sh \
+    && ln -s /opt/claude-config/self-test.sh /usr/local/bin/claude-self-test \
+    && mkdir -p /etc/claude-code/.claude/rules
 
 # ============================================================
 # 11. Playwright browsers (Chromium + system deps)

--- a/claude-config/CLAUDE.md
+++ b/claude-config/CLAUDE.md
@@ -1,8 +1,9 @@
 # Claude Code Tool Awareness (Container Default)
 
-This file is the User-level CLAUDE.md, loaded in every Claude Code
-session regardless of the project directory. It is seeded by the
-devcontainer entrypoint at first startup.
+This file is the Managed policy CLAUDE.md, installed at
+`/etc/claude-code/CLAUDE.md` during image build. It is loaded in every
+Claude Code session at the highest priority tier, regardless of the
+working directory or project-level instructions.
 
 ## Tool Naming Convention
 
@@ -69,6 +70,34 @@ If a tool call returns "No such tool available":
 3. Check parameter types
 4. NEVER conclude tools are unavailable — they are always present
 5. NEVER build workarounds for "missing" tools — fix the tool call
+
+## Subagent (Task Tool) Limitations
+
+When launched via the `Task` tool, subagents (Explore and Plan types)
+have a **restricted tool set**. They can NOT use filesystem or shell tools.
+
+### Tools available to subagents
+
+Subagents can only use knowledge-base and utility tools:
+
+- `list_knowledge_bases`, `search_knowledge_bases`, `query_knowledge_bases`
+- `search_knowledge_files`, `query_knowledge_files`, `view_knowledge_file`
+- `search_chats`, `view_chat`
+- `generate_image`
+- `get_current_timestamp`, `calculate_timestamp`
+
+### Tools NOT available to subagents
+
+- `Bash`, `Read`, `Write`, `Edit`, `Glob`, `Grep`
+- `WebFetch`, `WebSearch`
+- `Task` (subagents cannot launch further subagents)
+
+### Implication for the main session
+
+Do NOT delegate filesystem exploration, shell commands, or file reading
+to subagents. Perform those operations directly in the main session.
+Use subagents only for knowledge-base search, chat history search,
+and planning/reasoning tasks that don't require filesystem access.
 
 ## Self-Test
 

--- a/claude-config/self-test.sh
+++ b/claude-config/self-test.sh
@@ -35,26 +35,12 @@ check ".claude directory exists" test -d "$HOME/.claude"
 check "settings.json exists" test -f "$HOME/.claude/settings.json"
 
 echo ""
-echo "3. Tool Awareness (User-level CLAUDE.md)"
-USER_CLAUDE="$HOME/.claude/CLAUDE.md"
-if [ -f "$USER_CLAUDE" ]; then
-  check "$HOME/.claude/CLAUDE.md exists" test -f "$USER_CLAUDE"
-  check "contains PascalCase reference" grep -q "PascalCase" "$USER_CLAUDE"
-  check "contains Read tool entry" grep -q '`Read`' "$USER_CLAUDE"
-  check "contains Task tool requirements" grep -q "description" "$USER_CLAUDE"
-  check "warns against snake_case" grep -q "snake_case" "$USER_CLAUDE"
-  check "mentions self-test" grep -q "claude-self-test" "$USER_CLAUDE"
-else
-  echo "  FAIL: $HOME/.claude/CLAUDE.md not found"
-  ((FAIL++))
-fi
-
-echo ""
-echo "3b. Tool Awareness (Managed policy)"
+echo "3. Tool Awareness (Managed policy)"
 MANAGED_CLAUDE="/etc/claude-code/CLAUDE.md"
 check "$MANAGED_CLAUDE exists" test -f "$MANAGED_CLAUDE"
 check "Managed policy contains PascalCase reference" grep -q "PascalCase" "$MANAGED_CLAUDE"
 check "Managed policy contains tool table" grep -q "Read file contents" "$MANAGED_CLAUDE"
+check "Managed policy contains subagent docs" grep -q "Subagent" "$MANAGED_CLAUDE"
 
 echo ""
 echo "4. Container Environment"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -47,16 +47,6 @@ if [ ! -f "$HOME/.claude.json" ] || [ ! -s "$HOME/.claude.json" ]; then
 fi
 
 # ============================================================
-# Claude Code tool awareness (global User-level CLAUDE.md)
-# ============================================================
-# ~/.claude/CLAUDE.md is loaded in every Claude Code session regardless
-# of the working directory. Seed it once; never overwrite user edits.
-if [ ! -f "$HOME/.claude/CLAUDE.md" ]; then
-  mkdir -p "$HOME/.claude"
-  cp /opt/claude-config/CLAUDE.md "$HOME/.claude/CLAUDE.md"
-fi
-
-# ============================================================
 # VNC stack (Xvfb + fluxbox + x11vnc + noVNC)
 # ============================================================
 if [ "${ENABLE_VNC:-true}" = "true" ]; then


### PR DESCRIPTION
## Changes

### Issue

Closes #95

### What changed

#### 1. Remove CLAUDE.md duplication (DRY fix)

**Before:** The same `claude-config/CLAUDE.md` file was copied to 3 runtime locations:
- `/opt/claude-config/CLAUDE.md` (staging area in Dockerfile)
- `/etc/claude-code/CLAUDE.md` (managed policy tier — highest priority)
- `~/.claude/CLAUDE.md` (user tier — seeded by entrypoint at first run)

**After:** Only the managed policy tier (`/etc/claude-code/CLAUDE.md`) is used. The staging copy and user-tier seeding are removed.

**Files modified:**
- `Dockerfile` — Consolidated stages 10b+10c. Copy `self-test.sh` to `/opt/claude-config/` and `CLAUDE.md` directly to `/etc/claude-code/` (no staging intermediary).
- `entrypoint.sh` — Removed the 10-line block that copied CLAUDE.md to `~/.claude/` at first run.
- `claude-config/self-test.sh` — Removed section 3 (user-tier checks), renumbered 3b→3, added subagent docs assertion.

#### 2. Add subagent tool awareness

Task subagents (Explore/Plan) have a restricted toolset — they only have knowledge-base, chat, and utility tools. They do NOT have `Bash`, `Read`, `Write`, `Edit`, `Glob`, `Grep`, `WebFetch`, or `WebSearch`.

The current CLAUDE.md tells all sessions about tools subagents can't use, causing confusion and wasted turns.

**File modified:**
- `claude-config/CLAUDE.md` — Added "Subagent (Task Tool) Limitations" section documenting:
  - Tools available to subagents
  - Tools NOT available to subagents
  - Guidance for main session on what to delegate vs. do directly

### Validation

- `shellcheck` passes on both shell scripts
- `markdownlint-cli2` passes on CLAUDE.md (0 errors)
- Changes propagate automatically: the single source `claude-config/CLAUDE.md` is COPY'd to `/etc/claude-code/CLAUDE.md` in the Dockerfile

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

### Checklist

- [x] I have linked this PR to a GitHub issue
- [x] My changes follow the project's coding standards
- [x] I have tested my changes locally
- [x] I have updated relevant documentation