### PR TITLE
fix: use --ignore-installed for pip to handle all Debian python3 packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -352,10 +352,10 @@ RUN npm install -g \
 # ============================================================
 # 12. pip tools
 # ============================================================
-# hadolint ignore=DL3013,DL3059
 # --ignore-installed: VNC deps (novnc, x11vnc) pull in Debian python3
 # packages without pip RECORD files (typing_extensions, packaging, etc.).
 # pip cannot upgrade these normally, so we skip the uninstall check.
+# hadolint ignore=DL3013,DL3059
 RUN pip install --no-cache-dir --break-system-packages --ignore-installed \
     pre-commit \
     ansible \


### PR DESCRIPTION
## Summary

Replaces the targeted `typing_extensions` removal from #100 with `--ignore-installed` flag on the pip install command. This handles all Debian python3 packages without RECORD files, not just `typing_extensions`.

## Changes

- Added `--ignore-installed` to the pip install command
- Removed the `rm -rf typing_extensions*` / `apt-get purge` workaround
- Added comment explaining why `--ignore-installed` is needed (VNC deps)

## Root cause

The VNC stack (moved to `deps` stage in #94) pulls in `python3-typing-extensions`, `python3-packaging`, and other Debian packages. These are installed without pip RECORD files, so pip cannot uninstall/upgrade them normally.

## Related
Closes #101
Follow-up to #94, #98, #100