### PR TITLE
fix: add configs/ to .dockerignore allowlist

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,4 @@
 !claude-config/
 !opencode-config/
 !codex-config/
+!configs/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1018,7 +1018,7 @@ RUN mkdir -p "$HOME/.npm-global" \
     && git clone --depth=1 https://github.com/tfutils/tfenv.git "$HOME/.tfenv" \
     && zsh -c "autoload -U compinit && compinit" 2>/dev/null || true
 
-COPY --chown=${USERNAME}:${USERNAME} configs/.p10k.zsh $HOME/.p10k.zsh
+COPY --chown=${USERNAME}:${USERNAME} configs/.p10k.zsh /home/${USERNAME}/.p10k.zsh
 
 # ============================================================
 # 17. Claude Code configuration (self-test + managed policy)


### PR DESCRIPTION
## Summary

- Add `!configs/` to `.dockerignore` so `configs/.p10k.zsh` is available during Docker build
- Use `/home/${USERNAME}/.p10k.zsh` instead of `$HOME/.p10k.zsh` in COPY destination for reliable path resolution

## Test plan

- [ ] Docker Publish workflow passes (both amd64 and arm64)
- [ ] Container has `~/.p10k.zsh` at the correct path

Closes #218

🤖 Generated with [Claude Code](https://claude.com/claude-code)