### PR TITLE
fix: use sudo for npm uninstall after USER switch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -967,7 +967,7 @@ RUN mkdir -p ~/.cache ~/.local/bin ~/.claude ~/.config/nvim \
 # Install native Claude Code binary (replaces npm package)
 # hadolint ignore=DL3059
 RUN claude install --force \
-    && npm uninstall -g @anthropic-ai/claude-code
+    && sudo npm uninstall -g @anthropic-ai/claude-code
 
 # ============================================================
 # 14. Homebrew (needed by openclaw configure)


### PR DESCRIPTION
## Summary

Fix EACCES permission error when uninstalling npm `@anthropic-ai/claude-code` package after switching to `USER vscode`.

## Related Issue

Closes #236

## Changes

- Add `sudo` to `npm uninstall -g @anthropic-ai/claude-code` since npm globals are in root-owned `/usr/lib/node_modules/`

## Checklist

- [x] Linked to a GitHub issue (required — CI will block merge without it)
- [ ] Tested locally
- [x] Follows project conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)