### PR TITLE
fix: self-test arithmetic bug and add bypass permissions

### DIFF
--- a/claude-config/self-test.sh
+++ b/claude-config/self-test.sh
@@ -11,10 +11,10 @@ check() {
   shift
   if "$@" >/dev/null 2>&1; then
     echo "  PASS: $desc"
-    ((PASS++))
+    PASS=$((PASS + 1))
   else
     echo "  FAIL: $desc"
-    ((FAIL++))
+    FAIL=$((FAIL + 1))
   fi
 }
 
@@ -60,7 +60,7 @@ if [ -f /opt/searxng-mcp/server.py ]; then
   fi
 else
   echo "  FAIL: SearXNG MCP server not installed at /opt/searxng-mcp"
-  ((FAIL++))
+  FAIL=$((FAIL + 1))
 fi
 
 echo ""

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -80,6 +80,8 @@ if [ -d /opt/searxng-mcp ]; then
   fi
   if command -v jq >/dev/null 2>&1; then
     jq --arg url "$SEARXNG_MCP_URL" '
+      .defaultMode = "bypassPermissions" |
+      .skipDangerousModePermissionPrompt = true |
       .mcpServers.searxng = {
         "command": "/opt/searxng-mcp/.venv/bin/python",
         "args": ["/opt/searxng-mcp/server.py"],


### PR DESCRIPTION
## Summary

- Fix `claude-self-test` script crash caused by bash arithmetic with `set -euo pipefail`
- Add `defaultMode: "bypassPermissions"` and `skipDangerousModePermissionPrompt: true` to the settings.json seed in entrypoint

## Details

### Self-test bug

The `((PASS++))` construct evaluates to 0 when `PASS=0` (post-increment returns old value). Bash treats `((0))` as exit code 1, and `set -e` kills the script after the first passing check. Fixed by using `PASS=$((PASS + 1))` which always succeeds.

### Bypass permissions

Seeds `~/.claude/settings.json` with `defaultMode` and `skipDangerousModePermissionPrompt` during entrypoint initialization alongside the existing SearXNG MCP config.

## Test plan

- [ ] Build image and run `claude-self-test` — should complete all 15 checks
- [ ] Verify `~/.claude/settings.json` contains both new keys after container start
- [ ] Verify existing SearXNG MCP config still present

Closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)