### PR TITLE
fix: correct sed pattern for spiderfoot lxml version constraint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -799,11 +799,11 @@ RUN git clone --depth=1 https://github.com/drwetter/testssl.sh.git /opt/testssl.
     && pip install --no-cache-dir --break-system-packages -r /opt/recon-ng/REQUIREMENTS \
     && ln -s /opt/recon-ng/recon-ng /usr/local/bin/recon-ng \
     && git clone --depth=1 https://github.com/smicallef/spiderfoot.git /opt/spiderfoot \
-    # Spiderfoot pins lxml<5,>=4.9.2 but lxml 4.x Cython C code is
+    # Spiderfoot pins lxml>=4.9.2,<5 but lxml 4.x Cython C code is
     # incompatible with Python 3.13 (removed _PyObject_NextNotImplemented,
-    # changed _PyLong_AsByteArray).  Relax to >=4.9.2 so pip uses the
-    # already-installed lxml 6.x cp313 wheel.
-    && sed -i 's/lxml<5,>=4\.9\.2/lxml>=4.9.2/' /opt/spiderfoot/requirements.txt \
+    # changed _PyLong_AsByteArray).  Strip the <5 upper bound so pip uses
+    # the already-installed lxml 6.x cp313 wheel.
+    && sed -i 's/lxml>=4\.9\.2,<5/lxml>=4.9.2/' /opt/spiderfoot/requirements.txt \
     && pip install --no-cache-dir --break-system-packages -r /opt/spiderfoot/requirements.txt \
     && printf '#!/bin/sh\nexec python3 /opt/spiderfoot/sf.py "$@"\n' > /usr/local/bin/spiderfoot \
     && chmod +x /usr/local/bin/spiderfoot \


### PR DESCRIPTION
## Summary
- The previous sed pattern `s/lxml<5,>=4.9.2/lxml>=4.9.2/` didn't match because spiderfoot's requirements.txt uses `lxml>=4.9.2,<5` (different specifier order)
- Fix the sed pattern to `s/lxml>=4.9.2,<5/lxml>=4.9.2/` matching the actual format

Verified locally:
```
$ git clone --depth=1 https://github.com/smicallef/spiderfoot.git /tmp/sf
$ grep lxml /tmp/sf/requirements.txt
lxml>=4.9.2,<5
```

Closes #165

## Test plan
- [ ] CI passes
- [ ] Docker Publish builds on both amd64 and arm64