### PR TITLE
fix: pre-fetch gitstatusd at build time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -998,6 +998,7 @@ RUN ZSH_CUSTOM="${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}" \
       "${ZSH_CUSTOM}/plugins/zsh-aliases-lsd" \
     && git clone --depth=1 https://github.com/romkatv/powerlevel10k.git \
       "${ZSH_CUSTOM}/themes/powerlevel10k" \
+    && "${ZSH_CUSTOM}/themes/powerlevel10k/gitstatus/install" \
     && sed -i 's/^ZSH_THEME=.*/ZSH_THEME="powerlevel10k\/powerlevel10k"/' "$HOME/.zshrc" \
     && sed -i 's/^plugins=(.*/plugins=(zsh-syntax-highlighting zsh-autosuggestions zsh-interactive-cd ubuntu jsontools gh common-aliases zsh-aliases-lsd zsh-tfenv conda-zsh-completion z pip terraform fluxcd azure git-auto-fetch helm istioctl iterm2 kube-ps1 kubectl sudo vscode aws fzf docker history colored-man-pages command-not-found)/' \
       "$HOME/.zshrc" \


### PR DESCRIPTION
## What type of PR is this?

Bug fix — eliminates confusing `[powerlevel10k] fetching gitstatusd` message on first shell launch.

## What does this PR do?

Runs the gitstatus install script during the Docker build (after cloning powerlevel10k) to pre-cache the `gitstatusd` binary in the image.

## Why is this needed?

When launching zsh in a new container, users see:

```
[powerlevel10k] fetching gitstatusd .. [ok]
```

This is confusing because it looks like something is being downloaded/installed. The binary wasn't pre-cached, so p10k downloaded it on every first shell launch. Pre-fetching at build time eliminates this message entirely.

## Verification

```bash
podman pull ghcr.io/f5xc-salesdemos/devcontainer:latest
podman run --rm -it ghcr.io/f5xc-salesdemos/devcontainer:latest zsh
# Should NOT show "[powerlevel10k] fetching gitstatusd" message
```

Closes #224

🤖 Generated with [Claude Code](https://claude.com/claude-code)