### PR TITLE
feat: add Codex CLI configuration and proxy integration

### DIFF
--- a/.devcontainer/scripts/post-start.sh
+++ b/.devcontainer/scripts/post-start.sh
@@ -12,8 +12,17 @@ if [ -n "$OPENAI_API_KEY" ]; then
   else
     echo "not reachable (check /tmp/claude-proxy.log)"
   fi
-  echo -n "  Checking upstream ($OPENAI_BASE_URL)... "
-  if curl -sf --connect-timeout 5 -o /dev/null "$OPENAI_BASE_URL/models" \
+  echo -n "  Checking Responses API (Codex)... "
+  if curl -sf --connect-timeout 5 -o /dev/null -w "%{http_code}" \
+    -X POST "http://localhost:8082/responses" \
+    -H "Content-Type: application/json" \
+    -d '{"model":"test","input":"ping","stream":false}' 2>/dev/null | grep -qE '^(200|4[0-9]{2}|500)$'; then
+    echo "available"
+  else
+    echo "not available (proxy may need Responses API endpoints)"
+  fi
+  echo -n "  Checking upstream ($_UPSTREAM_OPENAI_BASE_URL)... "
+  if curl -sf --connect-timeout 5 -o /dev/null "${_UPSTREAM_OPENAI_BASE_URL:-${OPENAI_BASE_URL}}/models" \
     -H "Authorization: Bearer $OPENAI_API_KEY" 2>/dev/null; then
     echo "reachable"
   else

--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@
 !entrypoint.sh
 !claude-config/
 !opencode-config/
+!codex-config/

--- a/Dockerfile
+++ b/Dockerfile
@@ -76,7 +76,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     # Media / utilities
     ffmpeg poppler-utils qrencode \
     # Network tools
-    dnsutils net-tools iputils-ping traceroute tcpdump nmap \
+    dnsutils net-tools iputils-ping traceroute tcpdump nmap netcat-openbsd \
     # Shell tools
     bat fd-find ripgrep neovim htop tree tmux file \
     # Node.js
@@ -457,6 +457,7 @@ COPY claude-config/self-test.sh /opt/claude-config/self-test.sh
 COPY claude-config/CLAUDE.md /etc/claude-code/CLAUDE.md
 COPY claude-config/claude-proxy.sh /usr/local/lib/claude-proxy.sh
 COPY opencode-config/opencode.json /opt/opencode-config/opencode.json
+COPY codex-config/config.toml /opt/codex-config/config.toml
 RUN chmod +x /opt/claude-config/self-test.sh /usr/local/lib/claude-proxy.sh \
     && ln -s /opt/claude-config/self-test.sh /usr/local/bin/claude-self-test \
     && mkdir -p /etc/claude-code/.claude/rules

--- a/claude-config/claude-proxy.sh
+++ b/claude-config/claude-proxy.sh
@@ -14,7 +14,8 @@
 # The function is idempotent — safe to call from multiple places.
 # It checks whether proxy mode is requested (OPENAI_API_KEY set),
 # whether the proxy is already running, starts it if needed, and
-# exports ANTHROPIC_BASE_URL so Claude Code routes through it.
+# exports ANTHROPIC_BASE_URL and OPENAI_BASE_URL so Claude Code,
+# Codex, and OpenCode all route through it.
 # ============================================================
 
 start_claude_proxy() {
@@ -24,12 +25,20 @@ start_claude_proxy() {
   fi
 
   local proxy_port="${PROXY_PORT:-8082}"
+  local proxy_url="http://localhost:${proxy_port}"
+
+  # Save the original (upstream) OPENAI_BASE_URL before we overwrite it.
+  # Guard against re-source: only save if not already redirected to the proxy.
+  if [ -z "$_UPSTREAM_OPENAI_BASE_URL" ] && [ "${OPENAI_BASE_URL:-}" != "$proxy_url" ]; then
+    export _UPSTREAM_OPENAI_BASE_URL="${OPENAI_BASE_URL:-}"
+  fi
 
   # Always point Claude Code at the local proxy
-  export ANTHROPIC_BASE_URL="http://localhost:${proxy_port}"
+  export ANTHROPIC_BASE_URL="$proxy_url"
 
-  # If the proxy is already reachable, nothing more to do
-  if curl -sf --connect-timeout 1 "http://localhost:${proxy_port}/" >/dev/null 2>&1; then
+  # If the proxy is already reachable, redirect OPENAI_BASE_URL and return
+  if curl -sf --connect-timeout 1 "${proxy_url}/" >/dev/null 2>&1; then
+    export OPENAI_BASE_URL="$proxy_url"
     return 0
   fi
 
@@ -45,7 +54,7 @@ start_claude_proxy() {
     cd /opt/claude-code-proxy || exit 1
     HOST=0.0.0.0 PORT="$proxy_port" \
       OPENAI_API_KEY="$OPENAI_API_KEY" \
-      OPENAI_BASE_URL="${OPENAI_BASE_URL:-}" \
+      OPENAI_BASE_URL="${_UPSTREAM_OPENAI_BASE_URL:-}" \
       ANTHROPIC_API_KEY="${ANTHROPIC_API_KEY:-}" \
       BIG_MODEL="${BIG_MODEL:-}" \
       MIDDLE_MODEL="${MIDDLE_MODEL:-}" \
@@ -59,8 +68,9 @@ start_claude_proxy() {
   # Wait for the proxy to become ready (up to 30 s)
   local retries=0
   while [ "$retries" -lt 30 ]; do
-    if curl -sf --connect-timeout 1 "http://localhost:${proxy_port}/" >/dev/null 2>&1; then
+    if curl -sf --connect-timeout 1 "${proxy_url}/" >/dev/null 2>&1; then
       $quiet || echo "Claude Code proxy ready on port ${proxy_port}"
+      export OPENAI_BASE_URL="$proxy_url"
       return 0
     fi
     sleep 1

--- a/codex-config/config.toml
+++ b/codex-config/config.toml
@@ -1,0 +1,1 @@
+model = "gpt-5.2-codex"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -55,6 +55,15 @@ if [ ! -f "$OPENCODE_CONFIG_DIR/opencode.json" ] || [ ! -s "$OPENCODE_CONFIG_DIR
   fi
 fi
 
+# Seed codex config if missing
+CODEX_CONFIG_DIR="$HOME/.codex"
+if [ ! -f "$CODEX_CONFIG_DIR/config.toml" ] || [ ! -s "$CODEX_CONFIG_DIR/config.toml" ]; then
+  if [ -n "$OPENAI_API_KEY" ] && [ -f /opt/codex-config/config.toml ]; then
+    mkdir -p "$CODEX_CONFIG_DIR"
+    cp /opt/codex-config/config.toml "$CODEX_CONFIG_DIR/config.toml"
+  fi
+fi
+
 # ============================================================
 # Claude Code Proxy (Anthropic Messages API -> OpenAI)
 # ============================================================


### PR DESCRIPTION
## Summary

Adds devcontainer support for Codex CLI (OpenAI's code agent) by wiring it through the existing proxy infrastructure.

## Changes

### New files
- `codex-config/config.toml` — default Codex model configuration (`gpt-5.2-codex`)

### Modified files
- `.dockerignore` — allow `codex-config/` directory
- `Dockerfile` — add `netcat-openbsd` to network tools; COPY codex config into image
- `entrypoint.sh` — seed `~/.codex/config.toml` on first start
- `claude-config/claude-proxy.sh` — save upstream `OPENAI_BASE_URL` to `_UPSTREAM_OPENAI_BASE_URL` before redirecting through proxy; pass upstream URL to proxy subprocess; redirect `OPENAI_BASE_URL` after proxy is ready so Codex and OpenCode route through it
- `.devcontainer/scripts/post-start.sh` — add Responses API health check; use `_UPSTREAM_OPENAI_BASE_URL` for upstream connectivity check

## Context

Codex CLI v0.104.0 was already installed via npm. The proxy now supports Responses API endpoints (f5xc-salesdemos/claude-code-proxy#2). This PR wires them together so Codex works out of the box.

## Testing

Verified locally:
- `codex exec --model gpt-5.2-codex "say hello"` works through proxy
- Unauthenticated `/responses` endpoint works (Codex sends no auth header)
- `claude` still works via `ANTHROPIC_BASE_URL`

Closes #113