### PR TITLE
fix: install recon-ng and spiderfoot via git clone

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -792,8 +792,8 @@ RUN git clone --depth=1 https://github.com/drwetter/testssl.sh.git /opt/testssl.
     && pip install --no-cache-dir --break-system-packages -r /opt/spiderfoot/requirements.txt \
     && printf '#!/bin/sh\nexec python3 /opt/spiderfoot/sf.py "$@"\n' > /usr/local/bin/spiderfoot \
     && chmod +x /usr/local/bin/spiderfoot \
-    && rm -rf /opt/testssl.sh/.git /opt/exploitdb/.git /opt/seclists/.git /opt/docker-bench-security/.git \
-       /opt/recon-ng/.git /opt/spiderfoot/.git
+    && rm -rf /opt/testssl.sh/.git /opt/exploitdb/.git /opt/seclists/.git \
+        /opt/docker-bench-security/.git /opt/recon-ng/.git /opt/spiderfoot/.git
 
 # ============================================================
 # 13. Playwright browsers (Chromium + system deps)


### PR DESCRIPTION
## Summary
- Remove `recon-ng` and `spiderfoot` from pip install (not on PyPI)
- Install them via git clone in Section 12i with their respective requirements files

## Root Cause
Docker Publish [run 22609804817](https://github.com/f5xc-salesdemos/devcontainer/actions/runs/22609804817) fails at Section 12 (pip install):
```
ERROR: Could not find a version that satisfies the requirement recon-ng (from versions: none)
ERROR: No matching distribution found for recon-ng
```

Neither `recon-ng` nor `spiderfoot` are published on PyPI — they must be installed from their git repositories.

## Changes
- `Dockerfile`: Remove `recon-ng` and `spiderfoot` from pip install block
- `Dockerfile`: Add git clone + pip requirements install for both in Section 12i

## Test plan
- [ ] Docker Publish workflow passes on both amd64 and arm64
- [ ] `recon-ng --help` works in the container
- [ ] `spiderfoot --help` works in the container

Closes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)