### PR TITLE
feat: add WebSearch SearXNG interception support

### DIFF
--- a/.devcontainer/scripts/post-start.sh
+++ b/.devcontainer/scripts/post-start.sh
@@ -28,6 +28,13 @@ if [ -n "$OPENAI_API_KEY" ]; then
   else
     echo "not reachable (check VPN / network connectivity)"
   fi
+  SEARXNG_URL="${SEARXNG_URL:-http://searxng:8080}"
+  echo -n "  Checking SearXNG ($SEARXNG_URL)... "
+  if curl -sf --connect-timeout 3 "${SEARXNG_URL}/" >/dev/null 2>&1; then
+    echo "reachable (WebSearch enabled)"
+  else
+    echo "not reachable (WebSearch unavailable — enable with COMPOSE_PROFILES=search)"
+  fi
 else
   echo "  Mode: direct API (no proxy)"
   if [ -z "$ANTHROPIC_API_KEY" ]; then

--- a/claude-config/CLAUDE.md
+++ b/claude-config/CLAUDE.md
@@ -21,28 +21,24 @@ All Claude Code tools use PascalCase. NEVER use snake_case.
 | `WebFetch` | `web_fetch`, `fetch`, `curl` | Fetch a URL and return its contents |
 | `WebSearch` | `web_search`, `search_web` | Search the web and return results |
 
-**Note:** `WebSearch` requires a direct Anthropic API connection — it is
-a server-side tool executed by the Anthropic backend. Through a proxy, the
-tool is silently dropped and returns 0 results. Use the SearXNG fallback
-below or `WebFetch` for direct URL retrieval.
-`MultiEdit` is not available through all proxy configurations — use
-sequential `Edit` calls instead.
+**Note:** `MultiEdit` is not available through all proxy configurations —
+use sequential `Edit` calls instead.
 
 ## Web Search
 
-The built-in `WebSearch` tool only works with a direct Anthropic API
-connection. When running through a proxy, use these alternatives:
+When SearXNG is running (`COMPOSE_PROFILES=search`), the built-in
+`WebSearch` tool works transparently through the proxy. The proxy
+intercepts WebSearch calls and fulfills them via SearXNG — no special
+configuration needed.
 
-### SearXNG (self-hosted, no API key needed)
+If SearXNG is not running, WebSearch is silently unavailable. The model
+will proceed without search results.
 
-If the search profile is enabled (`COMPOSE_PROFILES=search`),
-a SearXNG metasearch engine is available inside the Docker network:
+### Manual SearXNG queries (fallback)
 
 ```bash
 curl -s "http://searxng:8080/search?q=your+query&format=json" | jq '.results[:5]'
 ```
-
-Use `Bash` with `curl` to query SearXNG and parse the JSON results.
 
 ### WebFetch (built-in, works through proxy)
 

--- a/claude-config/claude-proxy.sh
+++ b/claude-config/claude-proxy.sh
@@ -56,6 +56,7 @@ start_claude_proxy() {
       OPENAI_API_KEY="$OPENAI_API_KEY" \
       OPENAI_BASE_URL="${_UPSTREAM_OPENAI_BASE_URL:-}" \
       ANTHROPIC_API_KEY="${ANTHROPIC_API_KEY:-}" \
+      SEARXNG_URL="${SEARXNG_URL:-http://searxng:8080}" \
       BIG_MODEL="${BIG_MODEL:-}" \
       MIDDLE_MODEL="${MIDDLE_MODEL:-}" \
       SMALL_MODEL="${SMALL_MODEL:-}" \

--- a/claude-config/self-test.sh
+++ b/claude-config/self-test.sh
@@ -49,6 +49,21 @@ check "home directory writable" test -w "$HOME"
 check "TERM is set" test -n "${TERM:-}"
 
 echo ""
+echo "5. Web Search (SearXNG)"
+SEARXNG_URL="${SEARXNG_URL:-http://searxng:8080}"
+if curl -sf --connect-timeout 3 "${SEARXNG_URL}/" >/dev/null 2>&1; then
+  check "SearXNG reachable" true
+  if curl -sf --connect-timeout 5 "${SEARXNG_URL}/search?q=test&format=json" | python3 -c "import sys,json; json.load(sys.stdin)" >/dev/null 2>&1; then
+    check "SearXNG JSON API working" true
+  else
+    echo "  WARN: SearXNG reachable but JSON API failed"
+    ((WARN++))
+  fi
+else
+  echo "  SKIP: SearXNG not reachable (optional — enable with COMPOSE_PROFILES=search)"
+fi
+
+echo ""
 echo "=== Results: $PASS passed, $FAIL failed, $WARN warnings ==="
 
 if [ "$FAIL" -gt 0 ]; then


### PR DESCRIPTION
## Summary

Enable the built-in WebSearch tool to work transparently through the proxy by intercepting web_search calls and fulfilling them via SearXNG.

## Related Issue

Closes #115

## Changes

- **claude-config/claude-proxy.sh**: Pass `SEARXNG_URL` env var to proxy process
- **claude-config/CLAUDE.md**: Update Web Search section — WebSearch now works transparently through proxy when SearXNG is running; remove old "silently dropped" warning
- **claude-config/self-test.sh**: Add section 5 (Web Search) — checks SearXNG reachability and JSON API; SKIP when not available (opt-in)
- **.devcontainer/scripts/post-start.sh**: Add SearXNG reachability check in proxy mode section

## Checklist

- [x] Linked to a GitHub issue (required — CI will block merge without it)
- [x] Tested locally
- [x] Follows project conventions