### PR TITLE
docs: sync documentation with recent codebase changes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,15 @@
 ANTHROPIC_API_KEY=sk-ant-your-api-key-here
 
 # =============================================================================
+# Claude Max (OAuth) — OPTIONAL (alternative to API key)
+# =============================================================================
+# If you have a Claude Max subscription, set your OAuth token instead of an
+# API key.  Get it from Claude Code settings or the Anthropic console.
+# When set, Claude Code and OpenCode both authenticate via OAuth.
+
+# CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-your-token-here
+
+# =============================================================================
 # AI Proxy — OPTIONAL (for OpenAI-compatible providers)
 # =============================================================================
 # Uncomment these lines to route Claude Code through the built-in proxy.

--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -19,6 +19,14 @@ All configuration lives in the `.env` file at the project root. This file is git
 
 In **direct mode** (default), set this to your Anthropic API key (`sk-ant-...`). In **proxy mode**, this can be any non-empty value — the proxy authenticates upstream with `OPENAI_API_KEY` instead.
 
+### Claude Max (OAuth)
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `CLAUDE_CODE_OAUTH_TOKEN` | OAuth token from a Claude Max subscription | `sk-ant-oat01-...` |
+
+When set, both Claude Code and OpenCode authenticate directly with Anthropic using OAuth — no API key or proxy needed. This takes priority over `OPENAI_API_KEY` for OpenCode configuration. Get your token from Claude Code settings or the [Anthropic console](https://console.anthropic.com/).
+
 ### AI Proxy (OpenAI-compatible providers)
 
 When `OPENAI_API_KEY` is set, the container automatically starts a built-in proxy process on `localhost:8082` that translates Claude Code's native Anthropic Messages API calls to OpenAI Chat Completions format. No separate container or compose profile is needed.
@@ -67,11 +75,24 @@ This is **not recommended** for production use. Only set this when you trust the
 
 ### OpenCode
 
-When `OPENAI_API_KEY` and `OPENAI_BASE_URL` are set, the container automatically seeds an [OpenCode](https://opencode.ai/) configuration at `~/.config/opencode/opencode.json`. This configures a custom provider called **OpenAI Proxy** that points at the same upstream endpoint used by the Claude Code proxy.
+The container automatically configures [OpenCode](https://opencode.ai/) based on which credentials are available. OAuth mode takes priority when both are set.
+
+#### OAuth mode (Claude Max)
+
+When `CLAUDE_CODE_OAUTH_TOKEN` is set, the entrypoint seeds:
+
+- `~/.config/opencode/opencode.json` — Anthropic-native config with `claude-opus-4-6` as the default model
+- `~/.local/share/opencode/auth.json` — OAuth credentials for Anthropic
+
+This connects OpenCode directly to Anthropic with no proxy needed.
+
+#### Proxy mode (OpenAI-compatible)
+
+When `OPENAI_API_KEY` and `OPENAI_BASE_URL` are set (and no OAuth token), the entrypoint seeds `~/.config/opencode/opencode.json` with a custom provider called **OpenAI Proxy** that points at the same upstream endpoint used by the Claude Code proxy.
 
 The config uses OpenCode's `{env:VAR_NAME}` syntax, so credentials are resolved from environment variables at runtime — no secrets are baked into the file.
 
-Available models:
+Available models (proxy mode):
 
 | Model ID | Description |
 |----------|-------------|
@@ -80,7 +101,20 @@ Available models:
 | `claude-opus-4-6` | Claude Opus 4.6 |
 | `claude-haiku-4-5` | Claude Haiku 4.5 |
 
-The config is only seeded when the file doesn't already exist, so you can customize it without it being overwritten on restart. To reset to defaults, delete `~/.config/opencode/opencode.json` and restart the container.
+In both modes, the config is only seeded when the file doesn't already exist, so you can customize it without it being overwritten on restart. To reset to defaults, delete `~/.config/opencode/opencode.json` (and `~/.local/share/opencode/auth.json` for OAuth mode) and restart the container.
+
+### AI Coding Agents
+
+The container includes several AI coding agents in addition to Claude Code:
+
+| Agent | Command | Provider |
+|-------|---------|----------|
+| [OpenCode](https://opencode.ai/) | `opencode` | Anthropic (OAuth) or OpenAI-compatible (proxy) |
+| [Codex](https://github.com/openai/codex) | `codex` | OpenAI-compatible (proxy mode only) |
+| [Aider](https://aider.chat/) | `aider` | Multi-provider (configure at runtime) |
+| [Pi](https://github.com/mariozechner/pi-coding-agent) | `pi` | Multi-provider (configure at runtime) |
+
+Aider is installed via `uv tool install` with Python 3.12 (it requires Python &lt;3.13) and includes the `browser`, `help`, and `playwright` extras. Pi is installed as a global npm package. Codex is a standalone binary that self-updates at runtime.
 
 ### Web Search (SearXNG MCP)
 

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -95,13 +95,25 @@ curl -fsSLO https://raw.githubusercontent.com/f5xc-salesdemos/devcontainer/main/
 
 ## 2. Add Your API Key (Optional)
 
-Create a `.env` file in the same folder to pre-configure Claude Code:
+Create a `.env` file in the same folder to pre-configure Claude Code. Choose one of the following options:
+
+### Option A: Anthropic API key
 
 ```ini
 ANTHROPIC_API_KEY=sk-ant-your-key-here
 ```
 
-If you use an OpenAI-compatible provider instead, see [Configuration](./configuration) for proxy setup.
+### Option B: Claude Max (OAuth)
+
+If you have a Claude Max subscription, use your OAuth token instead:
+
+```ini
+CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-your-token-here
+```
+
+### Option C: OpenAI-compatible provider
+
+See [Configuration](./configuration) for proxy setup with any OpenAI-compatible endpoint.
 
 ## 3. Start
 
@@ -150,6 +162,8 @@ podman compose exec dev zsh
 claude --version
 opencode --version
 codex --version
+aider --version
+pi --version
 
 # Languages
 node --version

--- a/docs/local-development.mdx
+++ b/docs/local-development.mdx
@@ -28,7 +28,9 @@ cd devcontainer
 ├── entrypoint.sh               # Container startup script
 ├── .env.example                # Example environment variables
 ├── docs/                       # Documentation site (Starlight)
-└── claude-config/              # Claude Code configuration files
+├── claude-config/              # Claude Code configuration files
+├── opencode-config/            # OpenCode provider templates (OAuth + proxy)
+└── codex-config/               # Codex configuration
 ```
 
 ## Build File
@@ -99,14 +101,15 @@ These layers only rebuild when a version ARG is bumped or APT packages change. O
 
 | Section | Contents |
 |---------|----------|
-| 1. APT repos | NodeSource, deadsnakes, HashiCorp, GitHub, Docker, Microsoft |
+| 1. APT repos | NodeSource, deadsnakes, HashiCorp, GitHub, Docker, Microsoft, Google Cloud, Dart SDK |
 | 2. APT packages | System tools, Node.js, Python, Java, Terraform, GitHub CLI, Docker engine, Azure CLI, PowerShell, locales |
+| 2b. Security APT packages | Network analysis, web scanners, password tools, reverse engineering, forensics (~80 packages) |
 | 3. Python bootstrap | Symlinks + pip via get-pip.py |
-| 4. Go | Official tarball (pinned version) |
-| 5. Rust | rustup (system-wide, pinned version) |
+| 4. Go | Official tarball (latest stable, resolved at build time) |
+| 5. Rust | rustup (system-wide, latest stable) |
 | 6. Maven + Gradle | Binary downloads to `/opt` |
 | 7. VNC stack | Xvfb, x11vnc, noVNC, fluxbox — remote display via browser |
-| 8. Nerd Fonts | JetBrainsMono, Hack, FiraCode (version-pinned) |
+| 8. Nerd Fonts | JetBrainsMono, Hack, FiraCode (latest releases) |
 
 ### Stage 2: `final` (volatile tools + user setup, ~1.5 GB)
 
@@ -116,16 +119,31 @@ These layers change more frequently (npm/pip updates, config changes) but rebuil
 |---------|----------|
 | 9. AWS CLI v2 | Official installer |
 | 10. Binary tools | kubectl, helm, tflint, terraform-docs, act, actionlint, yt-dlp, uv, opencode |
-| 10b. Additional binaries | VS Code CLI, oc, yq, terragrunt, ibmcloud, fzf, hadolint |
-| 11. npm global tools | claude-code, codex, prettier, markdownlint-cli2, openclaw, devcontainers-cli, playwright |
+| 10b. Additional binaries | VS Code CLI, oc, yq, terragrunt, ibmcloud, fzf, hadolint, codex |
+| 10c. Super-linter binaries | shfmt, gitleaks, editorconfig-checker, trivy, clj-kondo, dotenv-linter, golangci-lint, goreleaser, kubeconform, protolint, scalafmt, ktlint |
+| 10d. Java JAR tools | checkstyle, google-java-format (wrapper scripts) |
+| 10e. PHP linters | phpcs, phpstan, psalm (PHAR downloads) |
+| 10f. PowerShell modules | PSScriptAnalyzer, arm-ttk |
+| 10g. Security binaries | nuclei, subfinder, httpx, ffuf, gobuster, feroxbuster, dalfox, amass, trufflehog, grype, syft, bettercap (amd64) |
+| 10h. OWASP ZAP | Java-based web application scanner |
+| 10i. Ghidra | Reverse engineering framework |
+| 10j. Metasploit | Exploitation framework (amd64 only) |
+| 11. npm global tools | claude-code, prettier, markdownlint-cli2, openclaw, devcontainers-cli, playwright, pi-coding-agent |
 | 12. pip tools | pre-commit, ansible, black, pylint, yamllint, playwright |
 | 12b. Claude Code Proxy | OpenAI-compatible translation proxy |
 | 12c. SearXNG MCP server | stdio MCP server for web search |
+| 12d. Ruby linters | rubocop + extensions |
+| 12e. Perl linter modules | Perl::Critic extensions |
+| 12f. Lua linter | luacheck |
+| 12g. R linter | lintr |
+| 12h. Security Ruby gems | wpscan, evil-winrm |
+| 12i. Git-cloned security tools | testssl.sh, exploitdb (searchsploit), SecLists, docker-bench-security, recon-ng, spiderfoot |
 | 13. Playwright browsers | Chromium + system deps via `playwright install --with-deps` |
 | 14. Homebrew | Linuxbrew (needed by openclaw configure) |
+| 14b. Aider | `uv tool install` with Python 3.12 (browser, help, playwright extras) |
 | 15. ZSH plugins | oh-my-zsh custom plugins |
 | 16. Shell bootstrap | npm-global, tfenv, compinit |
-| 17. Claude Code + OpenCode config | Tool awareness memory, managed policy, self-test script, OpenCode provider template |
+| 17. Claude Code + OpenCode + Codex config | Tool awareness memory, managed policy, self-test script, OpenCode provider templates, Codex config |
 | 18. Entrypoint | Container startup script (absolute last COPY) |
 
 ## Adding Tools

--- a/docs/security.mdx
+++ b/docs/security.mdx
@@ -105,6 +105,25 @@ The `docker-compose.yml` applies several defense-in-depth measures:
 - **Private proxy logs** — Proxy logs are written to `~/.local/share/claude-proxy/proxy.log` under the user's home directory (created with restrictive permissions), not to world-readable `/tmp`.
 - **SSH key umask** — SSH private keys are written under `umask 077`, so the file is never world-readable — even briefly — between creation and the `chmod` call.
 
+### Security and Penetration Testing Tools
+
+The container includes approximately 80 pre-installed security and penetration testing tools for authorized testing scenarios. Tools are organized by category:
+
+| Category | Tools (examples) |
+|----------|-----------------|
+| Network analysis | tshark, wireshark, masscan, hping3, bettercap (amd64), netdiscover |
+| Web scanners | nikto, sqlmap, dirb, whatweb, sslscan, OWASP ZAP, dalfox, feroxbuster |
+| Password and authentication | hydra, john, hashcat, medusa, ncrack |
+| Reverse engineering | radare2, Ghidra, gdb, binwalk, strace, ltrace |
+| Reconnaissance | subfinder, amass, httpx, nuclei, gau, waybackurls, recon-ng, spiderfoot |
+| Fuzzing and enumeration | ffuf, gobuster, SecLists |
+| Supply chain and secrets | trufflehog, grype, syft, gitleaks, trivy |
+| Exploitation frameworks | Metasploit (amd64), searchsploit (ExploitDB) |
+
+Some tools (bettercap, Metasploit) are only available on amd64 due to upstream packaging constraints. Packet capture tools (tshark, bettercap) require the `NET_ADMIN` capability, which is included in the default `docker-compose.yml`.
+
+For the complete list, run `claude-self-test` inside the container (section 7 checks all security tools).
+
 ## Compliance Checklist
 
 | Requirement | Status |

--- a/docs/troubleshooting.mdx
+++ b/docs/troubleshooting.mdx
@@ -97,6 +97,18 @@ Common causes:
 
 - **Key doesn't start with `sk-ant-`** — Anthropic API keys always start with `sk-ant-`. If yours doesn't, it may be for a different provider. Use the proxy mode above, or get a direct key from [console.anthropic.com](https://console.anthropic.com/).
 
+### OpenCode shows "Model not found"
+
+If using Claude Max OAuth, check that the auth credentials were seeded:
+
+```bash
+cat ~/.local/share/opencode/auth.json
+```
+
+The file should contain an `"anthropic"` key with your OAuth token. If missing, verify `CLAUDE_CODE_OAUTH_TOKEN` is set in `.env` and restart the container.
+
+To reset OpenCode config: delete `~/.config/opencode/opencode.json` and `~/.local/share/opencode/auth.json`, then restart.
+
 ### Claude shows "Connection error"
 
 The built-in proxy may not be running. Check:


### PR DESCRIPTION
## Summary

- Add Claude Max OAuth (`CLAUDE_CODE_OAUTH_TOKEN`) documentation across `.env.example`, getting-started, configuration, and troubleshooting pages
- Rewrite OpenCode section to cover both OAuth mode (Anthropic-native, Opus 4.6 default) and proxy mode
- Add new "AI Coding Agents" section documenting Aider, Pi, Codex, and OpenCode in a single table
- Add "Security and Penetration Testing Tools" section to security.mdx with category overview of ~80 pre-installed tools
- Fix incorrect "pinned version" claims for Go, Rust, and Nerd Fonts (now dynamically resolved at build time)
- Update Stage 1/2 tables in local-development.mdx with all missing Dockerfile sections (10c–10j, 12d–12i, Aider)
- Add `opencode-config/` and `codex-config/` to project structure tree

Closes #192

## Test plan

- [ ] Verify docs build succeeds with no MDX syntax errors
- [ ] Grep for `CLAUDE_CODE_OAUTH_TOKEN` — should appear in configuration.mdx, getting-started.mdx, troubleshooting.mdx, .env.example
- [ ] Grep for `aider` — should appear in configuration.mdx, getting-started.mdx
- [ ] Verify no docs page claims Go/Rust/Fonts are "pinned"
- [ ] Review rendered pages for formatting correctness

🤖 Generated with [Claude Code](https://claude.com/claude-code)