### PR TITLE
fix: split security pip packages to prevent zstandard resolver conflict

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -680,7 +680,17 @@ RUN pip install --no-cache-dir --break-system-packages --ignore-installed \
     codespell \
     zizmor \
     nbqa \
-    # Security & pentest
+    # Recon (recon-ng, spiderfoot installed via git clone below)
+    theHarvester \
+    fierce
+
+# Security & pentest pip packages are installed separately because
+# mitmproxy, sslyze, impacket, and prowler have conflicting transitive
+# deps on cryptography/pyOpenSSL.  A single pip install causes the
+# resolver to backtrack and downgrade zstandard (needed by pwntools)
+# to 0.22.0, which cannot build from source on Python 3.13.
+# hadolint ignore=DL3013,DL3059
+RUN pip install --no-cache-dir --break-system-packages \
     scapy \
     impacket \
     pwntools \
@@ -691,10 +701,7 @@ RUN pip install --no-cache-dir --break-system-packages --ignore-installed \
     mitmproxy \
     # Cloud security
     prowler \
-    kube-hunter \
-    # Recon (recon-ng, spiderfoot installed via git clone below)
-    theHarvester \
-    fierce
+    kube-hunter
 
 # ============================================================
 # 12b. Claude Code Proxy (Anthropic Messages API -> OpenAI)


### PR DESCRIPTION
## Summary
- Splits security & pentest pip packages into a separate `RUN pip install` command
- Prevents pip resolver from backtracking across conflicting `cryptography`/`pyOpenSSL` transitive deps (from `mitmproxy`, `sslyze`, `impacket`, `prowler`)
- Eliminates the `zstandard` downgrade from 0.25.0 (Python 3.13 wheels) to 0.22.0 (source-only, fails on Python 3.13 due to cffi incompatibility)

## Root Cause
All security packages were in one giant `pip install` with linter/tool packages. The resolver tried to satisfy all constraints simultaneously, causing aggressive backtracking that forced `zstandard` to 0.22.0 — which fails to build from source on Python 3.13:
```
ImportError: undefined symbol: _PyErr_WriteUnraisableMsg
ERROR: Failed to build 'zstandard' when getting requirements to build wheel
```

## Test plan
- [ ] CI checks pass (hadolint, editorconfig, super-linter)
- [ ] Docker Publish builds successfully on both amd64 and arm64
- [ ] All pip packages install without resolver conflicts

Closes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)