### PR TITLE
fix: enable browsh install on arm64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ ARG NODE_MAJOR=24
 ARG PYTHON_VERSION=3.13
 ARG JAVA_VERSION=21
 ARG MAVEN_VERSION=3.9.9
-ARG BROWSH_VERSION=1.8.0
+ARG BROWSH_VERSION=1.8.2
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -175,14 +175,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # ============================================================
-# 2c. Firefox ESR + Browsh (amd64 only — Browsh has no arm64 build)
+# 2c. Firefox ESR + Browsh (amd64 + arm64)
 # ============================================================
 # hadolint ignore=DL3008,DL3059
-RUN if [ "$(dpkg --print-architecture)" = "amd64" ]; then \
+RUN ARCH="$(dpkg --print-architecture)" \
+    && if [ "$ARCH" = "amd64" ] || [ "$ARCH" = "arm64" ]; then \
       apt-get update \
       && apt-get install -y --no-install-recommends firefox-esr \
       && curl ${CURL_RETRY} -fsSL \
-          "https://github.com/browsh-org/browsh/releases/download/v${BROWSH_VERSION}/browsh_${BROWSH_VERSION}_linux_amd64.deb" \
+          "https://github.com/browsh-org/browsh/releases/download/v${BROWSH_VERSION}/browsh_${BROWSH_VERSION}_linux_${ARCH}.deb" \
           -o /tmp/browsh.deb \
       && dpkg -i /tmp/browsh.deb \
       && rm /tmp/browsh.deb \


### PR DESCRIPTION
## Summary

- Bump `BROWSH_VERSION` from `1.8.0` to `1.8.2` (latest release with binary builds)
- Replace the amd64-only install guard with a multi-arch check supporting both `amd64` and `arm64`
- Use `$(dpkg --print-architecture)` dynamically in the download URL instead of hardcoding `amd64`

Closes #258

## Test plan

- [ ] CI lint passes (super-linter, hadolint)
- [ ] Docker build succeeds on both architectures
- [ ] `browsh --version` returns `1.8.2` inside an arm64 container
- [ ] Verified arm64 `.deb` URL returns HTTP 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)