### PR TITLE
fix: add --ignore-installed to security pip install for Debian packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -689,8 +689,10 @@ RUN pip install --no-cache-dir --break-system-packages --ignore-installed \
 # deps on cryptography/pyOpenSSL.  A single pip install causes the
 # resolver to backtrack and downgrade zstandard (needed by pwntools)
 # to 0.22.0, which cannot build from source on Python 3.13.
+# --ignore-installed: same as Section 12 — Debian system packages
+# (blinker, etc.) lack pip RECORD files and block uninstall.
 # hadolint ignore=DL3013,DL3059
-RUN pip install --no-cache-dir --break-system-packages \
+RUN pip install --no-cache-dir --break-system-packages --ignore-installed \
     "zstandard>=0.23.0" \
     scapy \
     impacket \


### PR DESCRIPTION
## Summary
- Adds `--ignore-installed` flag to the security pip install command
- Adds comment explaining why the flag is needed (same reason as Section 12)

## Root Cause
Debian system packages (blinker, etc.) lack pip RECORD files. When a security package dependency needs a different version, pip refuses to uninstall the Debian-installed version:
```
Cannot uninstall blinker 1.7.0 — no RECORD file was found
hint: The package was installed by debian
```

## Test plan
- [ ] CI checks pass
- [ ] Docker Publish builds successfully on both amd64 and arm64

Closes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)