### PR TITLE
docs: remove Web Search section from CLAUDE.md

### DIFF
--- a/claude-config/CLAUDE.md
+++ b/claude-config/CLAUDE.md
@@ -24,27 +24,6 @@ All Claude Code tools use PascalCase. NEVER use snake_case.
 **Note:** `MultiEdit` is not available through all proxy configurations —
 use sequential `Edit` calls instead.
 
-## Web Search
-
-When SearXNG is running (`COMPOSE_PROFILES=search`), the built-in
-`WebSearch` tool works transparently through the proxy. The proxy
-intercepts WebSearch calls and fulfills them via SearXNG — no special
-configuration needed.
-
-If SearXNG is not running, WebSearch is silently unavailable. The model
-will proceed without search results.
-
-### Manual SearXNG queries (fallback)
-
-```bash
-curl -s "http://searxng:8080/search?q=your+query&format=json" | jq '.results[:5]'
-```
-
-### WebFetch (built-in, works through proxy)
-
-Use `WebFetch` to retrieve content from a specific URL when you already
-know where to look.
-
 ## Task Tool Requirements
 
 - Always include `description` (string) — it is REQUIRED


### PR DESCRIPTION
## Summary

Removes the "Web Search" section from `claude-config/CLAUDE.md`, which is installed into the container at `/etc/claude-code/CLAUDE.md`.

## Why

WebSearch now works transparently through the proxy via SearXNG interception (PR #116, proxy PR #4). The proxy intercepts native `WebSearch` tool calls and fulfills them via SearXNG — no special configuration or instructions needed.

Since WebSearch simulates native functionality, the CLAUDE.md should **not** contain any special instructions about web search. The model should treat `WebSearch` like any other built-in tool.

## Changes

- Removed the entire "Web Search" section (previously lines 27-46) from `claude-config/CLAUDE.md`
- The `WebSearch` row in the tool table is preserved — it still needs the PascalCase reminder
- The `MultiEdit` note is preserved — it's unrelated
- "Task Tool Requirements" now immediately follows the MultiEdit note

## Testing

- [x] `claude-self-test` passes
- [x] `WebSearch` row still present in tool table
- [x] No orphaned references to SearXNG or web search fallbacks

Closes #117