### PR TITLE
feat: add Tailscale VPN client to devcontainer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -70,3 +70,13 @@ GIT_AUTHOR_NAME="Your Name"
 # Only needed when another devcontainer instance is already using the defaults.
 
 # NOVNC_HOST_PORT=7080
+
+# =============================================================================
+# Tailscale VPN — OPTIONAL
+# =============================================================================
+# Connect the container to your Tailscale network for secure access to
+# private resources.  Generate an auth key at:
+#   https://login.tailscale.com/admin/settings/keys
+
+# ENABLE_TAILSCALE=true
+# TAILSCALE_AUTHKEY=tskey-auth-your-key-here

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,6 +58,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       | gpg --dearmor -o /usr/share/keyrings/dart-archive-keyring.gpg \
     && echo "deb [signed-by=/usr/share/keyrings/dart-archive-keyring.gpg] https://storage.googleapis.com/download.dartlang.org/linux/debian stable main" \
       > /etc/apt/sources.list.d/dart_stable.list \
+    # Tailscale
+    && curl ${CURL_RETRY} -fsSL https://pkgs.tailscale.com/stable/ubuntu/noble.noarmor.gpg \
+      -o /usr/share/keyrings/tailscale-archive-keyring.gpg \
+    && echo "deb [signed-by=/usr/share/keyrings/tailscale-archive-keyring.gpg] https://pkgs.tailscale.com/stable/ubuntu noble main" \
+      > /etc/apt/sources.list.d/tailscale.list \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # ============================================================
@@ -71,6 +76,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ffmpeg poppler-utils qrencode \
     # Network tools
     dnsutils net-tools iputils-ping traceroute tcpdump nmap netcat-openbsd \
+    # Tailscale VPN
+    tailscale \
     # Shell tools
     bat fd-find ripgrep neovim htop tree tmux file \
     # Node.js

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -157,4 +157,22 @@ if [ "${ENABLE_VNC:-true}" = "true" ]; then
   ) &
 fi
 
+# ============================================================
+# Tailscale (userspace networking)
+# ============================================================
+if [ "${ENABLE_TAILSCALE:-false}" = "true" ]; then
+  sudo tailscaled --tun=userspace-networking --state=/var/lib/tailscale/tailscaled.state >/dev/null 2>&1 &
+  if [ -n "$TAILSCALE_AUTHKEY" ]; then
+    (
+      retries=0
+      while [ $retries -lt 50 ]; do
+        sudo tailscale status >/dev/null 2>&1 && break
+        sleep 0.1
+        retries=$((retries + 1))
+      done
+      sudo tailscale up --authkey="$TAILSCALE_AUTHKEY" --accept-routes >/dev/null 2>&1
+    ) &
+  fi
+fi
+
 exec "$@"


### PR DESCRIPTION
## Summary

Add the Tailscale VPN client to the devcontainer Docker image so users can join a Tailscale network from inside the container for secure access to private resources during development and demos.

## Related Issue

Closes #212

## Changes

- Add Tailscale APT repository to Dockerfile (Section 1)
- Install `tailscale` package in Dockerfile (Section 2)
- Add Tailscale daemon startup block in `entrypoint.sh` (userspace networking, opt-in via `ENABLE_TAILSCALE=true`)
- Add `ENABLE_TAILSCALE` and `TAILSCALE_AUTHKEY` env vars to `.env.example`

## Checklist

- [x] Linked to a GitHub issue (required — CI will block merge without it)
- [x] Tested locally
- [x] Follows project conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)