### PR TITLE
feat: add Pi AI coding agent to devcontainer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -630,6 +630,7 @@ RUN if [ "$(dpkg --print-architecture)" = "amd64" ]; then \
 # hadolint ignore=DL3016,DL3059
 RUN npm install -g \
     @anthropic-ai/claude-code \
+    @mariozechner/pi-coding-agent \
     prettier \
     markdownlint-cli2 \
     openclaw \

--- a/claude-config/self-test.sh
+++ b/claude-config/self-test.sh
@@ -23,6 +23,7 @@ echo ""
 
 echo "1. Core Tools"
 check "claude CLI installed" command -v claude
+check "pi CLI installed" command -v pi
 check "node installed" command -v node
 check "python installed" command -v python3
 check "git installed" command -v git


### PR DESCRIPTION
## Summary

- Install `@mariozechner/pi-coding-agent` npm package globally in Section 11 of the Dockerfile
- Add `pi` CLI verification check to the self-test script

## Why

[Pi](https://github.com/badlogic/pi-mono/) is an open-source AI coding agent CLI that complements Claude Code. It's distributed as an npm package and requires Node.js >= 20 (container has Node 24).

## Test plan

- [ ] CI linters pass (super-linter, hadolint)
- [ ] Docker Publish succeeds on amd64 and arm64
- [ ] `claude-self-test` shows `pi CLI installed: PASS`
- [ ] `docker compose exec dev pi --help` runs successfully

Closes #172

🤖 Generated with [Claude Code](https://claude.com/claude-code)