### PR TITLE
fix: rename docker-compose.override.yml to opt-in build file

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Dev Container",
-  "dockerComposeFile": ["../docker-compose.yml", "../docker-compose.override.yml"],
+  "dockerComposeFile": ["../docker-compose.yml", "../docker-compose.build.yml"],
   "service": "dev",
   "workspaceFolder": "/workspace",
 

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -1,0 +1,8 @@
+# Local build — NOT auto-merged. Use explicitly:
+#   docker compose -f docker-compose.yml -f docker-compose.build.yml up --build
+#   podman compose -f docker-compose.yml -f docker-compose.build.yml up --build
+services:
+  dev:
+    build:
+      context: .
+      dockerfile: Dockerfile

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,9 +1,0 @@
-# Local build override — auto-merged by Docker Compose when present.
-# This file is only used by clone users; standalone docker-compose.yml
-# pulls the pre-built image without needing this override.
-services:
-  dev:
-    build:
-      context: .
-      dockerfile: Dockerfile
-    pull_policy: missing

--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -129,12 +129,24 @@ Every language runtime, CLI, and tool is installed directly in the `Dockerfile` 
 <Tabs syncKey="runtime">
 <TabItem label="Docker">
 
-Running `docker compose up -d` pulls the pre-built image automatically. If you've cloned the repository, the `docker-compose.override.yml` file adds local build support — use `docker compose up -d --build` to force a local build after customizing the Dockerfile. See [Local Development](./local-development) for details.
+Running `docker compose up -d` pulls the pre-built image automatically. To build locally after customizing the Dockerfile, pass the build file explicitly:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.build.yml up -d --build
+```
+
+See [Local Development](./local-development) for details.
 
 </TabItem>
 <TabItem label="Podman">
 
-Running `podman compose up -d` pulls the pre-built image automatically. If you've cloned the repository, the `docker-compose.override.yml` file adds local build support — use `podman compose up -d --build` to force a local build after customizing the Dockerfile. See [Local Development](./local-development) for details.
+Running `podman compose up -d` pulls the pre-built image automatically. To build locally after customizing the Dockerfile, pass the build file explicitly:
+
+```bash
+podman compose -f docker-compose.yml -f docker-compose.build.yml up -d --build
+```
+
+See [Local Development](./local-development) for details.
 
 </TabItem>
 </Tabs>

--- a/docs/local-development.mdx
+++ b/docs/local-development.mdx
@@ -22,7 +22,7 @@ cd devcontainer
 .
 ├── Dockerfile                  # Multi-stage image build
 ├── docker-compose.yml          # Base compose — pulls pre-built image
-├── docker-compose.override.yml # Build override — auto-merged when present
+├── docker-compose.build.yml    # Build override — use explicitly with -f
 ├── .devcontainer/              # VS Code Dev Container config
 │   └── devcontainer.json
 ├── entrypoint.sh               # Container startup script
@@ -31,32 +31,38 @@ cd devcontainer
 └── claude-config/              # Claude Code configuration files
 ```
 
-## How the Override File Works
+## Build File
 
-Docker Compose automatically merges `docker-compose.override.yml` when it exists in the same directory as `docker-compose.yml`. This means:
+The `docker-compose.build.yml` file adds local build support. It is **not** auto-merged — you must pass it explicitly with `-f` flags. This means `docker compose up -d` (or `podman compose up -d`) always pulls the pre-built image from GHCR, whether you cloned the repo or not.
 
 <Tabs syncKey="runtime">
 <TabItem label="Docker">
 
-- **Clone users** (have both files): `docker compose up -d` uses the local `Dockerfile` with `pull_policy: missing` — it builds locally if no image is cached, otherwise uses the cache.
-- **Standalone users** (only `docker-compose.yml`): `docker compose up -d` pulls the pre-built image from ghcr.io.
-
-You can verify the merged configuration:
+You can verify that a plain `docker compose up` uses only the pre-built image (no `build:` context):
 
 ```bash
 docker compose config
 ```
 
+Compare with the explicit build configuration:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.build.yml config
+```
+
 </TabItem>
 <TabItem label="Podman">
 
-- **Clone users** (have both files): `podman compose up -d` uses the local `Dockerfile` with `pull_policy: missing` — it builds locally if no image is cached, otherwise uses the cache.
-- **Standalone users** (only `docker-compose.yml`): `podman compose up -d` pulls the pre-built image from ghcr.io.
-
-You can verify the merged configuration:
+You can verify that a plain `podman compose up` uses only the pre-built image (no `build:` context):
 
 ```bash
 podman compose config
+```
+
+Compare with the explicit build configuration:
+
+```bash
+podman compose -f docker-compose.yml -f docker-compose.build.yml config
 ```
 
 </TabItem>
@@ -68,20 +74,20 @@ podman compose config
 <TabItem label="Docker">
 
 ```bash
-docker compose up -d --build
+docker compose -f docker-compose.yml -f docker-compose.build.yml up -d --build
 ```
 
 </TabItem>
 <TabItem label="Podman">
 
 ```bash
-podman compose up -d --build
+podman compose -f docker-compose.yml -f docker-compose.build.yml up -d --build
 ```
 
 </TabItem>
 </Tabs>
 
-This builds the image from the local `Dockerfile` and starts the container. The `--build` flag forces a rebuild even if a cached image exists.
+This merges the build file with the base compose file, builds the image from the local `Dockerfile`, and starts the container. The `--build` flag forces a rebuild even if a cached image exists.
 
 ## Two-Stage Build Architecture
 
@@ -130,14 +136,14 @@ Edit the `Dockerfile` and add your tool to the appropriate section. Rebuild afte
 <TabItem label="Docker">
 
 ```bash
-docker compose up -d --build
+docker compose -f docker-compose.yml -f docker-compose.build.yml up -d --build
 ```
 
 </TabItem>
 <TabItem label="Podman">
 
 ```bash
-podman compose up -d --build
+podman compose -f docker-compose.yml -f docker-compose.build.yml up -d --build
 ```
 
 </TabItem>

--- a/docs/security.mdx
+++ b/docs/security.mdx
@@ -66,7 +66,7 @@ In both modes, the container has no access to VPN tunnels, corporate network int
 
 ### Ephemeral by Design
 
-The entire environment can be destroyed and recreated with `docker compose down -v` followed by `docker compose up -d --build`. Treat the container as disposable.
+The entire environment can be destroyed and recreated with `docker compose down -v` followed by `docker compose pull && docker compose up -d`. Treat the container as disposable.
 
 ### CLI-Only Tools
 
@@ -107,7 +107,7 @@ The `docker-compose.yml` applies several defense-in-depth measures:
 2. **Do not add bind mounts** to `docker-compose.yml`. The named-volume configuration is intentional.
 3. **Rotate SSH keys** used inside the container periodically.
 4. **Review `.env` before sharing.** It contains API keys and may contain SSH private keys.
-5. **Rebuild periodically** to pick up security patches: `docker compose up -d --build`
+5. **Update periodically** to pick up security patches: `docker compose pull && docker compose up -d`
 6. **The proxy runs inside the container** on `localhost:8082` and is not exposed to the host network.
 
 ## References

--- a/docs/troubleshooting.mdx
+++ b/docs/troubleshooting.mdx
@@ -34,20 +34,22 @@ podman compose up -d
 
 ### "claude: command not found"
 
-The image may be outdated. Rebuild it:
+The image may be outdated. Pull the latest and restart:
 
 <Tabs syncKey="runtime">
 <TabItem label="Docker">
 
 ```bash
-docker compose up -d --build
+docker compose pull
+docker compose up -d
 ```
 
 </TabItem>
 <TabItem label="Podman">
 
 ```bash
-podman compose up -d --build
+podman compose pull
+podman compose up -d
 ```
 
 </TabItem>
@@ -311,7 +313,8 @@ ports:
 ```bash
 docker compose down -v
 docker rm -f devcontainer 2>/dev/null
-docker compose up -d --build
+docker compose pull
+docker compose up -d
 ```
 
 </TabItem>
@@ -320,7 +323,8 @@ docker compose up -d --build
 ```bash
 podman compose down -v
 podman rm -f devcontainer 2>/dev/null
-podman compose up -d --build
+podman compose pull
+podman compose up -d
 ```
 
 </TabItem>

--- a/docs/vscode.mdx
+++ b/docs/vscode.mdx
@@ -29,12 +29,12 @@ VS Code builds (or pulls) the image, starts the container, installs extensions, 
 The `.devcontainer/devcontainer.json` file tells VS Code to use Docker Compose:
 
 ```json
-"dockerComposeFile": ["../docker-compose.yml", "../docker-compose.override.yml"],
+"dockerComposeFile": ["../docker-compose.yml", "../docker-compose.build.yml"],
 "service": "dev",
 "workspaceFolder": "/workspace"
 ```
 
-Because you cloned the repo, both compose files are present. Docker Compose merges them automatically — the override adds `build:` support so VS Code can build the image locally if needed.
+The devcontainer config explicitly includes the build file, so VS Code can build the image locally when you use "Reopen in Container" or "Rebuild Container".
 
 ## Extensions
 


### PR DESCRIPTION
## Summary

- Renames `docker-compose.override.yml` to `docker-compose.build.yml` so local builds are opt-in, not auto-merged
- Updates `.devcontainer/devcontainer.json` to reference the new filename
- Updates 5 docs files to use explicit `-f` syntax for local builds and `pull` + `up` for non-developers

## Why

`docker-compose.override.yml` is a "magic" filename — Docker and Podman Compose auto-merge it whenever present alongside `docker-compose.yml`. Since this file was tracked in the repo, anyone who cloned and ran `docker compose up -d` got a ~30 min local build instead of a ~2 min pull from GHCR.

## Behavior after changes

| User | Command | Result |
|------|---------|--------|
| Non-technical (standalone) | `docker compose up -d` | Pulls from GHCR |
| Non-technical (clone) | `docker compose up -d` | Pulls from GHCR |
| Developer (explicit) | `docker compose -f docker-compose.yml -f docker-compose.build.yml up --build` | Builds locally |
| VS Code devcontainer | "Reopen in Container" | Builds locally (devcontainer.json includes build file) |
| CI | `docker/build-push-action` | Unchanged |

## Test plan

- [x] `docker compose config` — shows NO `build:` context (just `image:`)
- [x] `docker compose -f docker-compose.yml -f docker-compose.build.yml config` — shows `build:` context
- [x] No remaining references to `docker-compose.override.yml` in codebase
- [x] `devcontainer.json` references the new filename
- [ ] `docker compose up -d` pulls from GHCR (not build)
- [ ] VS Code "Reopen in Container" still works

Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)