### PR TITLE
feat: seed OAuth auth for OpenClaw and Pi

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,7 +15,7 @@ ANTHROPIC_API_KEY=sk-ant-your-api-key-here
 # =============================================================================
 # If you have a Claude Max subscription, set your OAuth token instead of an
 # API key.  Get it from Claude Code settings or the Anthropic console.
-# When set, Claude Code and OpenCode both authenticate via OAuth.
+# When set, Claude Code, OpenCode, OpenClaw, and Pi all authenticate via OAuth.
 
 # CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-your-token-here
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1058,6 +1058,15 @@ RUN printf '#!/bin/bash\n. /usr/local/lib/claude-proxy.sh\nstart_claude_proxy\n'
     && printf '. /usr/local/lib/claude-proxy.sh\nstart_claude_proxy\n' \
       >> /etc/zsh/zshenv
 
+# Map CLAUDE_CODE_OAUTH_TOKEN → ANTHROPIC_OAUTH_TOKEN for tools
+# that read the Anthropic-native env var (e.g. Pi).
+# hadolint ignore=SC2016
+RUN printf '#!/bin/bash\nif [ -n "$CLAUDE_CODE_OAUTH_TOKEN" ] && [ -z "$ANTHROPIC_OAUTH_TOKEN" ]; then\n  export ANTHROPIC_OAUTH_TOKEN="$CLAUDE_CODE_OAUTH_TOKEN"\nfi\n' \
+      > /etc/profile.d/anthropic-oauth.sh \
+    && chmod +x /etc/profile.d/anthropic-oauth.sh \
+    && printf 'if [ -n "$CLAUDE_CODE_OAUTH_TOKEN" ] && [ -z "$ANTHROPIC_OAUTH_TOKEN" ]; then\n  export ANTHROPIC_OAUTH_TOKEN="$CLAUDE_CODE_OAUTH_TOKEN"\nfi\n' \
+      >> /etc/zsh/zshenv
+
 # ============================================================
 # 18. Entrypoint (absolute last COPY — most volatile file)
 # ============================================================

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -48,6 +48,22 @@ SSHCONF
   fi
 fi
 
+# Export ANTHROPIC_OAUTH_TOKEN for tools that read it (e.g. Pi)
+if [ -n "$CLAUDE_CODE_OAUTH_TOKEN" ] && [ -z "$ANTHROPIC_OAUTH_TOKEN" ]; then
+  export ANTHROPIC_OAUTH_TOKEN="$CLAUDE_CODE_OAUTH_TOKEN"
+fi
+
+# Seed Pi settings if missing
+PI_AGENT_DIR="$HOME/.pi/agent"
+if [ ! -f "$PI_AGENT_DIR/settings.json" ] || [ ! -s "$PI_AGENT_DIR/settings.json" ]; then
+  if [ -n "$CLAUDE_CODE_OAUTH_TOKEN" ]; then
+    mkdir -p "$PI_AGENT_DIR"
+    cat >"$PI_AGENT_DIR/settings.json" <<'PIEOF'
+{"defaultProvider":"anthropic","defaultModel":"claude-opus-4-6"}
+PIEOF
+  fi
+fi
+
 # Seed Claude Code config if missing
 if [ ! -f "$HOME/.claude.json" ] || [ ! -s "$HOME/.claude.json" ]; then
   echo '{"hasCompletedOnboarding": true}' >"$HOME/.claude.json"
@@ -68,6 +84,17 @@ AUTHEOF
   elif [ -n "$OPENAI_API_KEY" ] && [ -f /opt/opencode-config/opencode.json ]; then
     mkdir -p "$OPENCODE_CONFIG_DIR"
     cp /opt/opencode-config/opencode.json "$OPENCODE_CONFIG_DIR/opencode.json"
+  fi
+fi
+
+# Seed openclaw auth if missing
+OPENCLAW_AUTH_DIR="$HOME/.openclaw/agents/main/agent"
+if [ ! -f "$OPENCLAW_AUTH_DIR/auth-profiles.json" ] || [ ! -s "$OPENCLAW_AUTH_DIR/auth-profiles.json" ]; then
+  if [ -n "$CLAUDE_CODE_OAUTH_TOKEN" ]; then
+    mkdir -p "$OPENCLAW_AUTH_DIR"
+    cat >"$OPENCLAW_AUTH_DIR/auth-profiles.json" <<CLAWEOF
+{"version":1,"profiles":{"anthropic:oauth":{"type":"oauth","provider":"anthropic","access":"${CLAUDE_CODE_OAUTH_TOKEN}","refresh":"","expires":9999999999999}}}
+CLAWEOF
   fi
 fi
 


### PR DESCRIPTION
## Summary

- Seed OpenClaw `auth-profiles.json` from `CLAUDE_CODE_OAUTH_TOKEN` in entrypoint
- Seed Pi `settings.json` with Anthropic as default provider/model
- Map `CLAUDE_CODE_OAUTH_TOKEN` → `ANTHROPIC_OAUTH_TOKEN` in entrypoint and shell hooks (`/etc/profile.d/`, `/etc/zsh/zshenv`)
- Update `.env.example` to document all four tools (Claude Code, OpenCode, OpenClaw, Pi)

Closes #232

## Test plan

- [ ] Build image locally: `podman build -t devcontainer:local .`
- [ ] Run with `.env`: `podman run --rm -it --env-file .env devcontainer:local`
- [ ] Verify `openclaw models status` shows anthropic OAuth token
- [ ] Verify `pi -p "hello"` responds using Anthropic provider
- [ ] Verify `printenv ANTHROPIC_OAUTH_TOKEN` is set in new shells

🤖 Generated with [Claude Code](https://claude.com/claude-code)