### PR TITLE
fix: remove noVNC URL echo from entrypoint startup

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -154,7 +154,6 @@ if [ "${ENABLE_VNC:-true}" = "true" ]; then
       websockify --web /usr/share/novnc "${NOVNC_PORT}" localhost:"${VNC_PORT}" >/dev/null 2>&1 &
     fi
 
-    echo "noVNC: http://localhost:${NOVNC_PORT}/vnc.html"
   ) &
 fi
 


### PR DESCRIPTION
## Summary

- Remove the `noVNC: http://localhost:6080/vnc.html` echo from the VNC startup subshell in `entrypoint.sh`
- Interactive CLI users don't need this message — the port is documented and discoverable
- Follow-up to #208 which suppressed the other VNC daemon noise

Closes #210

## Test plan

- [ ] `podman run --rm -it ghcr.io/f5xc-salesdemos/devcontainer:latest bash` — should show no VNC-related output at all
- [ ] VNC still works at `http://localhost:6080/vnc.html`
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)