### PR TITLE
fix: use correct CLAUDE_CODE_OAUTH_TOKEN env var name

### DIFF
--- a/.devcontainer/scripts/post-start.sh
+++ b/.devcontainer/scripts/post-start.sh
@@ -41,14 +41,8 @@ if [ -n "$OPENAI_API_KEY" ]; then
   fi
 else
   echo "  Mode: direct API (no proxy)"
-  if [ -n "$CLAUDE_OAUTH_TOKEN" ]; then
-    echo "  Auth: Claude Max (OAuth)"
-    if [ -f "$HOME/.claude/.credentials.json" ]; then
-      echo "  Credentials file: present (~/.claude/.credentials.json)"
-    else
-      echo "  WARNING: CLAUDE_OAUTH_TOKEN is set but credentials file is missing"
-      echo "           The entrypoint should have created it — check entrypoint.sh"
-    fi
+  if [ -n "$CLAUDE_CODE_OAUTH_TOKEN" ]; then
+    echo "  Auth: Claude Max (OAuth via CLAUDE_CODE_OAUTH_TOKEN)"
   elif [ -z "$ANTHROPIC_API_KEY" ]; then
     echo "  WARNING: ANTHROPIC_API_KEY is not set — AI tools will not work"
     echo "           Set your key in .env: ANTHROPIC_API_KEY=sk-ant-..."

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -50,18 +50,20 @@ fi
 # ============================================================
 # Claude Code OAuth credentials (Claude Max subscription)
 # ============================================================
-# When CLAUDE_OAUTH_TOKEN is set (sk-ant-oat01-... from `claude setup-token`),
-# write it into ~/.claude/.credentials.json so Claude Code finds it
-# via its plaintext credential storage backend (Linux fallback).
-if [ -n "$CLAUDE_OAUTH_TOKEN" ]; then
+# When CLAUDE_CODE_OAUTH_TOKEN is set (sk-ant-oat01-... from macOS Keychain
+# or `claude setup-token`), also write it into ~/.claude/.credentials.json
+# as a fallback for the plaintext credential storage backend (Linux).
+# Claude Code reads the env var directly, but the file ensures persistence
+# across shell sessions that may not inherit the env var.
+if [ -n "$CLAUDE_CODE_OAUTH_TOKEN" ]; then
   mkdir -p "$HOME/.claude"
   CRED_FILE="$HOME/.claude/.credentials.json"
   if command -v jq >/dev/null 2>&1; then
-    jq -n --arg token "$CLAUDE_OAUTH_TOKEN" \
+    jq -n --arg token "$CLAUDE_CODE_OAUTH_TOKEN" \
       '{"claudeAiOauth": {"accessToken": $token}}' \
       >"$CRED_FILE"
   else
-    printf '{"claudeAiOauth":{"accessToken":"%s"}}\n' "$CLAUDE_OAUTH_TOKEN" \
+    printf '{"claudeAiOauth":{"accessToken":"%s"}}\n' "$CLAUDE_CODE_OAUTH_TOKEN" \
       >"$CRED_FILE"
   fi
   chmod 600 "$CRED_FILE"


### PR DESCRIPTION
## Summary

- Fix env var name from `CLAUDE_OAUTH_TOKEN` to `CLAUDE_CODE_OAUTH_TOKEN`
- Claude Code v2.1.66+ reads this env var natively for OAuth authentication
- Simplify post-start.sh status check (no credentials file check needed)

## Test results

Verified inside container:
```
$ claude auth status
{ "loggedIn": true, "authMethod": "oauth_token", "apiProvider": "firstParty" }

$ claude -p "Reply with exactly: hello world"
hello world
```

Closes #186

🤖 Generated with [Claude Code](https://claude.com/claude-code)