### PR TITLE
feat: bake opencode configuration into the devcontainer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -456,6 +456,7 @@ USER root
 COPY claude-config/self-test.sh /opt/claude-config/self-test.sh
 COPY claude-config/CLAUDE.md /etc/claude-code/CLAUDE.md
 COPY claude-config/claude-proxy.sh /usr/local/lib/claude-proxy.sh
+COPY opencode-config/opencode.json /opt/opencode-config/opencode.json
 RUN chmod +x /opt/claude-config/self-test.sh /usr/local/lib/claude-proxy.sh \
     && ln -s /opt/claude-config/self-test.sh /usr/local/bin/claude-self-test \
     && mkdir -p /etc/claude-code/.claude/rules

--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -53,6 +53,23 @@ curl http://localhost:8082/
 cat /tmp/claude-proxy.log
 ```
 
+### OpenCode
+
+When `OPENAI_API_KEY` and `OPENAI_BASE_URL` are set, the container automatically seeds an [OpenCode](https://opencode.ai/) configuration at `~/.config/opencode/opencode.json`. This configures a custom provider called **OpenAI Proxy** that points at the same upstream endpoint used by the Claude Code proxy.
+
+The config uses OpenCode's `{env:VAR_NAME}` syntax, so credentials are resolved from environment variables at runtime — no secrets are baked into the file.
+
+Available models:
+
+| Model ID | Description |
+|----------|-------------|
+| `claude-sonnet-4-5` | Claude Sonnet 4.5 |
+| `claude-sonnet-4-6` | Claude Sonnet 4.6 |
+| `claude-opus-4-6` | Claude Opus 4.6 |
+| `claude-haiku-4-5` | Claude Haiku 4.5 |
+
+The config is only seeded when the file doesn't already exist, so you can customize it without it being overwritten on restart. To reset to defaults, delete `~/.config/opencode/opencode.json` and restart the container.
+
 ### Web Search (SearXNG)
 
 The built-in `WebSearch` tool is a server-side tool executed by the Anthropic backend. It only works with a direct Anthropic API connection — through a proxy, it is silently dropped and returns no results.
@@ -158,7 +175,7 @@ These layers change more frequently (npm/pip updates, config changes) but rebuil
 | 14. Homebrew | Linuxbrew (needed by openclaw configure) |
 | 15. ZSH plugins | oh-my-zsh custom plugins |
 | 16. Shell bootstrap | npm-global, tfenv, compinit |
-| 17. Claude Code config | Tool awareness memory, managed policy, self-test script |
+| 17. Claude Code + OpenCode config | Tool awareness memory, managed policy, self-test script, OpenCode provider template |
 | 18. Entrypoint | Container startup script (absolute last COPY) |
 
 ### Build Cache

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -46,6 +46,15 @@ if [ ! -f "$HOME/.claude.json" ] || [ ! -s "$HOME/.claude.json" ]; then
   echo '{"hasCompletedOnboarding": true}' >"$HOME/.claude.json"
 fi
 
+# Seed opencode config if missing
+OPENCODE_CONFIG_DIR="$HOME/.config/opencode"
+if [ ! -f "$OPENCODE_CONFIG_DIR/opencode.json" ] || [ ! -s "$OPENCODE_CONFIG_DIR/opencode.json" ]; then
+  if [ -n "$OPENAI_API_KEY" ] && [ -f /opt/opencode-config/opencode.json ]; then
+    mkdir -p "$OPENCODE_CONFIG_DIR"
+    cp /opt/opencode-config/opencode.json "$OPENCODE_CONFIG_DIR/opencode.json"
+  fi
+fi
+
 # ============================================================
 # Claude Code Proxy (Anthropic Messages API -> OpenAI)
 # ============================================================

--- a/opencode-config/opencode.json
+++ b/opencode-config/opencode.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "openai-proxy": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "OpenAI Proxy",
+      "options": {
+        "baseURL": "{env:OPENAI_BASE_URL}",
+        "apiKey": "{env:OPENAI_API_KEY}"
+      },
+      "models": {
+        "claude-sonnet-4-5": {
+          "name": "claude-sonnet-4-5"
+        },
+        "claude-sonnet-4-6": {
+          "name": "claude-sonnet-4-6"
+        },
+        "claude-opus-4-6": {
+          "name": "claude-opus-4-6"
+        },
+        "claude-haiku-4-5": {
+          "name": "claude-haiku-4-5"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Bakes an OpenCode configuration template into the devcontainer image so that opencode works out of the box when `OPENAI_API_KEY` and `OPENAI_BASE_URL` are set.

## Changes

### `opencode-config/opencode.json` (NEW)
OpenCode config template using `{env:VAR_NAME}` syntax to resolve credentials from environment variables at runtime. Defines an "OpenAI Proxy" provider with four Claude models (sonnet-4-5, sonnet-4-6, opus-4-6, haiku-4-5).

### `Dockerfile`
Added `COPY opencode-config/opencode.json /opt/opencode-config/opencode.json` in section 17 alongside existing claude-config COPYs.

### `entrypoint.sh`
Added opencode config seeding after Claude Code config seeding. Guards:
- Only seeds when `OPENAI_API_KEY` is set (proxy mode)
- Only seeds when the template exists in the image
- Only seeds when `~/.config/opencode/opencode.json` doesn't exist or is empty (won't overwrite user customization)

### `docs/configuration.mdx`
- Added "OpenCode" section documenting the auto-configuration behavior
- Updated section 17 row in the build layers table

## Testing

- **Build**: `docker compose build` — opencode config at `/opt/opencode-config/opencode.json`
- **Seed**: With `OPENAI_API_KEY` set, start container → `~/.config/opencode/opencode.json` is created
- **No-overwrite**: Modify the config, restart → existing config preserved
- **No-proxy**: Without `OPENAI_API_KEY`, no config is seeded

## Related

Closes #107