### PR TITLE
feat: add 9 formatters and enable opencode permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -490,7 +490,16 @@ RUN ghlatest() { curl -fsSL -o /dev/null -w '%{url_effective}' "https://github.c
     # ktlint (runnable JAR — arch-independent, needs Java)
     && curl ${CURL_RETRY} -fsSLo /usr/local/bin/ktlint \
       "https://github.com/pinterest/ktlint/releases/latest/download/ktlint" \
-    && chmod +x /usr/local/bin/ktlint
+    && chmod +x /usr/local/bin/ktlint \
+    # cljfmt (GraalVM native binary — Clojure formatter)
+    && CLJFMT_VERSION=$(ghlatest weavejester/cljfmt) \
+    && if [ "$DPKG_ARCH" = "amd64" ]; then CLJFMT_ARCH="amd64-static"; else CLJFMT_ARCH="aarch64"; fi \
+    && curl ${CURL_RETRY} -fsSL "https://github.com/weavejester/cljfmt/releases/latest/download/cljfmt-${CLJFMT_VERSION}-linux-${CLJFMT_ARCH}.tar.gz" \
+      | tar -xz -C /usr/local/bin cljfmt \
+    # gleam (static musl binary — Gleam formatter)
+    && GLEAM_VERSION=$(ghlatest gleam-lang/gleam) \
+    && curl ${CURL_RETRY} -fsSL "https://github.com/gleam-lang/gleam/releases/latest/download/gleam-v${GLEAM_VERSION}-${UNAME_ARCH}-unknown-linux-musl.tar.gz" \
+      | tar -xz -C /usr/local/bin gleam
 
 # ============================================================
 # 10d. Java JAR tools (checkstyle, google-java-format)
@@ -532,7 +541,11 @@ RUN curl ${CURL_RETRY} -fsSLo /usr/local/bin/phpcs \
     && chmod +x /usr/local/bin/phpstan \
     && curl ${CURL_RETRY} -fsSLo /usr/local/bin/psalm \
       "https://github.com/vimeo/psalm/releases/latest/download/psalm.phar" \
-    && chmod +x /usr/local/bin/psalm
+    && chmod +x /usr/local/bin/psalm \
+    # pint (Laravel PHP formatter — PHAR download, NOT the Homebrew "pint")
+    && curl ${CURL_RETRY} -fsSLo /usr/local/bin/pint \
+      "https://github.com/laravel/pint/releases/latest/download/pint.phar" \
+    && chmod +x /usr/local/bin/pint
 
 # ============================================================
 # 10f. PowerShell modules (PSScriptAnalyzer + arm-ttk)
@@ -802,7 +815,9 @@ RUN gem install --no-document \
     rubocop-rails \
     rubocop-rake \
     rubocop-rspec \
-    rubocop-minitest
+    rubocop-minitest \
+    htmlbeautifier \
+    standardrb
 
 # ============================================================
 # 12e. Perl linter modules (Perl::Critic extensions via cpanm)
@@ -950,9 +965,10 @@ RUN NONINTERACTIVE=1 /bin/bash -c "$(curl ${CURL_RETRY} -fsSL https://raw.github
 ENV HOMEBREW_NO_AUTO_UPDATE=1
 ENV PATH="/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:${PATH}"
 
-# AI assistant tool dependencies (no APT packages available)
+# AI assistant deps + formatters (no APT packages available)
 # hadolint ignore=DL3059
 RUN brew install ada-url hdrhistogram_c icu4c@78 llhttp uvwasi \
+      air dfmt nixfmt ormolu oxfmt \
     && brew cleanup --prune=all -s
 
 # ============================================================

--- a/claude-config/self-test.sh
+++ b/claude-config/self-test.sh
@@ -117,6 +117,17 @@ check "xmllint installed" command -v xmllint
 check "chktex installed" command -v chktex
 check "clippy available" rustup component list --installed
 check "rustfmt available" command -v rustfmt
+# Additional formatters
+check "cljfmt installed" command -v cljfmt
+check "gleam installed" command -v gleam
+check "pint installed" command -v pint
+check "htmlbeautifier installed" command -v htmlbeautifier
+check "standardrb installed" command -v standardrb
+check "air installed" command -v air
+check "dfmt installed" command -v dfmt
+check "nixfmt installed" command -v nixfmt
+check "ormolu installed" command -v ormolu
+check "oxfmt installed" command -v oxfmt
 # PowerShell modules
 check "PSScriptAnalyzer installed" pwsh -NoProfile -Command 'Get-Module -ListAvailable PSScriptAnalyzer'
 check "arm-ttk installed" test -f /usr/lib/microsoft/arm-ttk/arm-ttk/arm-ttk.psd1

--- a/opencode-config/opencode-anthropic.json
+++ b/opencode-config/opencode-anthropic.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://opencode.ai/config.json",
+  "permission": "allow",
   "model": "anthropic/claude-opus-4-6"
 }

--- a/opencode-config/opencode.json
+++ b/opencode-config/opencode.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://opencode.ai/config.json",
+  "permission": "allow",
   "provider": {
     "openai-proxy": {
       "npm": "@ai-sdk/openai-compatible",


### PR DESCRIPTION
## Summary

- Add 9 formatters from the Claude Code supported list: cljfmt, gleam, pint, htmlbeautifier, standardrb, air, dfmt, nixfmt, ormolu, oxfmt (~95 MB total)
- Enable all opencode tool permissions by default (`"permission": "allow"`) in both config files
- Add self-test checks for all 10 new formatters

## Changes

### Dockerfile
- **Section 10c**: Add cljfmt (GraalVM binary) and gleam (musl binary) downloads
- **Section 10e**: Add pint PHAR download (Laravel PHP formatter)
- **Section 12d**: Add htmlbeautifier and standardrb gems
- **Section 14**: Add air, dfmt, nixfmt, ormolu, oxfmt to brew install

### claude-config/self-test.sh
- Add 10 formatter verification checks

### opencode-config/opencode.json & opencode-anthropic.json
- Add `"permission": "allow"` to enable all tool permissions by default

## Skipped formatters (too heavy)
- mix (~500 MB Erlang/OTP)
- ocamlformat (~300 MB opam)
- zig (~200 MB)

## Test plan

- [ ] CI super-linter passes (hadolint, shellcheck)
- [ ] Docker image builds on both amd64 and arm64
- [ ] All 10 formatters pass self-test checks inside the container

Closes #206

🤖 Generated with [Claude Code](https://claude.com/claude-code)