### PR TITLE
feat: add COLORTERM=truecolor and change proxy placeholder to openai-proxy

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -36,6 +36,7 @@
   "containerEnv": {
     "EDITOR": "vim",
     "TERM": "xterm-256color",
+    "COLORTERM": "truecolor",
     "LANG": "en_US.UTF-8",
     "LC_ALL": "en_US.UTF-8",
     "DISPLAY": ":99",

--- a/Dockerfile
+++ b/Dockerfile
@@ -125,6 +125,7 @@ RUN ln -sf /usr/bin/fdfind /usr/local/bin/fd \
 ENV LANG=en_US.UTF-8
 ENV LC_ALL=en_US.UTF-8
 ENV TERM=xterm-256color
+ENV COLORTERM=truecolor
 
 # PowerShell — Microsoft only publishes amd64 .deb packages;
 # arm64 uses the official tar.gz from GitHub releases.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
       - GIT_COMMITTER_EMAIL=${GIT_AUTHOR_EMAIL:-}
       - NODE_TLS_REJECT_UNAUTHORIZED=0
       - TERM=xterm-256color
+      - COLORTERM=truecolor
       - LANG=en_US.UTF-8
       - LC_ALL=en_US.UTF-8
     ports:

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -83,7 +83,7 @@ That's it — Claude Code will connect directly to the Anthropic API.
 If you need to route Claude Code traffic through an OpenAI-compatible endpoint (for example, Open WebUI, Ollama, or any provider that speaks the OpenAI Chat Completions API), set the proxy variables in `.env`:
 
 ```ini
-ANTHROPIC_API_KEY=placeholder
+ANTHROPIC_API_KEY=openai-proxy
 OPENAI_API_KEY=sk-your-api-key-here
 OPENAI_BASE_URL=https://your-api-endpoint.example.com/v1
 ```

--- a/docs/troubleshooting.mdx
+++ b/docs/troubleshooting.mdx
@@ -46,7 +46,7 @@ Common causes:
 - **Using an OpenAI-compatible provider without proxy vars** — If your key is not an Anthropic key, you need to set `OPENAI_API_KEY` and `OPENAI_BASE_URL` in `.env` so the built-in proxy activates. Set `ANTHROPIC_API_KEY` to any non-empty value.
 
   ```text
-  ANTHROPIC_API_KEY=placeholder
+  ANTHROPIC_API_KEY=openai-proxy
   OPENAI_API_KEY=<your-provider-key>
   OPENAI_BASE_URL=<your-provider-url>
   ```


### PR DESCRIPTION
## Summary

Two quality-of-life improvements: add `COLORTERM=truecolor` to all container config files and change the proxy-mode placeholder value from `placeholder` to `openai-proxy` in documentation.

## Related Issue

Closes #119

## Changes

- Add `ENV COLORTERM=truecolor` to `Dockerfile` (after `ENV TERM=xterm-256color`)
- Add `COLORTERM=truecolor` to `docker-compose.yml` environment section
- Add `"COLORTERM": "truecolor"` to `.devcontainer/devcontainer.json` containerEnv
- Change `ANTHROPIC_API_KEY=placeholder` → `ANTHROPIC_API_KEY=openai-proxy` in `docs/getting-started.mdx`
- Change `ANTHROPIC_API_KEY=placeholder` → `ANTHROPIC_API_KEY=openai-proxy` in `docs/troubleshooting.mdx`

No changes needed to `post-start.sh` — `openai-proxy` correctly passes through to the proxy-mode warning path.

## Checklist

- [x] Linked to a GitHub issue (required — CI will block merge without it)
- [x] Tested locally
- [x] Follows project conventions