### PR TITLE
fix: add configs/ to docker-publish.yml path filter

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - Dockerfile
       - entrypoint.sh
+      - configs/**
       - claude-config/**
       - docker-compose.yml
       - .devcontainer/**


### PR DESCRIPTION
## Summary

- Add `configs/**` to the `docker-publish.yml` path filter so changes to files COPYed into the image (e.g., `init.vim`, `.p10k.zsh`) trigger Docker rebuilds

Closes #230

## Test plan

- [ ] Merging this PR triggers the Docker Publish workflow (since it changes the workflow file itself)
- [ ] Future changes to `configs/` files will trigger Docker Publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)