### PR TITLE
fix: restore onboarding bypass and set dark-daltonized theme

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -967,7 +967,9 @@ RUN mkdir -p ~/.cache ~/.local/bin ~/.claude ~/.config/nvim \
 # Install native Claude Code binary (replaces npm package)
 # hadolint ignore=DL3059
 RUN claude install --force \
-    && sudo npm uninstall -g @anthropic-ai/claude-code
+    && sudo npm uninstall -g @anthropic-ai/claude-code \
+    && jq '. + {"hasCompletedOnboarding": true, "theme": "dark-daltonized"}' \
+       ~/.claude.json > /tmp/claude.json && mv /tmp/claude.json ~/.claude.json
 
 # ============================================================
 # 14. Homebrew (needed by openclaw configure)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -64,9 +64,12 @@ PIEOF
   fi
 fi
 
-# Seed Claude Code config if missing
-if [ ! -f "$HOME/.claude.json" ] || [ ! -s "$HOME/.claude.json" ]; then
-  echo '{"hasCompletedOnboarding": true}' >"$HOME/.claude.json"
+# Ensure Claude Code onboarding + theme are always set
+if [ -f "$HOME/.claude.json" ] && [ -s "$HOME/.claude.json" ]; then
+  jq '. + {"hasCompletedOnboarding": true, "theme": (.theme // "dark-daltonized")}' \
+    "$HOME/.claude.json" >"$HOME/.claude.json.tmp" && mv "$HOME/.claude.json.tmp" "$HOME/.claude.json"
+else
+  echo '{"hasCompletedOnboarding": true, "theme": "dark-daltonized"}' >"$HOME/.claude.json"
 fi
 
 # Seed opencode config if missing


### PR DESCRIPTION
## Summary

Fix onboarding wizard and theme regression after switching to native Claude Code installer.

## Related Issue

Closes #240

## Changes

- Merge `hasCompletedOnboarding: true` and `theme: "dark-daltonized"` into `~/.claude.json` after `claude install` at build time
- Update entrypoint to merge these fields into existing config (preserving user theme if already set) rather than only seeding when the file is missing

## Checklist

- [x] Linked to a GitHub issue (required — CI will block merge without it)
- [x] Tested locally
- [x] Follows project conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)