### PR TITLE
docs: remove --build instructions from getting-started guide

### DIFF
--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -100,12 +100,6 @@ docker compose up -d
 
 The first run pulls the pre-built image from ghcr.io (~1 min depending on your connection). Subsequent starts use the cached image and take seconds.
 
-To force a local build instead (e.g., if you've customized the Dockerfile):
-
-```bash
-docker compose up -d --build
-```
-
 ## 5. Connect
 
 ### Option A: Terminal
@@ -196,12 +190,9 @@ docker compose down
 # Start again
 docker compose up -d
 
-# Rebuild after config changes
-docker compose up -d --build
-
 # Destroy everything and start fresh
 docker compose down -v
-docker compose up -d --build
+docker compose up -d
 ```
 
 Your code in `/workspace` and home directory persist across restarts. See [Configuration — Data Persistence](./configuration#data-persistence) for details.


### PR DESCRIPTION
## Summary

Remove local build commands (`--build`) from the getting-started guide so users follow the simple pull-and-run happy path instead of encountering potential build failures from transient infrastructure issues.

## Changes

### Step 4 — Start the Container
- Removed the "force a local build" paragraph and `docker compose up -d --build` code block
- Kept the existing `docker compose up -d` command and note about pulling the pre-built image

### Stopping and Restarting
- Removed the "Rebuild after config changes" entry (`docker compose up -d --build`)
- Changed "Destroy everything and start fresh" to use `docker compose up -d` instead of `docker compose up -d --build`

## What's NOT changed

`docs/troubleshooting.mdx` — retains its `--build` references where they're appropriate (e.g., "claude: command not found" → rebuild image, "Reset Everything").

## Rationale

- The `docker-compose.yml` uses `pull_policy: missing`, so `docker compose up -d` automatically pulls the pre-built image from ghcr.io
- `.env` config changes take effect on restart without rebuilding
- Local builds can fail due to transient APT/network issues unrelated to the user's setup

Closes #125