### PR TITLE
fix: isolate security pip installs to prevent resolver backtracking

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -684,27 +684,23 @@ RUN pip install --no-cache-dir --break-system-packages --ignore-installed \
     theHarvester \
     fierce
 
-# Security & pentest pip packages are installed separately because
-# mitmproxy, sslyze, impacket, and prowler have conflicting transitive
-# deps on cryptography/pyOpenSSL.  A single pip install causes the
-# resolver to backtrack and downgrade zstandard (needed by pwntools)
-# to 0.22.0, which cannot build from source on Python 3.13.
-# --ignore-installed: same as Section 12 — Debian system packages
-# (blinker, etc.) lack pip RECORD files and block uninstall.
+# Security & pentest pip packages.
+# Installed in isolated groups because mitmproxy, sslyze, impacket,
+# and prowler pull conflicting cryptography/pyOpenSSL versions.
+# A single pip install triggers massive resolver backtracking that
+# downgrades zstandard (Python 3.13 cffi issue) or mitmproxy (ancient
+# urwid with use_2to3).  Separate installs let each resolve cleanly.
+# --ignore-installed: Debian system packages (blinker, etc.) lack
+# pip RECORD files and block uninstall.
 # hadolint ignore=DL3013,DL3059
 RUN pip install --no-cache-dir --break-system-packages --ignore-installed \
-    "zstandard>=0.23.0" \
-    scapy \
-    impacket \
-    pwntools \
-    volatility3 \
-    sslyze \
-    arjun \
-    hashid \
+    scapy impacket sslyze arjun hashid \
+    && pip install --no-cache-dir --break-system-packages --ignore-installed \
+    pwntools volatility3 \
+    && pip install --no-cache-dir --break-system-packages --ignore-installed \
     mitmproxy \
-    # Cloud security
-    prowler \
-    kube-hunter
+    && pip install --no-cache-dir --break-system-packages --ignore-installed \
+    prowler kube-hunter
 
 # ============================================================
 # 12b. Claude Code Proxy (Anthropic Messages API -> OpenAI)


### PR DESCRIPTION
## Summary
- Splits security pip packages into 4 isolated install groups to prevent resolver backtracking
- Each group resolves independently, avoiding cross-package version conflicts

## Groups
1. `scapy impacket sslyze arjun hashid` — share cryptography deps
2. `pwntools volatility3` — needs zstandard with Python 3.13 wheels
3. `mitmproxy` — complex dependency tree; ancient versions pull urwid 1.3.x with `use_2to3` (fails on Python 3.13)
4. `prowler kube-hunter` — cloud security with large dependency trees

## Root Cause
When all security packages are in one `pip install`, the resolver backtracks through conflicting `cryptography`/`pyOpenSSL` constraints and eventually tries ancient `mitmproxy` versions whose `urwid` dependency (1.3.x) uses `use_2to3` — unsupported in Python 3.13:
```
SystemExit: error in urwid setup command: use_2to3 is invalid.
```

## Test plan
- [ ] CI checks pass
- [ ] Docker Publish builds successfully on both amd64 and arm64

Closes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)