### PR TITLE
fix: dalfox tar extraction and amass binary-only extract

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -540,12 +540,13 @@ RUN ghlatest() { curl -fsSL -o /dev/null -w '%{url_effective}' "https://github.c
       && unzip -oq /tmp/feroxbuster.zip -d /usr/local/bin && rm /tmp/feroxbuster.zip; \
     fi \
     && chmod +x /usr/local/bin/feroxbuster \
-    # --- XSS scanner ---
+    # --- XSS scanner (binary is named dalfox-linux-ARCH inside archive) ---
     && curl ${CURL_RETRY} -fsSL "https://github.com/hahwul/dalfox/releases/latest/download/dalfox-linux-${DPKG_ARCH}.tar.gz" \
-      | tar -xz -C /usr/local/bin dalfox \
-    # --- Domain & URL enumeration ---
+      | tar -xz -C /usr/local/bin \
+    && mv /usr/local/bin/dalfox-linux-${DPKG_ARCH} /usr/local/bin/dalfox \
+    # --- Domain & URL enumeration (extract only the binary) ---
     && curl ${CURL_RETRY} -fsSL "https://github.com/owasp-amass/amass/releases/latest/download/amass_linux_${DPKG_ARCH}.tar.gz" \
-      | tar -xz --strip-components=1 -C /usr/local/bin \
+      | tar -xz --strip-components=1 -C /usr/local/bin "amass_linux_${DPKG_ARCH}/amass" \
     && GAU_VERSION=$(ghlatest lc/gau) \
     && curl ${CURL_RETRY} -fsSL "https://github.com/lc/gau/releases/latest/download/gau_${GAU_VERSION}_linux_${DPKG_ARCH}.tar.gz" \
       | tar -xz -C /usr/local/bin gau \


### PR DESCRIPTION
## Summary
- Fix dalfox extraction: tarball contains `dalfox-linux-ARCH` not `dalfox`, causing `tar: dalfox: Not found in archive` (exit code 2)
- Narrow amass extraction to only the binary instead of the full archive contents (LICENSE, README, resources/)

## Root Cause
Docker Publish [run 22609503889](https://github.com/f5xc-salesdemos/devcontainer/actions/runs/22609503889) failed at Section 10g with:
```
#28 6.122 tar: dalfox: Not found in archive
#28 6.122 tar: Exiting with failure status due to previous errors
```

## Changes
- `Dockerfile`: Remove filename filter from dalfox tar extraction, add `mv` rename step
- `Dockerfile`: Add path filter to amass tar to extract only the `amass` binary

## Test plan
- [ ] Docker Publish workflow passes on both amd64 and arm64
- [ ] `dalfox --version` works in the container
- [ ] `amass --help` works in the container

Closes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)