### PR TITLE
feat: enhance terminal capabilities and add asciinema

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -737,7 +737,8 @@ RUN npm install -g \
     tekton-lint \
     asl-validator \
     renovate \
-    markdownlint-cli
+    markdownlint-cli \
+    asciinema-player
 
 # oh-my-opencode (OpenCode plugin system — "ultrawork" / "ulw" command)
 # hadolint ignore=DL3059
@@ -779,7 +780,8 @@ RUN pip install --no-cache-dir --break-system-packages --ignore-installed \
     mitreattack-python \
     # Recon (recon-ng, spiderfoot installed via git clone below)
     theHarvester \
-    fierce
+    fierce \
+    asciinema
 
 # Security & pentest pip packages.
 # Installed in isolated groups because mitmproxy, sslyze, impacket,

--- a/configs/.p10k.zsh
+++ b/configs/.p10k.zsh
@@ -364,8 +364,8 @@
   # Version control background colors.
   typeset -g POWERLEVEL9K_VCS_CLEAN_BACKGROUND=2
   typeset -g POWERLEVEL9K_VCS_MODIFIED_BACKGROUND=3
-  typeset -g POWERLEVEL9K_VCS_UNTRACKED_BACKGROUND=2
-  typeset -g POWERLEVEL9K_VCS_CONFLICTED_BACKGROUND=3
+  typeset -g POWERLEVEL9K_VCS_UNTRACKED_BACKGROUND=39
+  typeset -g POWERLEVEL9K_VCS_CONFLICTED_BACKGROUND=1
   typeset -g POWERLEVEL9K_VCS_LOADING_BACKGROUND=8
 
   # Branch icon. Set this parameter to '\UE0A0 ' for the popular Powerline branch icon.
@@ -398,7 +398,7 @@
     local      clean='%0F' # black foreground
     local   modified='%0F' # black foreground
     local  untracked='%0F' # black foreground
-    local conflicted='%1F' # red foreground
+    local conflicted='%7F' # white foreground
 
     local res
 

--- a/configs/.tmux.conf
+++ b/configs/.tmux.conf
@@ -1,7 +1,15 @@
 # ── General ──────────────────────────────────────────────
 set -g default-shell /usr/bin/zsh
 set -g default-terminal "tmux-256color"
-set -sa terminal-overrides ",xterm*:Tc"
+# ── True color & extended capabilities ──────────────────
+# Declare 24-bit RGB color support (tmux 3.2+)
+set -as terminal-features ",xterm-256color:RGB"
+
+# Undercurl support (curly underlines — used by neovim diagnostics)
+set -as terminal-overrides ",xterm-256color:Smulx=\E[4::%p1%dm"
+
+# Colored underlines (separate underline color — neovim, editors)
+set -as terminal-overrides ",xterm-256color:Setulc=\E[58::2::%p1%{65536}%/%d::%p1%{256}%/%{255}%&%d::%p1%{255}%&%d%;m"
 set -g history-limit 50000
 set -g mouse on
 set -g focus-events on


### PR DESCRIPTION
## Summary

Enhance tmux terminal rendering for iTerm2 and add asciinema recorder/player to the devcontainer.

## Related Issue

Closes #256

## Changes

- Replace basic tmux `Tc` override with RGB, Smulx (undercurl), and Setulc (colored underlines) terminal feature declarations for full iTerm2 rendering through tmux
- Update p10k VCS colors: untracked background to 39 (cyan), conflicted background to 1 (red), conflicted foreground to white for better visibility
- Add `asciinema` CLI via pip for recording terminal sessions as `.cast` files
- Add `asciinema-player` via npm for embedding playback in web pages

## Checklist

- [x] Linked to a GitHub issue (required — CI will block merge without it)
- [x] Tested locally
- [x] Follows project conventions