### PR TITLE
feat: optimize proxy startup priority in entrypoint

### DIFF
--- a/claude-config/claude-proxy.sh
+++ b/claude-config/claude-proxy.sh
@@ -65,7 +65,9 @@ start_claude_proxy() {
       uv run python start_proxy.py >>/tmp/claude-proxy.log 2>&1
   ) &
 
-  # Wait for the proxy to become ready (up to 30 s)
+  # Wait for the proxy to become ready (up to ~30 s)
+  # Poll every 0.2s for the first 5 attempts (proxy typically starts in ~300ms),
+  # then fall back to 1s intervals for the remaining attempts.
   local retries=0
   while [ "$retries" -lt 30 ]; do
     if curl -sf --connect-timeout 1 "${proxy_url}/" >/dev/null 2>&1; then
@@ -73,7 +75,11 @@ start_claude_proxy() {
       export OPENAI_BASE_URL="$proxy_url"
       return 0
     fi
-    sleep 1
+    if [ "$retries" -lt 5 ]; then
+      sleep 0.2
+    else
+      sleep 1
+    fi
     retries=$((retries + 1))
   done
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -108,18 +108,20 @@ if [ "${ENABLE_DOCKER:-true}" = "true" ] && command -v dockerd >/dev/null 2>&1; 
   # Only start if we're in a privileged container (cgroup access required)
   if [ -d /sys/fs/cgroup ]; then
     sudo sh -c "dockerd --host=unix:///var/run/docker.sock --host=tcp://0.0.0.0:2375 >/var/log/dockerd.log 2>&1" &
-    # Wait for Docker daemon to be ready
-    retries=0
-    while [ $retries -lt 30 ]; do
-      docker info >/dev/null 2>&1 && break
-      sleep 1
-      retries=$((retries + 1))
-    done
-    if docker info >/dev/null 2>&1; then
-      echo "Docker daemon started successfully"
-    else
-      echo "Warning: Docker daemon failed to start (not running in privileged mode?)" >&2
-    fi
+    # Background readiness check — does NOT block entrypoint
+    (
+      retries=0
+      while [ $retries -lt 30 ]; do
+        docker info >/dev/null 2>&1 && break
+        sleep 1
+        retries=$((retries + 1))
+      done
+      if docker info >/dev/null 2>&1; then
+        echo "Docker daemon started successfully"
+      else
+        echo "Warning: Docker daemon failed to start (not running in privileged mode?)" >&2
+      fi
+    ) &
   fi
 fi
 
@@ -134,35 +136,38 @@ if [ "${ENABLE_VNC:-true}" = "true" ]; then
 
   Xvfb "${DISPLAY}" -screen 0 "${VNC_RESOLUTION}" -ac +extension GLX +render -noreset &
 
-  retries=0
-  while [ $retries -lt 50 ]; do
-    xdpyinfo -display "${DISPLAY}" >/dev/null 2>&1 && break
-    sleep 0.1
-    retries=$((retries + 1))
-  done
+  # Background readiness check + dependent daemons — does NOT block entrypoint
+  (
+    retries=0
+    while [ $retries -lt 50 ]; do
+      xdpyinfo -display "${DISPLAY}" >/dev/null 2>&1 && break
+      sleep 0.1
+      retries=$((retries + 1))
+    done
 
-  fluxbox &
-  x11vnc -display "${DISPLAY}" -forever -shared -rfbport "${VNC_PORT}" \
-    -nopw -xkb -noxrecord -noxfixes -noxdamage &
+    fluxbox &
+    x11vnc -display "${DISPLAY}" -forever -shared -rfbport "${VNC_PORT}" \
+      -nopw -xkb -noxrecord -noxfixes -noxdamage &
 
-  NOVNC_LAUNCHER=""
-  for candidate in \
-    /usr/share/novnc/utils/novnc_proxy \
-    /usr/share/novnc/utils/launch.sh \
-    /usr/share/novnc/utils/websockify/run; do
-    if [ -x "$candidate" ]; then
-      NOVNC_LAUNCHER="$candidate"
-      break
+    NOVNC_LAUNCHER=""
+    for candidate in \
+      /usr/share/novnc/utils/novnc_proxy \
+      /usr/share/novnc/utils/launch.sh \
+      /usr/share/novnc/utils/websockify/run; do
+      if [ -x "$candidate" ]; then
+        NOVNC_LAUNCHER="$candidate"
+        break
+      fi
+    done
+
+    if [ -n "$NOVNC_LAUNCHER" ]; then
+      "$NOVNC_LAUNCHER" --vnc localhost:"${VNC_PORT}" --listen "${NOVNC_PORT}" &
+    else
+      websockify --web /usr/share/novnc "${NOVNC_PORT}" localhost:"${VNC_PORT}" &
     fi
-  done
 
-  if [ -n "$NOVNC_LAUNCHER" ]; then
-    "$NOVNC_LAUNCHER" --vnc localhost:"${VNC_PORT}" --listen "${NOVNC_PORT}" &
-  else
-    websockify --web /usr/share/novnc "${NOVNC_PORT}" localhost:"${VNC_PORT}" &
-  fi
-
-  echo "noVNC: http://localhost:${NOVNC_PORT}/vnc.html"
+    echo "noVNC: http://localhost:${NOVNC_PORT}/vnc.html"
+  ) &
 fi
 
 exec "$@"


### PR DESCRIPTION
## Summary

Optimizes container startup so `exec "$@"` runs as soon as the proxy is ready, without waiting for Docker-in-Docker (~30s) or VNC/Xvfb (~5s) to finish initializing.

## Changes

### `entrypoint.sh`
- **Docker-in-Docker wait loop** → moved into a background subshell. The `dockerd` process still starts, and readiness is still checked/logged, but the entrypoint no longer blocks on it.
- **VNC stack (Xvfb wait + fluxbox + x11vnc + noVNC)** → moved into a background subshell. Xvfb is started in the foreground (needs to be running for the subshell to connect), but all dependent daemons and the readiness poll run asynchronously.

### `claude-config/claude-proxy.sh`
- **Faster initial poll**: check every 0.2s for the first 5 attempts (proxy typically starts in ~300ms), then fall back to 1s for the remaining 25 attempts. This catches the proxy at ~400ms instead of always waiting a full second.

## Impact

| Before | After |
|--------|-------|
| Proxy ready → wait up to 35s for Docker+VNC → `exec "$@"` | Proxy ready → `exec "$@"` immediately |
| First proxy check at 1s | First proxy check at 0.2s |

Docker and VNC still work — they just report readiness in the background.

Closes #123