### PR TITLE
fix: make VNC stack opt-in by defaulting ENABLE_VNC to false

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,6 +64,17 @@ GIT_AUTHOR_NAME="Your Name"
 # SSH_PRIVATE_KEY=
 
 # =============================================================================
+# VNC Remote Desktop — OPTIONAL
+# =============================================================================
+# Start the VNC stack (Xvfb + fluxbox + x11vnc + noVNC) for GUI access.
+# Access via browser at http://localhost:6080
+
+# ENABLE_VNC=true
+# VNC_RESOLUTION=1280x1024x24
+# VNC_PORT=5900
+# NOVNC_PORT=6080
+
+# =============================================================================
 # Port Overrides — OPTIONAL (for running multiple containers)
 # =============================================================================
 # Override host-side ports to avoid conflicts when running multiple containers.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -116,7 +116,7 @@ start_claude_proxy
 # ============================================================
 # VNC stack (Xvfb + fluxbox + x11vnc + noVNC)
 # ============================================================
-if [ "${ENABLE_VNC:-true}" = "true" ]; then
+if [ "${ENABLE_VNC:-false}" = "true" ]; then
   VNC_RESOLUTION="${VNC_RESOLUTION:-1280x1024x24}"
   VNC_PORT="${VNC_PORT:-5900}"
   NOVNC_PORT="${NOVNC_PORT:-6080}"


### PR DESCRIPTION
## Summary

Make the VNC stack (Xvfb + fluxbox + x11vnc + noVNC) opt-in instead of starting by default, consistent with all other daemons in the entrypoint.

## Related Issue

Closes #214

## Changes

- Change `ENABLE_VNC` default from `true` to `false` in `entrypoint.sh`
- Add VNC configuration section to `.env.example` with commented-out `ENABLE_VNC=true` and related settings

## Checklist

- [x] Linked to a GitHub issue (required — CI will block merge without it)
- [x] Tested locally
- [x] Follows project conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)