### PR TITLE
fix: pin zstandard>=0.23.0 to prevent cffi build failure on Python 3.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -691,6 +691,7 @@ RUN pip install --no-cache-dir --break-system-packages --ignore-installed \
 # to 0.22.0, which cannot build from source on Python 3.13.
 # hadolint ignore=DL3013,DL3059
 RUN pip install --no-cache-dir --break-system-packages \
+    "zstandard>=0.23.0" \
     scapy \
     impacket \
     pwntools \


### PR DESCRIPTION
## Summary
- Pins `zstandard>=0.23.0` in the security pip install to prevent pip resolver from downgrading to 0.22.0
- `zstandard>=0.23.0` ships pre-built `cp313` wheels for both amd64 and arm64, avoiding the cffi source build failure

## Context
PR #159 split security pip packages into a separate install, but the resolver still backtracks within that group (`prowler` → `mitmproxy` → `cryptography` conflicts) and downgrades `zstandard` to 0.22.0. The explicit version constraint prevents this.

## Test plan
- [ ] CI checks pass (hadolint, editorconfig, super-linter)
- [ ] Docker Publish builds successfully on both amd64 and arm64

Closes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)