### PR TITLE
fix: relax spiderfoot lxml<5 upper bound for Python 3.13 compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -799,10 +799,11 @@ RUN git clone --depth=1 https://github.com/drwetter/testssl.sh.git /opt/testssl.
     && pip install --no-cache-dir --break-system-packages -r /opt/recon-ng/REQUIREMENTS \
     && ln -s /opt/recon-ng/recon-ng /usr/local/bin/recon-ng \
     && git clone --depth=1 https://github.com/smicallef/spiderfoot.git /opt/spiderfoot \
-    # Pre-install lxml with cp313 wheel — spiderfoot pins an old version
-    # whose Cython-generated C code is incompatible with Python 3.13
-    # (_PyObject_NextNotImplemented removed, _PyLong_AsByteArray changed).
-    && pip install --no-cache-dir --break-system-packages "lxml>=5.1.0" \
+    # Spiderfoot pins lxml<5,>=4.9.2 but lxml 4.x Cython C code is
+    # incompatible with Python 3.13 (removed _PyObject_NextNotImplemented,
+    # changed _PyLong_AsByteArray).  Relax to >=4.9.2 so pip uses the
+    # already-installed lxml 6.x cp313 wheel.
+    && sed -i 's/lxml<5,>=4\.9\.2/lxml>=4.9.2/' /opt/spiderfoot/requirements.txt \
     && pip install --no-cache-dir --break-system-packages -r /opt/spiderfoot/requirements.txt \
     && printf '#!/bin/sh\nexec python3 /opt/spiderfoot/sf.py "$@"\n' > /usr/local/bin/spiderfoot \
     && chmod +x /usr/local/bin/spiderfoot \


### PR DESCRIPTION
## Summary
- Spiderfoot's `requirements.txt` pins `lxml<5,>=4.9.2` but no lxml 4.x version has cp313 wheels
- The `lxml<5` upper bound forces pip to download `lxml-4.9.4.tar.gz` and build from source, which fails on Python 3.13 (removed CPython internal APIs)
- Replace the pre-install approach from #167 with `sed` to relax the bound to `>=4.9.2`, so pip uses the already-installed lxml 6.x wheel (from markitdown deps)

The key log lines from the failed run:
```
Requirement already satisfied: lxml>=5.1.0 in /usr/local/lib/python3.13/dist-packages (6.0.2)
Collecting lxml<5,>=4.9.2 (from -r /opt/spiderfoot/requirements.txt (line 8))
  Downloading lxml-4.9.4.tar.gz (3.6 MB)
```

Closes #165

## Test plan
- [ ] CI passes (hadolint, super-linter)
- [ ] Docker Publish builds on both amd64 and arm64
- [ ] `python3 -c "import lxml"` works in the container
- [ ] `spiderfoot --help` works in the container