### PR TITLE
fix: seed workspace trust in ~/.claude.json instead of settings.json

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -67,19 +67,13 @@ PIEOF
   fi
 fi
 
-# Ensure Claude Code onboarding + theme are always set
+# Ensure Claude Code onboarding + theme + workspace trust are always set
 if [ -f "$HOME/.claude.json" ] && [ -s "$HOME/.claude.json" ]; then
-  jq '. + {"hasCompletedOnboarding": true, "theme": (.theme // "dark-daltonized")}' \
+  jq '. + {"hasCompletedOnboarding": true, "theme": (.theme // "dark-daltonized")}
+      | .projects["/workspace"].hasTrustDialogAccepted = true' \
     "$HOME/.claude.json" >"$HOME/.claude.json.tmp" && mv "$HOME/.claude.json.tmp" "$HOME/.claude.json"
 else
-  echo '{"hasCompletedOnboarding": true, "theme": "dark-daltonized"}' >"$HOME/.claude.json"
-fi
-
-# Pre-trust /workspace for Claude Code interactive mode
-WORKSPACE_SETTINGS="$HOME/.claude/projects/-workspace/settings.json"
-if [ ! -f "$WORKSPACE_SETTINGS" ]; then
-  mkdir -p "$(dirname "$WORKSPACE_SETTINGS")"
-  echo '{"hasTrustDialogAccepted": true}' >"$WORKSPACE_SETTINGS"
+  echo '{"hasCompletedOnboarding":true,"theme":"dark-daltonized","projects":{"/workspace":{"hasTrustDialogAccepted":true}}}' >"$HOME/.claude.json"
 fi
 
 # Seed opencode config if missing


### PR DESCRIPTION
## Summary

- Fixes persistent workspace trust prompt by writing `hasTrustDialogAccepted` to `~/.claude.json` under `projects."/workspace"` instead of the wrong path `~/.claude/projects/-workspace/settings.json`
- Combines trust seeding with existing onboarding/theme `jq` call into a single read-modify-write operation
- Removes 6 lines of stale `settings.json` logic

## Test plan

- [ ] Run container and verify `jq '.projects["/workspace"].hasTrustDialogAccepted' ~/.claude.json` returns `true`
- [ ] Run `claude` interactively in `/workspace` — should not show trust prompt
- [ ] Verify onboarding bypass and theme still work (`jq '.hasCompletedOnboarding, .theme' ~/.claude.json`)

Closes #248

🤖 Generated with [Claude Code](https://claude.com/claude-code)