### PR TITLE
fix: disable line numbers in neovim config

### DIFF
--- a/configs/init.vim
+++ b/configs/init.vim
@@ -7,8 +7,8 @@
 set termguicolors
 set background=dark
 colorscheme industry
-set number
-set relativenumber
+set nonumber
+set norelativenumber
 set cursorline
 set signcolumn=yes
 set colorcolumn=120


### PR DESCRIPTION
## Summary

- Disable `number` and `relativenumber` in `configs/init.vim` — line numbers in the gutter display incorrectly when scrolling

Closes #228

## Test plan

- [ ] `nvim --headless -c 'set number?' -c 'q'` outputs `nonumber`

🤖 Generated with [Claude Code](https://claude.com/claude-code)