### PR TITLE
fix: add opencode-config to .dockerignore allowlist

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 *
 !entrypoint.sh
 !claude-config/
+!opencode-config/


### PR DESCRIPTION
## Summary

The Docker Publish workflow failed after merging #108 because `.dockerignore` uses a deny-all (`*`) pattern and `opencode-config/` was not included in the allowlist. This caused `COPY opencode-config/opencode.json` to fail with:

```
CopyIgnoredFile: Attempting to Copy file "opencode-config/opencode.json" that is excluded by .dockerignore
```

## Changes

Added `!opencode-config/` to `.dockerignore` alongside the existing `!claude-config/` entry.

## Testing

Docker build should now find `opencode-config/opencode.json` in the build context.

## Related

Closes #109
Follow-up fix for #107 / #108