### PR TITLE
fix: place aider uv tool environment in shared /opt/uv-tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -709,7 +709,7 @@ RUN pip install --no-cache-dir --break-system-packages --ignore-installed \
 
 # Aider AI chat — requires Python <3.13, so install isolated with uv + Python 3.12
 # hadolint ignore=DL3059
-RUN UV_TOOL_BIN_DIR=/usr/local/bin \
+RUN UV_TOOL_DIR=/opt/uv-tools UV_TOOL_BIN_DIR=/usr/local/bin \
     uv tool install --python python3.12 aider-chat@latest \
       --with aider-chat[browser] \
       --with aider-chat[help] \


### PR DESCRIPTION
## Summary

Fix permission denied error when running aider as the `vscode` user.

The uv tool venv was installed to `/root/.local/share/uv/tools/` (default), making it inaccessible to non-root users. Setting `UV_TOOL_DIR=/opt/uv-tools` places the environment in a world-readable location.

## Test plan

- [ ] CI linters pass
- [ ] Docker Publish succeeds on amd64 and arm64
- [ ] `docker compose exec dev aider --version` works as vscode user
- [ ] `claude-self-test` shows `aider CLI installed: PASS`

Closes #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)