### PR TITLE
fix: dearmor Mozilla APT signing key for Firefox ESR

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,7 +67,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     # Mozilla (Firefox ESR — Browsh backend, amd64 only)
     && if [ "$(dpkg --print-architecture)" = "amd64" ]; then \
       curl ${CURL_RETRY} -fsSL https://packages.mozilla.org/apt/repo-signing-key.gpg \
-        -o /usr/share/keyrings/packages.mozilla.org.gpg \
+        | gpg --dearmor -o /usr/share/keyrings/packages.mozilla.org.gpg \
       && echo "deb [signed-by=/usr/share/keyrings/packages.mozilla.org.gpg] https://packages.mozilla.org/apt mozilla main" \
         > /etc/apt/sources.list.d/mozilla.list \
       && printf 'Package: *\nPin: origin packages.mozilla.org\nPin-Priority: 1000\n' \


### PR DESCRIPTION
## Summary

- Pipe Mozilla APT signing key through `gpg --dearmor` to fix unsigned repo error on amd64 Docker build
- The key at `repo-signing-key.gpg` is ASCII armored despite the `.gpg` extension

## Test plan

- [ ] amd64 Docker image builds successfully (no "not signed" error)
- [ ] Firefox ESR installs from Mozilla APT repo
- [ ] Browsh installs and works

Closes #254

🤖 Generated with [Claude Code](https://claude.com/claude-code)