### PR TITLE
docs: move Remote Display (noVNC) section into its own page

### DIFF
--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -95,14 +95,7 @@ To customize SearXNG further, edit the `configs.searxng-settings.content` block 
 
 ### Remote Display (noVNC)
 
-The container runs a virtual display stack so you can watch and interact with headed browsers (e.g., Chromium controlled by `@playwright/mcp`).
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `ENABLE_VNC` | `true` | Set to `false` to disable the VNC stack |
-| `VNC_RESOLUTION` | `1280x1024x24` | Virtual display resolution (WxHxDepth) |
-| `DISPLAY` | `:99` | X11 display number |
-| `NOVNC_HOST_PORT` | `6080` | Host-side port for noVNC (override to avoid conflicts with other containers) |
+The container runs a virtual display stack for watching and interacting with headed browsers. See [Remote Display (noVNC)](./vnc) for connection instructions and environment variables (`ENABLE_VNC`, `VNC_RESOLUTION`, `DISPLAY`, `NOVNC_HOST_PORT`).
 
 ### Docker-in-Docker
 

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -103,12 +103,7 @@ claude
 
 ## 7. Remote Display (noVNC)
 
-The container runs a virtual display so you can watch AI agents control a browser and intervene when needed (e.g., for login or MFA prompts).
-
-1. Open `http://localhost:6080/vnc.html` in your browser and click **Connect**
-2. You'll see a lightweight fluxbox desktop — this is the container's virtual display
-
-AI agents using `@playwright/mcp` in headed mode render Chromium into this display. You can click and type directly in the noVNC window to intervene at any time.
+The container includes a virtual display for watching AI agents control a browser. Open `http://localhost:6080/vnc.html` to connect. See [Remote Display (noVNC)](./vnc) for details.
 
 ## 8. Stopping and Restarting
 
@@ -128,4 +123,4 @@ Your code in `/workspace` and home directory persist across restarts. See [Confi
 
 ---
 
-For local builds and Dockerfile customization, see [Local Development](./local-development). For VS Code integration, see [VS Code](./vscode).
+For local builds and Dockerfile customization, see [Local Development](./local-development). For VS Code integration, see [VS Code](./vscode). For remote display options, see [Remote Display (noVNC)](./vnc).

--- a/docs/vnc.mdx
+++ b/docs/vnc.mdx
@@ -1,0 +1,53 @@
+---
+title: Remote Display (noVNC)
+description: Watch and interact with headed browsers through a virtual display in your browser.
+sidebar:
+  order: 3
+---
+
+The container runs a virtual display stack (Xvfb + x11vnc + noVNC + fluxbox) so you can watch AI agents control a browser and intervene when needed — for example, to handle login or MFA prompts.
+
+## Connecting
+
+1. Open `http://localhost:6080/vnc.html` in your browser and click **Connect**
+2. You'll see a lightweight fluxbox desktop — this is the container's virtual display
+
+AI agents using `@playwright/mcp` in headed mode render Chromium into this display. You can click and type directly in the noVNC window to intervene at any time — no pause/resume needed.
+
+## Manual Browser Launch
+
+To open a browser manually inside the container:
+
+```bash
+chromium --no-sandbox &
+```
+
+To run Playwright tests in headed mode:
+
+```bash
+npx playwright test --headed
+```
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `ENABLE_VNC` | `true` | Set to `false` to disable the VNC stack |
+| `VNC_RESOLUTION` | `1280x1024x24` | Virtual display resolution (WxHxDepth) |
+| `DISPLAY` | `:99` | X11 display number |
+| `NOVNC_HOST_PORT` | `6080` | Host-side port for noVNC (override to avoid conflicts with other containers) |
+
+Set these in your `.env` file or in `.devcontainer/devcontainer.json` under `containerEnv`.
+
+## Disabling the VNC Stack
+
+For headless-only operation, set `ENABLE_VNC=false` in `.env` and restart the container:
+
+```bash
+docker compose down
+docker compose up -d
+```
+
+## Troubleshooting
+
+See [Troubleshooting — Remote Display](./troubleshooting#remote-display-novnc) for solutions to black screens, connection refused errors, and port conflicts.


### PR DESCRIPTION
## Summary of Changes

Consolidate the Remote Display (noVNC) content — currently split across `getting-started.mdx` (brief usage) and `configuration.mdx` (env var table) — into a dedicated `docs/vnc.mdx` page. The original sections are replaced with brief summaries linking to the new page.

## Changes

- **`docs/vnc.mdx`** (new) — Consolidated page covering connection instructions, manual browser launch, Playwright headed mode, environment variables (`ENABLE_VNC`, `VNC_RESOLUTION`, `DISPLAY`, `NOVNC_HOST_PORT`), disabling the VNC stack, and a troubleshooting link
- **`docs/getting-started.mdx`** — Step 7 replaced with one-line summary + link to vnc page; footer updated to include vnc link
- **`docs/configuration.mdx`** — `### Remote Display (noVNC)` env var table replaced with summary + link listing the variable names

## Issues

Closes #129

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] My changes follow the project coding standards
- [x] I have tested my changes locally
- [x] I have updated documentation as needed
- [x] My commit messages follow conventional commit format
- [x] I have linked this PR to an issue using `Closes #N`