### PR TITLE
feat: add neovim configuration to devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -42,7 +42,7 @@
   },
 
   "containerEnv": {
-    "EDITOR": "vim",
+    "EDITOR": "nvim",
     "TERM": "xterm-256color",
     "COLORTERM": "truecolor",
     "LANG": "en_US.UTF-8",

--- a/Dockerfile
+++ b/Dockerfile
@@ -961,7 +961,7 @@ RUN mkdir -p /home/linuxbrew/.linuxbrew \
 USER $USERNAME
 WORKDIR /home/$USERNAME
 
-RUN mkdir -p ~/.cache ~/.local/bin ~/.claude \
+RUN mkdir -p ~/.cache ~/.local/bin ~/.claude ~/.config/nvim \
     && echo '{"hasCompletedOnboarding": true}' > ~/.claude.json.default
 
 # ============================================================
@@ -1008,7 +1008,8 @@ RUN ZSH_CUSTOM="${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}" \
     && echo 'export HISTSIZE=50000' >> "$HOME/.zshrc" \
     && echo 'export SAVEHIST=50000' >> "$HOME/.zshrc" \
     && echo '[[ ! -f ~/.p10k.zsh ]] || source ~/.p10k.zsh' >> "$HOME/.zshrc" \
-    && echo 'export PATH="$HOME/.npm-global/bin:$PATH"' >> "$HOME/.zshrc"
+    && echo 'export PATH="$HOME/.npm-global/bin:$PATH"' >> "$HOME/.zshrc" \
+    && echo 'alias vim=nvim' >> "$HOME/.zshrc"
 
 # ============================================================
 # 16. User shell bootstrap (baked in — eliminates runtime setup)
@@ -1022,6 +1023,7 @@ RUN mkdir -p "$HOME/.npm-global" \
     && zsh -c "autoload -U compinit && compinit" 2>/dev/null || true
 
 COPY --chown=${USERNAME}:${USERNAME} configs/.p10k.zsh /home/${USERNAME}/.p10k.zsh
+COPY --chown=${USERNAME}:${USERNAME} configs/init.vim /home/${USERNAME}/.config/nvim/init.vim
 
 # ============================================================
 # 17. Claude Code configuration (self-test + managed policy)

--- a/configs/init.vim
+++ b/configs/init.vim
@@ -1,0 +1,90 @@
+" ============================================================
+" Neovim configuration — built-in only (no plugin manager)
+" Complements the p10k rainbow prompt theme with 'industry'
+" ============================================================
+
+" --- Visual ---
+set termguicolors
+set background=dark
+colorscheme industry
+set number
+set relativenumber
+set cursorline
+set signcolumn=yes
+set colorcolumn=120
+set showmode
+set showcmd
+set title
+
+" --- Indentation ---
+set expandtab
+set tabstop=2
+set shiftwidth=2
+set softtabstop=2
+set smartindent
+set shiftround
+
+" --- Search ---
+set ignorecase
+set smartcase
+set incsearch
+set hlsearch
+
+" --- Navigation ---
+set scrolloff=8
+set sidescrolloff=8
+set mouse=a
+set splitright
+set splitbelow
+
+" --- Performance ---
+set lazyredraw
+set updatetime=250
+
+" --- Temp directories ---
+silent! call mkdir('/tmp/nvim-undo', 'p')
+silent! call mkdir('/tmp/nvim-backup', 'p')
+silent! call mkdir('/tmp/nvim-swap', 'p')
+
+" --- Files ---
+set undofile
+set undodir=/tmp/nvim-undo//
+set backup
+set backupdir=/tmp/nvim-backup//
+set directory=/tmp/nvim-swap//
+set autoread
+
+" --- Editing ---
+set backspace=indent,eol,start
+set wildmenu
+set wildmode=longest:full,full
+set showmatch
+set matchtime=2
+set nojoinspaces
+set formatoptions+=j
+set hidden
+set confirm
+
+" --- Neovim-specific ---
+set clipboard=unnamedplus
+set inccommand=split
+
+" --- Statusline ---
+set laststatus=2
+set statusline=
+set statusline+=%#PmenuSel#
+set statusline+=\ %{toupper(mode())}\
+set statusline+=%#LineNr#
+set statusline+=\ %f
+set statusline+=%m
+set statusline+=%=
+set statusline+=\ %y
+set statusline+=\ %l:%c
+set statusline+=\ %p%%\
+
+" --- Keymaps ---
+" Clear search highlight with Escape
+nnoremap <Esc> :nohlsearch<CR>
+" Keep selection when indenting in visual mode
+vnoremap < <gv
+vnoremap > >gv


### PR DESCRIPTION
## Summary

- Add built-in-only neovim config (`configs/init.vim`) using the `industry` colorscheme to complement the p10k rainbow prompt theme
- Set `EDITOR=nvim` in `devcontainer.json` (was `vim` but only neovim is installed)
- Add `alias vim=nvim` to `.zshrc` for muscle-memory compatibility
- COPY `init.vim` into `~/.config/nvim/` in the Docker image

Config includes: visual settings (termguicolors, line numbers, cursorline, signcolumn), 2-space indentation, smart search, navigation (scrolloff=8, splitright/below), undo/backup/swap to `/tmp`, built-in statusline, and useful keymaps.

No plugin manager — all settings use neovim built-ins only.

Closes #226

## Test plan

- [ ] `nvim --headless -c 'echo g:colors_name' -c 'q'` outputs `industry`
- [ ] `zsh -lc 'which vim'` shows `vim: aliased to nvim`
- [ ] `zsh -lc 'echo $EDITOR'` outputs `nvim`
- [ ] `nvim --headless -c 'set scrolloff?' -c 'q'` outputs `scrolloff=8`
- [ ] Temp dirs (`/tmp/nvim-undo`, etc.) created on first launch

🤖 Generated with [Claude Code](https://claude.com/claude-code)