### PR TITLE
docs: add explicit pull to Podman compose commands

### DIFF
--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -128,7 +128,7 @@ docker compose up -d
 <TabItem label="Podman">
 
 ```bash
-podman compose up -d
+podman compose pull && podman compose up -d
 ```
 
 </TabItem>
@@ -219,12 +219,12 @@ docker compose up -d
 # Stop (preserves data)
 podman compose down
 
-# Start again
-podman compose up -d
+# Start again (pull ensures latest image)
+podman compose pull && podman compose up -d
 
 # Destroy everything and start fresh
 podman compose down -v
-podman compose up -d
+podman compose pull && podman compose up -d
 ```
 
 </TabItem>


### PR DESCRIPTION
## Summary

- Prepends `podman compose pull &&` to all Podman `up -d` commands in getting-started.mdx
- Fixes stale image issue caused by podman-compose 1.5.0 not enforcing `pull_policy: always`
- Docker tabs unchanged (Docker Compose honors the policy)

## Test plan

- [ ] Verify Podman tab code blocks show `podman compose pull && podman compose up -d`
- [ ] Verify Docker tab code blocks are unchanged
- [ ] Build docs locally to confirm no MDX rendering issues

Closes #250

🤖 Generated with [Claude Code](https://claude.com/claude-code)