### PR TITLE
fix: switch claude-code-proxy to org fork with streaming error fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -373,7 +373,7 @@ RUN pip install --no-cache-dir --break-system-packages --ignore-installed \
 # Runs as a background process in entrypoint.sh when OPENAI_API_KEY is set.
 # Build tools are needed for C extensions (httptools, uvloop) on Python 3.13.
 # hadolint ignore=DL3008,DL3059
-RUN git clone --depth=1 https://github.com/fuergaosi233/claude-code-proxy.git /opt/claude-code-proxy
+RUN git clone --depth=1 https://github.com/f5xc-salesdemos/claude-code-proxy.git /opt/claude-code-proxy
 
 WORKDIR /opt/claude-code-proxy
 # hadolint ignore=DL3008,DL3059


### PR DESCRIPTION
## Summary

Switch the Dockerfile to clone `claude-code-proxy` from the org fork (`f5xc-salesdemos/claude-code-proxy`) instead of the upstream (`fuergaosi233/claude-code-proxy`).

## Problem

The upstream proxy has a bug in `response_converter.py` where mid-stream `HTTPException` errors are re-raised after HTTP headers have already been sent. This causes:

1. `RuntimeError: Caught handled exception, but response already started`
2. Claude Code receives truncated/malformed SSE streams
3. Claude Code falls back to non-streaming mode, which hits cascading 400/429 errors
4. The user sees `429 Rate limit exceeded` even when the upstream API is healthy

## Fix (in the org fork)

Three changes applied to `f5xc-salesdemos/claude-code-proxy`:

1. **`response_converter.py`**: Emit proper SSE error events instead of re-raising `HTTPException` mid-stream — eliminates the `RuntimeError`
2. **`client.py`**: Add retry with exponential backoff (2s, 4s) for `RateLimitError` on the initial streaming connection — uses existing `MAX_RETRIES` config (default 2)
3. **`client.py`**: Log raw upstream error messages before `classify_openai_error` rewrites them — preserves original errors for debugging

## Verification

All fixes were tested locally in the running container before forking:

| Test | Result |
|------|--------|
| Proxy health/connectivity | Pass |
| Anthropic SDK non-streaming (haiku + opus) | Pass |
| Anthropic SDK streaming (haiku + opus) | Pass |
| Claude CLI `claude -p` | Pass |
| Mid-stream HTTPException(429) unit test | Pass — yields SSE error event |
| Mid-stream HTTPException(400) billing unit test | Pass — yields SSE error event |
| 3 concurrent streaming requests | Pass |
| Proxy log — zero RuntimeErrors after fix | Pass |

## Changes

- `Dockerfile`: line 376 — change clone URL from `fuergaosi233` to `f5xc-salesdemos`

Closes #111