### PR TITLE
fix: remove Debian typing_extensions to unblock pip install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -352,9 +352,14 @@ RUN npm install -g \
 # ============================================================
 # 12. pip tools
 # ============================================================
+# Remove Debian typing_extensions (installed by python3-typing-extensions without
+# a RECORD file, causing pip uninstall-no-record-file errors on upgrade).
+# hadolint ignore=DL3059
+RUN rm -rf /usr/lib/python3/dist-packages/typing_extensions* \
+    && apt-get -y purge python3-typing-extensions 2>/dev/null || true
+
 # hadolint ignore=DL3013,DL3059
-RUN pip install --no-cache-dir --break-system-packages --force-reinstall typing_extensions \
-    && pip install --no-cache-dir --break-system-packages \
+RUN pip install --no-cache-dir --break-system-packages \
     pre-commit \
     ansible \
     black \


### PR DESCRIPTION
## Summary

Fixes Docker build failure caused by `typing_extensions 4.10.0` installed by Debian (via VNC dependencies) without a pip RECORD file.

## Changes

- Added `rm -rf /usr/lib/python3/dist-packages/typing_extensions*` + `apt-get purge python3-typing-extensions` before the pip install step
- Removed the `--force-reinstall typing_extensions` from #98 (didn't work — pip can't force-reinstall what it can't uninstall)

## Root cause

Moving VNC to the `deps` stage in #94 means `python3-typing-extensions 4.10.0` is now installed before pip runs. Previously VNC was installed after pip, so there was no conflict.

## Related
Closes #99
Follow-up to #94, #98