### PR TITLE
feat: add Aider AI coding agent to devcontainer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -707,6 +707,13 @@ RUN pip install --no-cache-dir --break-system-packages --ignore-installed \
     && pip install --no-cache-dir --break-system-packages --ignore-installed \
     prowler kube-hunter
 
+# Aider AI chat — requires Python <3.13, so install isolated with uv + Python 3.12
+# hadolint ignore=DL3059
+RUN uv tool install --python python3.12 aider-chat@latest \
+      --with aider-chat[browser] \
+      --with aider-chat[help] \
+      --with aider-chat[playwright]
+
 # ============================================================
 # 12b. Claude Code Proxy (Anthropic Messages API -> OpenAI)
 # ============================================================

--- a/claude-config/self-test.sh
+++ b/claude-config/self-test.sh
@@ -24,6 +24,7 @@ echo ""
 echo "1. Core Tools"
 check "claude CLI installed" command -v claude
 check "pi CLI installed" command -v pi
+check "aider CLI installed" command -v aider
 check "node installed" command -v node
 check "python installed" command -v python3
 check "git installed" command -v git


### PR DESCRIPTION
## Summary

- Add [Aider](https://aider.chat/) AI pair programming chat tool with all optional extras (`browser`, `help`, `playwright`)
- Uses `uv tool install --python python3.12` for isolated install since aider requires Python <3.13
- Add self-test check for `aider` CLI

## Test plan

- [ ] CI linters pass (hadolint, shellcheck, super-linter)
- [ ] Docker Publish succeeds on amd64 and arm64
- [ ] `claude-self-test` shows `aider CLI installed: PASS`
- [ ] `aider --version` runs successfully in container

Closes #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)