### PR TITLE
fix: prime tfenv with latest Terraform at build time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1016,6 +1016,8 @@ RUN ZSH_CUSTOM="${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}" \
 RUN mkdir -p "$HOME/.npm-global" \
     && npm config set prefix "$HOME/.npm-global" \
     && git clone --depth=1 https://github.com/tfutils/tfenv.git "$HOME/.tfenv" \
+    && "$HOME/.tfenv/bin/tfenv" install latest \
+    && "$HOME/.tfenv/bin/tfenv" use latest \
     && zsh -c "autoload -U compinit && compinit" 2>/dev/null || true
 
 COPY --chown=${USERNAME}:${USERNAME} configs/.p10k.zsh /home/${USERNAME}/.p10k.zsh


### PR DESCRIPTION
## What type of PR is this?

Bug fix — tfenv shim fails because no Terraform version is installed via tfenv.

## What does this PR do?

Adds `tfenv install latest && tfenv use latest` after the tfenv clone in the Dockerfile so that the latest Terraform version is installed and activated at image build time.

## Why is this needed?

The `zsh-tfenv` ZSH plugin prepends `$HOME/.tfenv/bin` to PATH, making tfenv's `terraform` shim take precedence over the APT-installed binary. Without a version installed via tfenv, any `terraform` command fails with:

```
cat: /home/vscode/.tfenv/version: No such file or directory
Version could not be resolved (set by /home/vscode/.tfenv/version or tfenv use <version>)
```

## Verification

```bash
docker build -t devcontainer-test .
docker run --rm devcontainer-test zsh -lc 'terraform --version'
docker run --rm devcontainer-test cat /home/vscode/.tfenv/version
docker run --rm devcontainer-test zsh -lc 'tfenv list'
```

Closes #222

🤖 Generated with [Claude Code](https://claude.com/claude-code)