### PR TITLE
fix: pre-install lxml>=5.1.0 wheel for Python 3.13 compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -799,6 +799,10 @@ RUN git clone --depth=1 https://github.com/drwetter/testssl.sh.git /opt/testssl.
     && pip install --no-cache-dir --break-system-packages -r /opt/recon-ng/REQUIREMENTS \
     && ln -s /opt/recon-ng/recon-ng /usr/local/bin/recon-ng \
     && git clone --depth=1 https://github.com/smicallef/spiderfoot.git /opt/spiderfoot \
+    # Pre-install lxml with cp313 wheel — spiderfoot pins an old version
+    # whose Cython-generated C code is incompatible with Python 3.13
+    # (_PyObject_NextNotImplemented removed, _PyLong_AsByteArray changed).
+    && pip install --no-cache-dir --break-system-packages "lxml>=5.1.0" \
     && pip install --no-cache-dir --break-system-packages -r /opt/spiderfoot/requirements.txt \
     && printf '#!/bin/sh\nexec python3 /opt/spiderfoot/sf.py "$@"\n' > /usr/local/bin/spiderfoot \
     && chmod +x /usr/local/bin/spiderfoot \
@@ -807,7 +811,7 @@ RUN git clone --depth=1 https://github.com/drwetter/testssl.sh.git /opt/testssl.
 
 # Purge build-essential now that all C-extension installs are done.
 # Kept through: Section 12b (claude-code-proxy), 12d (rubocop/prism),
-# 12h (wpscan gem), and 12i (lxml for spiderfoot).
+# 12h (wpscan gem), and 12i (recon-ng/spiderfoot pip deps).
 # hadolint ignore=DL3059
 RUN apt-get purge -y build-essential \
     && apt-get autoremove -y \


### PR DESCRIPTION
## Summary
- Pre-install `lxml>=5.1.0` (cp313 wheel from PyPI) before installing spiderfoot's requirements.txt
- Spiderfoot pins an old lxml whose Cython-generated C code uses removed Python 3.13 internal APIs (`_PyObject_NextNotImplemented`, `_PyLong_AsByteArray` signature change)
- The pre-installed wheel satisfies the lxml dependency so pip skips source compilation

Fixes Docker Publish failure in run [22630794271](https://github.com/f5xc-salesdemos/devcontainer/actions/runs/22630794271). Continuation of #158 / #163.

Closes #165

## Test plan
- [ ] CI passes (hadolint, super-linter)
- [ ] Docker Publish builds successfully on both amd64 and arm64
- [ ] `python3 -c "import lxml"` works in the container
- [ ] `spiderfoot --help` works in the container