### PR TITLE
fix: always pull latest image in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 services:
   dev:
     image: ghcr.io/f5xc-salesdemos/devcontainer:latest
+    pull_policy: always
     container_name: devcontainer
     hostname: devcontainer
     volumes:


### PR DESCRIPTION
## Summary

Add `pull_policy: always` to the `dev` service so users automatically get the latest container image on every `compose up`.

## Related Issue

Closes #238

## Changes

- Add `pull_policy: always` to the `dev` service in `docker-compose.yml`

## Checklist

- [x] Linked to a GitHub issue (required — CI will block merge without it)
- [x] Tested locally
- [x] Follows project conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)