### PR TITLE
fix: correct gitleaks and editorconfig-checker download URLs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -411,14 +411,15 @@ RUN ghlatest() { curl -fsSL -o /dev/null -w '%{url_effective}' "https://github.c
     && curl ${CURL_RETRY} -fsSLo /usr/local/bin/shfmt \
       "https://github.com/mvdan/sh/releases/latest/download/shfmt_v${SHFMT_VERSION}_linux_${DPKG_ARCH}" \
     && chmod +x /usr/local/bin/shfmt \
-    # gitleaks (version in asset name)
+    # gitleaks (assets use x64/arm64, not amd64/arm64)
     && GITLEAKS_VERSION=$(ghlatest gitleaks/gitleaks) \
-    && curl ${CURL_RETRY} -fsSL "https://github.com/gitleaks/gitleaks/releases/latest/download/gitleaks_${GITLEAKS_VERSION}_linux_${DPKG_ARCH}.tar.gz" \
+    && if [ "$DPKG_ARCH" = "amd64" ]; then GL_ARCH="x64"; else GL_ARCH="arm64"; fi \
+    && curl ${CURL_RETRY} -fsSL "https://github.com/gitleaks/gitleaks/releases/latest/download/gitleaks_${GITLEAKS_VERSION}_linux_${GL_ARCH}.tar.gz" \
       | tar -xz -C /usr/local/bin gitleaks \
-    # editorconfig-checker (version-free asset)
+    # editorconfig-checker (version-free asset; binary is bin/ec-linux-<arch>)
     && curl ${CURL_RETRY} -fsSL "https://github.com/editorconfig-checker/editorconfig-checker/releases/latest/download/ec-linux-${DPKG_ARCH}.tar.gz" \
-      | tar -xz --strip-components=1 -C /usr/local/bin \
-    && mv /usr/local/bin/ec-linux-${DPKG_ARCH} /usr/local/bin/editorconfig-checker 2>/dev/null || true \
+      | tar -xz --strip-components=1 -C /usr/local/bin "bin/ec-linux-${DPKG_ARCH}" \
+    && mv /usr/local/bin/ec-linux-${DPKG_ARCH} /usr/local/bin/editorconfig-checker \
     # trivy (install script auto-detects arch)
     && curl ${CURL_RETRY} -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin \
     # clj-kondo


### PR DESCRIPTION
## Summary
- Fix gitleaks download: map `amd64` → `x64` to match release asset naming
- Fix editorconfig-checker: extract only the binary from tarball, remove `|| true`
- Remove dangerous `|| true` that silently swallowed both tools' installation failures

## Root Cause
1. **gitleaks**: Release assets use `x64`/`arm64`, not `amd64`/`arm64`. The URL built with `${DPKG_ARCH}` returned 404.
2. **`|| true` failure masking**: Shell operator precedence caused `|| true` on the editorconfig-checker `mv` line to catch ALL upstream `&&` chain failures — including gitleaks — allowing subsequent tools (trivy, clj-kondo, etc.) to install normally while silently skipping both broken tools.

## Test plan
- [ ] CI linters pass
- [ ] Docker Publish succeeds on both amd64 and arm64
- [ ] `claude-self-test` shows gitleaks and editorconfig-checker as PASS

Closes #170

🤖 Generated with [Claude Code](https://claude.com/claude-code)