### PR TITLE
feat: add Bash tool escaping rules to container managed policy

### DIFF
--- a/claude-config/CLAUDE.md
+++ b/claude-config/CLAUDE.md
@@ -71,6 +71,37 @@ to subagents. Perform those operations directly in the main session.
 Use subagents only for knowledge-base search, chat history search,
 and planning/reasoning tasks that don't require filesystem access.
 
+## Bash Tool Escaping
+
+The Bash tool escapes `!` to `\!` on all platforms. This
+happens in the transport layer before the shell receives
+the command. Avoid `!` in all generated Bash commands.
+
+### jq — use `| not` instead of `!=`
+
+| Avoid | Use Instead |
+| ----- | ----------- |
+| `select(.x != "y")` | `select((.x == "y") \| not)` |
+| `if .x != "y"` | `if ((.x == "y") \| not)` |
+
+### Bash — avoid `!` in conditionals
+
+| Avoid | Use Instead |
+| ----- | ----------- |
+| `if ! cmd; then` | `cmd \|\| { handle; }` |
+| `while ! test; do` | `until test; do` |
+
+### Escape hatch — single-quoted heredoc
+
+When `!` is unavoidable, use `<<'EOF'` (single-quoted
+delimiter prevents transport-layer escaping):
+
+    cat <<'SCRIPT' > /tmp/run.sh
+    #!/bin/bash
+    if ! command -v foo; then echo missing; fi
+    SCRIPT
+    bash /tmp/run.sh
+
 ## Self-Test
 
 Run `claude-self-test` to verify container configuration is correct.


### PR DESCRIPTION
## Summary

- Adds a `## Bash Tool Escaping` section to the container's managed policy (`claude-config/CLAUDE.md` → `/etc/claude-code/CLAUDE.md`)
- Documents transport-layer `!` → `\!` escaping with concrete avoidance patterns for jq and Bash conditionals
- Includes single-quoted heredoc escape hatch for cases where `!` is unavoidable

Closes #182

## Test plan

- [ ] Verify `grep -c "Bash Tool Escaping" claude-config/CLAUDE.md` returns `1`
- [ ] Confirm file stays under 200 lines (currently ~102)
- [ ] Super-linter passes (no Markdown lint issues)
- [ ] No Dockerfile changes needed — existing `COPY` picks up the updated file

🤖 Generated with [Claude Code](https://claude.com/claude-code)