### PR TITLE
feat: add Podman tab alternative across all docs

### DIFF
--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -5,6 +5,8 @@ sidebar:
   order: 2
 ---
 
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+
 All configuration lives in the `.env` file at the project root. This file is gitignored — it never gets committed.
 
 ## Environment Variables
@@ -108,7 +110,7 @@ The container includes the full Docker engine (`docker-ce`, `containerd.io`) and
 The `vscode` user is a member of the `docker` group, so `docker` commands work without `sudo`.
 
 :::note
-Docker-in-Docker requires the container to run in **privileged mode** (`privileged: true` in `docker-compose.yml`). This is set by default. If you see "Docker daemon failed to start", check that your container runtime allows privileged containers.
+Docker-in-Docker requires the container to run in **privileged mode** (`privileged: true` in `docker-compose.yml`). This is set by default. If you see "Docker daemon failed to start", check that your container runtime allows privileged containers. This applies regardless of whether you use Docker or Podman on the host.
 :::
 
 ### Git
@@ -128,7 +130,18 @@ Docker-in-Docker requires the container to run in **privileged mode** (`privileg
 
 Every language runtime, CLI, and tool is installed directly in the `Dockerfile` at image build time. The pre-built image is published to `ghcr.io/f5xc-salesdemos/devcontainer:latest` on every push to `main`, so most users never need to build locally.
 
+<Tabs syncKey="runtime">
+<TabItem label="Docker">
+
 Running `docker compose up -d` pulls the pre-built image automatically. If you've cloned the repository, the `docker-compose.override.yml` file adds local build support — use `docker compose up -d --build` to force a local build after customizing the Dockerfile. See [Local Development](./local-development) for details.
+
+</TabItem>
+<TabItem label="Podman">
+
+Running `podman compose up -d` pulls the pre-built image automatically. If you've cloned the repository, the `docker-compose.override.yml` file adds local build support — use `podman compose up -d --build` to force a local build after customizing the Dockerfile. See [Local Development](./local-development) for details.
+
+</TabItem>
+</Tabs>
 
 The Dockerfile uses a two-stage build optimized for Docker layer caching. See [Local Development — Two-Stage Build Architecture](./local-development#two-stage-build-architecture) for the full layer breakdown and build cache details.
 
@@ -170,12 +183,15 @@ Extensions are configured in `.devcontainer/devcontainer.json` under `customizat
 
 ## Data Persistence
 
-All data lives in Docker named volumes — no host directories are mounted:
+All data lives in named volumes — no host directories are mounted:
 
 | Volume | Mount Point | Contents |
 |--------|-------------|----------|
 | `workspace` | `/workspace` | Your cloned repositories and project files |
 | `home` | `/home/vscode` | Shell history, tool configs, caches, SSH keys |
+
+<Tabs syncKey="runtime">
+<TabItem label="Docker">
 
 Both persist across container restarts and rebuilds. Run `docker compose pull` to fetch the latest pre-built image before restarting.
 
@@ -183,6 +199,19 @@ Both persist across container restarts and rebuilds. Run `docker compose pull` t
 |--------|------|
 | `docker compose down` | Preserved |
 | `docker compose down -v` | **Deleted** |
+
+</TabItem>
+<TabItem label="Podman">
+
+Both persist across container restarts and rebuilds. Run `podman compose pull` to fetch the latest pre-built image before restarting.
+
+| Action | Data |
+|--------|------|
+| `podman compose down` | Preserved |
+| `podman compose down -v` | **Deleted** |
+
+</TabItem>
+</Tabs>
 
 ## Port Mapping
 

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -5,11 +5,16 @@ sidebar:
   order: 1
 ---
 
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+
 ## Prerequisites
 
-### Docker
+### Container Runtime
 
-You need Docker running on your machine. Any recent version will work.
+You need a container runtime on your machine. Either Docker or Podman will work.
+
+<Tabs syncKey="runtime">
+<TabItem label="Docker">
 
 | Platform | Install |
 |----------|---------|
@@ -24,15 +29,59 @@ docker --version
 docker compose version
 ```
 
+</TabItem>
+<TabItem label="Podman">
+
+| Platform | Install |
+|----------|---------|
+| macOS | [Podman Desktop for Mac](https://podman-desktop.io/docs/installation/macos-install) |
+| Windows | [Podman Desktop for Windows](https://podman-desktop.io/docs/installation/windows-install) |
+| Linux | [Podman](https://podman.io/docs/installation#installing-on-linux) + [Podman Compose](https://github.com/containers/podman-compose#installation) |
+
+Verify it's working:
+
+```bash
+podman --version
+podman compose version
+```
+
+:::note
+The container runs in **privileged mode** (`privileged: true` in `docker-compose.yml`). If you're using rootless Podman, you may need to enable rootful mode:
+
+```bash
+podman machine set --rootful
+podman machine stop && podman machine start
+```
+:::
+
+</TabItem>
+</Tabs>
+
 ### System Resources
 
 | Resource | Minimum | Recommended |
 |----------|---------|-------------|
 | Disk | 5 GB | 10 GB+ |
-| RAM | 4 GB allocated to Docker | 8 GB+ |
+| RAM | 4 GB allocated to container runtime | 8 GB+ |
 | CPU | 2 cores | 4+ cores |
 
-Adjust Docker resource limits in Docker Desktop &rarr; Settings &rarr; Resources.
+<Tabs syncKey="runtime">
+<TabItem label="Docker">
+
+Adjust resource limits in Docker Desktop &rarr; Settings &rarr; Resources.
+
+</TabItem>
+<TabItem label="Podman">
+
+Adjust resource limits in Podman Desktop &rarr; Settings &rarr; Resources, or via the CLI:
+
+```bash
+podman machine set --cpus 4 --memory 8192
+podman machine stop && podman machine start
+```
+
+</TabItem>
+</Tabs>
 
 ## 1. Set Up
 
@@ -55,17 +104,43 @@ If you use an OpenAI-compatible provider instead, see [Configuration](./configur
 
 ## 3. Start
 
+<Tabs syncKey="runtime">
+<TabItem label="Docker">
+
 ```bash
 docker compose up -d
 ```
+
+</TabItem>
+<TabItem label="Podman">
+
+```bash
+podman compose up -d
+```
+
+</TabItem>
+</Tabs>
 
 The first run pulls the pre-built image from ghcr.io (~1 min depending on your connection). Subsequent starts use the cached image and take seconds.
 
 ## 4. Connect
 
+<Tabs syncKey="runtime">
+<TabItem label="Docker">
+
 ```bash
 docker compose exec dev zsh
 ```
+
+</TabItem>
+<TabItem label="Podman">
+
+```bash
+podman compose exec dev zsh
+```
+
+</TabItem>
+</Tabs>
 
 ## 5. Verify
 
@@ -107,6 +182,9 @@ The container includes a virtual display for watching AI agents control a browse
 
 ## 8. Stopping and Restarting
 
+<Tabs syncKey="runtime">
+<TabItem label="Docker">
+
 ```bash
 # Stop (preserves data)
 docker compose down
@@ -118,6 +196,24 @@ docker compose up -d
 docker compose down -v
 docker compose up -d
 ```
+
+</TabItem>
+<TabItem label="Podman">
+
+```bash
+# Stop (preserves data)
+podman compose down
+
+# Start again
+podman compose up -d
+
+# Destroy everything and start fresh
+podman compose down -v
+podman compose up -d
+```
+
+</TabItem>
+</Tabs>
 
 Your code in `/workspace` and home directory persist across restarts. See [Configuration — Data Persistence](./configuration#data-persistence) for details.
 

--- a/docs/local-development.mdx
+++ b/docs/local-development.mdx
@@ -5,6 +5,8 @@ sidebar:
   order: 5
 ---
 
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+
 This page is for developers who want to clone the repository, build the image locally, or customize the Dockerfile. If you just want to use the pre-built container, see [Getting Started](./getting-started).
 
 ## Clone the Repository
@@ -33,6 +35,9 @@ cd devcontainer
 
 Docker Compose automatically merges `docker-compose.override.yml` when it exists in the same directory as `docker-compose.yml`. This means:
 
+<Tabs syncKey="runtime">
+<TabItem label="Docker">
+
 - **Clone users** (have both files): `docker compose up -d` uses the local `Dockerfile` with `pull_policy: missing` — it builds locally if no image is cached, otherwise uses the cache.
 - **Standalone users** (only `docker-compose.yml`): `docker compose up -d` pulls the pre-built image from ghcr.io.
 
@@ -42,11 +47,39 @@ You can verify the merged configuration:
 docker compose config
 ```
 
+</TabItem>
+<TabItem label="Podman">
+
+- **Clone users** (have both files): `podman compose up -d` uses the local `Dockerfile` with `pull_policy: missing` — it builds locally if no image is cached, otherwise uses the cache.
+- **Standalone users** (only `docker-compose.yml`): `podman compose up -d` pulls the pre-built image from ghcr.io.
+
+You can verify the merged configuration:
+
+```bash
+podman compose config
+```
+
+</TabItem>
+</Tabs>
+
 ## Building Locally
+
+<Tabs syncKey="runtime">
+<TabItem label="Docker">
 
 ```bash
 docker compose up -d --build
 ```
+
+</TabItem>
+<TabItem label="Podman">
+
+```bash
+podman compose up -d --build
+```
+
+</TabItem>
+</Tabs>
 
 This builds the image from the local `Dockerfile` and starts the container. The `--build` flag forces a rebuild even if a cached image exists.
 
@@ -93,9 +126,22 @@ These layers change more frequently (npm/pip updates, config changes) but rebuil
 
 Edit the `Dockerfile` and add your tool to the appropriate section. Rebuild after adding:
 
+<Tabs syncKey="runtime">
+<TabItem label="Docker">
+
 ```bash
 docker compose up -d --build
 ```
+
+</TabItem>
+<TabItem label="Podman">
+
+```bash
+podman compose up -d --build
+```
+
+</TabItem>
+</Tabs>
 
 Or in VS Code: **Dev Containers &rarr; Rebuild Container**.
 

--- a/docs/troubleshooting.mdx
+++ b/docs/troubleshooting.mdx
@@ -5,14 +5,30 @@ sidebar:
   order: 8
 ---
 
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+
 ## Container Won't Start
 
 ### "Conflict. The container name is already in use"
+
+<Tabs syncKey="runtime">
+<TabItem label="Docker">
 
 ```bash
 docker rm -f devcontainer
 docker compose up -d
 ```
+
+</TabItem>
+<TabItem label="Podman">
+
+```bash
+podman rm -f devcontainer
+podman compose up -d
+```
+
+</TabItem>
+</Tabs>
 
 ## AI Tools Not Working
 
@@ -20,9 +36,22 @@ docker compose up -d
 
 The image may be outdated. Rebuild it:
 
+<Tabs syncKey="runtime">
+<TabItem label="Docker">
+
 ```bash
 docker compose up -d --build
 ```
+
+</TabItem>
+<TabItem label="Podman">
+
+```bash
+podman compose up -d --build
+```
+
+</TabItem>
+</Tabs>
 
 ### Claude shows "Not logged in"
 
@@ -51,7 +80,18 @@ Common causes:
   OPENAI_BASE_URL=<your-provider-url>
   ```
 
+<Tabs syncKey="runtime">
+<TabItem label="Docker">
+
   Then restart: `docker compose up -d`.
+
+</TabItem>
+<TabItem label="Podman">
+
+  Then restart: `podman compose up -d`.
+
+</TabItem>
+</Tabs>
 
 - **Key doesn't start with `sk-ant-`** — Anthropic API keys always start with `sk-ant-`. If yours doesn't, it may be for a different provider. Use the proxy mode above, or get a direct key from [console.anthropic.com](https://console.anthropic.com/).
 
@@ -121,15 +161,41 @@ export PATH="$HOME/.npm-global/bin:$PATH"
 
 The first build downloads the base image (~1 GB). Subsequent builds use cache. If slow every time:
 
+<Tabs syncKey="runtime">
+<TabItem label="Docker">
+
 ```bash
 docker builder prune
 ```
 
+</TabItem>
+<TabItem label="Podman">
+
+```bash
+podman builder prune
+```
+
+</TabItem>
+</Tabs>
+
 ### "No space left on device"
+
+<Tabs syncKey="runtime">
+<TabItem label="Docker">
 
 ```bash
 docker system prune -a --volumes
 ```
+
+</TabItem>
+<TabItem label="Podman">
+
+```bash
+podman system prune -a --volumes
+```
+
+</TabItem>
+</Tabs>
 
 **Warning:** This removes all unused containers, images, and volumes — not just this project's.
 
@@ -143,6 +209,9 @@ nslookup google.com
 curl -I https://github.com
 ```
 
+<Tabs syncKey="runtime">
+<TabItem label="Docker">
+
 If DNS fails, add to `/etc/docker/daemon.json` on the host:
 
 ```json
@@ -152,6 +221,29 @@ If DNS fails, add to `/etc/docker/daemon.json` on the host:
 ```
 
 Then restart Docker.
+
+</TabItem>
+<TabItem label="Podman">
+
+If DNS fails, configure DNS inside the Podman machine:
+
+```bash
+podman machine ssh
+sudo sh -c 'echo "nameserver 8.8.8.8" > /etc/resolv.conf'
+exit
+```
+
+Or add DNS settings to `~/.config/containers/containers.conf` on the host:
+
+```ini
+[containers]
+dns_servers = ["8.8.8.8", "8.8.4.4"]
+```
+
+Then restart Podman: `podman machine stop && podman machine start`.
+
+</TabItem>
+</Tabs>
 
 ## Remote Display (noVNC)
 
@@ -185,9 +277,22 @@ ps aux | grep -E 'novnc|websockify'
 
 If not running, verify `ENABLE_VNC` is `true` (the default) and check container logs:
 
+<Tabs syncKey="runtime">
+<TabItem label="Docker">
+
 ```bash
 docker compose logs dev | grep -i vnc
 ```
+
+</TabItem>
+<TabItem label="Podman">
+
+```bash
+podman compose logs dev | grep -i vnc
+```
+
+</TabItem>
+</Tabs>
 
 ### Port 6080 already in use
 
@@ -200,10 +305,25 @@ ports:
 
 ## Reset Everything
 
+<Tabs syncKey="runtime">
+<TabItem label="Docker">
+
 ```bash
 docker compose down -v
 docker rm -f devcontainer 2>/dev/null
 docker compose up -d --build
 ```
+
+</TabItem>
+<TabItem label="Podman">
+
+```bash
+podman compose down -v
+podman rm -f devcontainer 2>/dev/null
+podman compose up -d --build
+```
+
+</TabItem>
+</Tabs>
 
 This destroys all data in volumes. You'll need to re-clone repos and reconfigure tools.

--- a/docs/vnc.mdx
+++ b/docs/vnc.mdx
@@ -5,6 +5,8 @@ sidebar:
   order: 3
 ---
 
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+
 The container runs a virtual display stack (Xvfb + x11vnc + noVNC + fluxbox) so you can watch AI agents control a browser and intervene when needed — for example, to handle login or MFA prompts.
 
 ## Connecting
@@ -43,10 +45,24 @@ Set these in your `.env` file or in `.devcontainer/devcontainer.json` under `con
 
 For headless-only operation, set `ENABLE_VNC=false` in `.env` and restart the container:
 
+<Tabs syncKey="runtime">
+<TabItem label="Docker">
+
 ```bash
 docker compose down
 docker compose up -d
 ```
+
+</TabItem>
+<TabItem label="Podman">
+
+```bash
+podman compose down
+podman compose up -d
+```
+
+</TabItem>
+</Tabs>
 
 ## Troubleshooting
 

--- a/docs/vscode.mdx
+++ b/docs/vscode.mdx
@@ -9,7 +9,7 @@ sidebar:
 
 1. [VS Code](https://code.visualstudio.com/)
 2. [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) (`ms-vscode-remote.remote-containers`)
-3. Docker running on your machine (see [Getting Started](./getting-started#docker))
+3. Docker or Podman running on your machine (see [Getting Started](./getting-started#container-runtime)). VS Code Dev Containers also supports [Podman as a backend](https://code.visualstudio.com/remote/advancedcontainers/docker-options#_podman).
 
 ## Quick Start
 


### PR DESCRIPTION
## Summary
- Adds Docker/Podman tab switchers using Starlight's `<Tabs syncKey="runtime">` component across all 6 docs pages where host-side container runtime commands appear
- Covers prerequisites, system resources, start/connect/stop, configuration, local development, troubleshooting, VNC, and VS Code pages
- Only tab-ifies host-side commands — commands running inside the container (e.g., `claude --version`) remain unchanged since they're runtime-agnostic
- Adds Podman-specific prerequisites (install links, rootful mode note) and DNS troubleshooting instructions

## Changes
| File | Tab blocks | Notes |
|------|-----------|-------|
| `getting-started.mdx` | 5 | Prerequisites, resources, start, connect, stop/restart |
| `configuration.mdx` | 2 | Tool install commands, data persistence |
| `local-development.mdx` | 3 | Override explanation, build, adding tools |
| `troubleshooting.mdx` | 7 | Container conflict, rebuild, build cache, disk space, DNS, VNC logs, reset |
| `vnc.mdx` | 1 | Disable VNC stack |
| `vscode.mdx` | 0 | Note about Podman backend support (no tabs needed) |

## Test plan
- [ ] Run local dev server and verify all tabs render correctly
- [ ] Verify `syncKey="runtime"` syncs tab selection across all tab blocks on a page
- [ ] Confirm code fences inside `<TabItem>` render properly (not indented)
- [ ] Check that no markdownlint / super-linter regressions occur
- [ ] Verify Docker-in-Docker and build architecture sections remain untabbed (correct — they describe internal engine, not host runtime)

Closes #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)