### PR TITLE
feat: configure opencode for Claude Max OAuth with Opus 4.6 default

### DIFF
--- a/.devcontainer/scripts/post-start.sh
+++ b/.devcontainer/scripts/post-start.sh
@@ -43,6 +43,9 @@ else
   echo "  Mode: direct API (no proxy)"
   if [ -n "$CLAUDE_CODE_OAUTH_TOKEN" ]; then
     echo "  Auth: Claude Max (OAuth via CLAUDE_CODE_OAUTH_TOKEN)"
+    if [ -f "$HOME/.local/share/opencode/auth.json" ]; then
+      echo "  opencode: OAuth credentials seeded"
+    fi
   elif [ -z "$ANTHROPIC_API_KEY" ]; then
     echo "  WARNING: ANTHROPIC_API_KEY is not set — AI tools will not work"
     echo "           Set your key in .env: ANTHROPIC_API_KEY=sk-ant-..."

--- a/Dockerfile
+++ b/Dockerfile
@@ -900,6 +900,7 @@ COPY claude-config/self-test.sh /opt/claude-config/self-test.sh
 COPY claude-config/CLAUDE.md /etc/claude-code/CLAUDE.md
 COPY claude-config/claude-proxy.sh /usr/local/lib/claude-proxy.sh
 COPY opencode-config/opencode.json /opt/opencode-config/opencode.json
+COPY opencode-config/opencode-anthropic.json /opt/opencode-config/opencode-anthropic.json
 COPY codex-config/config.toml /opt/codex-config/config.toml
 RUN chmod +x /opt/claude-config/self-test.sh /usr/local/lib/claude-proxy.sh \
     && ln -s /opt/claude-config/self-test.sh /usr/local/bin/claude-self-test \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -50,7 +50,16 @@ fi
 # Seed opencode config if missing
 OPENCODE_CONFIG_DIR="$HOME/.config/opencode"
 if [ ! -f "$OPENCODE_CONFIG_DIR/opencode.json" ] || [ ! -s "$OPENCODE_CONFIG_DIR/opencode.json" ]; then
-  if [ -n "$OPENAI_API_KEY" ] && [ -f /opt/opencode-config/opencode.json ]; then
+  if [ -n "$CLAUDE_CODE_OAUTH_TOKEN" ] && [ -f /opt/opencode-config/opencode-anthropic.json ]; then
+    mkdir -p "$OPENCODE_CONFIG_DIR"
+    cp /opt/opencode-config/opencode-anthropic.json "$OPENCODE_CONFIG_DIR/opencode.json"
+    # Seed OAuth credentials for opencode's Anthropic provider
+    OPENCODE_DATA_DIR="$HOME/.local/share/opencode"
+    mkdir -p "$OPENCODE_DATA_DIR"
+    cat >"$OPENCODE_DATA_DIR/auth.json" <<AUTHEOF
+{"anthropic":{"type":"oauth","access":"${CLAUDE_CODE_OAUTH_TOKEN}","refresh":"","expires":9999999999999}}
+AUTHEOF
+  elif [ -n "$OPENAI_API_KEY" ] && [ -f /opt/opencode-config/opencode.json ]; then
     mkdir -p "$OPENCODE_CONFIG_DIR"
     cp /opt/opencode-config/opencode.json "$OPENCODE_CONFIG_DIR/opencode.json"
   fi

--- a/opencode-config/opencode-anthropic.json
+++ b/opencode-config/opencode-anthropic.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "model": "anthropic/claude-opus-4-6"
+}


### PR DESCRIPTION
## Summary

- Add Anthropic-native opencode config with `claude-opus-4-6` as default model
- Seed `auth.json` with OAuth credentials when `CLAUDE_CODE_OAUTH_TOKEN` is set
- Fall back to existing proxy config when only `OPENAI_API_KEY` is available
- Report opencode OAuth status in post-start checks

Closes #190

## Test plan

- [x] JSON config validates (`python3 -m json.tool`)
- [x] shellcheck passes on modified scripts
- [x] Functional tests: OAuth branch, proxy branch, no-credentials, priority (11/11 pass)
- [x] End-to-end: minimal container with OAuth token → `opencode run "why is the sky blue"` succeeds with `claude-opus-4-6`
- [ ] Full container rebuild and verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)