### PR TITLE
feat: switch Claude Code from npm to native installer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -964,13 +964,18 @@ WORKDIR /home/$USERNAME
 RUN mkdir -p ~/.cache ~/.local/bin ~/.claude ~/.config/nvim \
     && echo '{"hasCompletedOnboarding": true}' > ~/.claude.json.default
 
+# Install native Claude Code binary (replaces npm package)
+# hadolint ignore=DL3059
+RUN claude install --force \
+    && npm uninstall -g @anthropic-ai/claude-code
+
 # ============================================================
 # 14. Homebrew (needed by openclaw configure)
 # ============================================================
 RUN NONINTERACTIVE=1 /bin/bash -c "$(curl ${CURL_RETRY} -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 
 ENV HOMEBREW_NO_AUTO_UPDATE=1
-ENV PATH="/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:${PATH}"
+ENV PATH="/home/vscode/.local/bin:/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:${PATH}"
 
 # AI assistant deps + formatters (no APT packages available)
 # hadolint ignore=DL3059


### PR DESCRIPTION
## Summary

Switch Claude Code from npm global install to native installer to eliminate the deprecation warning shown at startup.

## Related Issue

Closes #234

## Changes

- Run `claude install --force` after npm bootstrap to install the native Bun binary at `~/.local/bin/claude`
- Remove the npm `@anthropic-ai/claude-code` package after native install
- Add `~/.local/bin` to PATH with highest precedence

## Checklist

- [x] Linked to a GitHub issue (required — CI will block merge without it)
- [ ] Tested locally
- [x] Follows project conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)