### PR TITLE
fix: enable Mozilla APT repo on arm64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,8 +64,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       -o /usr/share/keyrings/tailscale-archive-keyring.gpg \
     && echo "deb [signed-by=/usr/share/keyrings/tailscale-archive-keyring.gpg] https://pkgs.tailscale.com/stable/ubuntu noble main" \
       > /etc/apt/sources.list.d/tailscale.list \
-    # Mozilla (Firefox ESR — Browsh backend, amd64 only)
-    && if [ "$(dpkg --print-architecture)" = "amd64" ]; then \
+    # Mozilla (Firefox ESR — Browsh backend, amd64 + arm64)
+    && ARCH="$(dpkg --print-architecture)" \
+    && if [ "$ARCH" = "amd64" ] || [ "$ARCH" = "arm64" ]; then \
       curl ${CURL_RETRY} -fsSL https://packages.mozilla.org/apt/repo-signing-key.gpg \
         | gpg --dearmor -o /usr/share/keyrings/packages.mozilla.org.gpg \
       && echo "deb [signed-by=/usr/share/keyrings/packages.mozilla.org.gpg] https://packages.mozilla.org/apt mozilla main" \


### PR DESCRIPTION
## Summary

- Update Mozilla APT repo setup guard from amd64-only to amd64 + arm64
- Mozilla's repo at `packages.mozilla.org/apt` supports both architectures
- Fixes arm64 Docker build failure from #259 where `firefox-esr` had no installation candidate

Closes #260

## Test plan

- [ ] CI lint passes (super-linter, hadolint)
- [ ] Docker Publish workflow succeeds on both amd64 and arm64
- [ ] `firefox-esr` and `browsh` available in arm64 container

🤖 Generated with [Claude Code](https://claude.com/claude-code)