### PR TITLE
fix: install aider binary to /usr/local/bin for PATH visibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -709,7 +709,8 @@ RUN pip install --no-cache-dir --break-system-packages --ignore-installed \
 
 # Aider AI chat — requires Python <3.13, so install isolated with uv + Python 3.12
 # hadolint ignore=DL3059
-RUN uv tool install --python python3.12 aider-chat@latest \
+RUN UV_TOOL_BIN_DIR=/usr/local/bin \
+    uv tool install --python python3.12 aider-chat@latest \
       --with aider-chat[browser] \
       --with aider-chat[help] \
       --with aider-chat[playwright]


### PR DESCRIPTION
## Summary

Fix aider not being found on PATH when running as the `vscode` user.

`uv tool install` defaults to `/root/.local/bin/` which is only accessible to root. Setting `UV_TOOL_BIN_DIR=/usr/local/bin` places the symlink where all users can find it.

## Test plan

- [ ] CI linters pass
- [ ] Docker Publish succeeds on amd64 and arm64
- [ ] `docker compose exec dev aider --version` works (as vscode user)
- [ ] `claude-self-test` shows `aider CLI installed: PASS`

Closes #176

🤖 Generated with [Claude Code](https://claude.com/claude-code)