### PR TITLE
feat: add git history rewriting tools (git-filter-repo, BFG)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -515,8 +515,8 @@ RUN ghlatest() { curl -fsSL -o /dev/null -w '%{url_effective}' "https://github.c
     # BFG Repo Cleaner (git history rewriting)
     && BFG_VERSION=$(ghlatest rtyley/bfg-repo-cleaner) \
     && curl ${CURL_RETRY} -fsSL \
-         "https://repo1.maven.org/maven2/com/madgag/bfg/${BFG_VERSION}/bfg-${BFG_VERSION}.jar" \
-         -o /opt/bfg.jar \
+      "https://repo1.maven.org/maven2/com/madgag/bfg/${BFG_VERSION}/bfg-${BFG_VERSION}.jar" \
+      -o /opt/bfg.jar \
     && printf '#!/bin/sh\nexec java -jar /opt/bfg.jar "$@"\n' > /usr/local/bin/bfg \
     && chmod +x /usr/local/bin/bfg
 


### PR DESCRIPTION
## Summary

Add `git-filter-repo` and BFG Repo Cleaner to the devcontainer for git history rewriting tasks.

## Related Issue

Closes #202

## Changes

- Add `git-filter-repo` to the pip install block (section 12)
- Add BFG Repo Cleaner JAR download from Maven Central and wrapper script to Java JAR tools section (section 10d), following the existing checkstyle/google-java-format pattern

## Checklist

- [x] Linked to a GitHub issue (required — CI will block merge without it)
- [x] Tested locally
- [x] Follows project conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)