### PR TITLE
docs: replace podman compose with podman-compose

### DIFF
--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -174,10 +174,10 @@ See [Local Development](./local-development) for details.
 </TabItem>
 <TabItem label="Podman">
 
-Running `podman compose up -d` pulls the pre-built image automatically. To build locally after customizing the Dockerfile, pass the build file explicitly:
+Running `podman-compose up -d` pulls the pre-built image automatically. To build locally after customizing the Dockerfile, pass the build file explicitly:
 
 ```bash
-podman compose -f docker-compose.yml -f docker-compose.build.yml up -d --build
+podman-compose -f docker-compose.yml -f docker-compose.build.yml up -d --build
 ```
 
 See [Local Development](./local-development) for details.
@@ -245,12 +245,12 @@ Both persist across container restarts and rebuilds. Run `docker compose pull` t
 </TabItem>
 <TabItem label="Podman">
 
-Both persist across container restarts and rebuilds. Run `podman compose pull` to fetch the latest pre-built image before restarting.
+Both persist across container restarts and rebuilds. Run `podman-compose pull` to fetch the latest pre-built image before restarting.
 
 | Action | Data |
 |--------|------|
-| `podman compose down` | Preserved |
-| `podman compose down -v` | **Deleted** |
+| `podman-compose down` | Preserved |
+| `podman-compose down -v` | **Deleted** |
 
 </TabItem>
 </Tabs>

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -42,11 +42,11 @@ Verify it's working:
 
 ```bash
 podman --version
-podman compose version
+podman-compose version
 ```
 
 :::note[Linux only]
-Podman on Linux runs containers directly (no VM). Ensure the Podman socket is active so `podman compose` can connect:
+Podman on Linux runs containers directly (no VM). Ensure the Podman socket is active so `podman-compose` can connect:
 
 ```bash
 systemctl --user enable --now podman.socket
@@ -128,7 +128,7 @@ docker compose up -d
 <TabItem label="Podman">
 
 ```bash
-podman compose pull && podman compose up -d
+podman-compose pull && podman-compose up -d
 ```
 
 </TabItem>
@@ -149,7 +149,7 @@ docker compose exec dev zsh
 <TabItem label="Podman">
 
 ```bash
-podman compose exec dev zsh
+podman-compose exec dev zsh
 ```
 
 </TabItem>
@@ -217,14 +217,14 @@ docker compose up -d
 
 ```bash
 # Stop (preserves data)
-podman compose down
+podman-compose down
 
 # Start again (pull ensures latest image)
-podman compose pull && podman compose up -d
+podman-compose pull && podman-compose up -d
 
 # Destroy everything and start fresh
-podman compose down -v
-podman compose pull && podman compose up -d
+podman-compose down -v
+podman-compose pull && podman-compose up -d
 ```
 
 </TabItem>

--- a/docs/local-development.mdx
+++ b/docs/local-development.mdx
@@ -35,7 +35,7 @@ cd devcontainer
 
 ## Build File
 
-The `docker-compose.build.yml` file adds local build support. It is **not** auto-merged — you must pass it explicitly with `-f` flags. This means `docker compose up -d` (or `podman compose up -d`) always pulls the pre-built image from GHCR, whether you cloned the repo or not.
+The `docker-compose.build.yml` file adds local build support. It is **not** auto-merged — you must pass it explicitly with `-f` flags. This means `docker compose up -d` (or `podman-compose up -d`) always pulls the pre-built image from GHCR, whether you cloned the repo or not.
 
 <Tabs syncKey="runtime">
 <TabItem label="Docker">
@@ -55,16 +55,16 @@ docker compose -f docker-compose.yml -f docker-compose.build.yml config
 </TabItem>
 <TabItem label="Podman">
 
-You can verify that a plain `podman compose up` uses only the pre-built image (no `build:` context):
+You can verify that a plain `podman-compose up` uses only the pre-built image (no `build:` context):
 
 ```bash
-podman compose config
+podman-compose config
 ```
 
 Compare with the explicit build configuration:
 
 ```bash
-podman compose -f docker-compose.yml -f docker-compose.build.yml config
+podman-compose -f docker-compose.yml -f docker-compose.build.yml config
 ```
 
 </TabItem>
@@ -83,7 +83,7 @@ docker compose -f docker-compose.yml -f docker-compose.build.yml up -d --build
 <TabItem label="Podman">
 
 ```bash
-podman compose -f docker-compose.yml -f docker-compose.build.yml up -d --build
+podman-compose -f docker-compose.yml -f docker-compose.build.yml up -d --build
 ```
 
 </TabItem>
@@ -161,7 +161,7 @@ docker compose -f docker-compose.yml -f docker-compose.build.yml up -d --build
 <TabItem label="Podman">
 
 ```bash
-podman compose -f docker-compose.yml -f docker-compose.build.yml up -d --build
+podman-compose -f docker-compose.yml -f docker-compose.build.yml up -d --build
 ```
 
 </TabItem>

--- a/docs/security.mdx
+++ b/docs/security.mdx
@@ -82,8 +82,8 @@ docker compose pull && docker compose up -d
 <TabItem label="Podman">
 
 ```bash
-podman compose down -v
-podman compose pull && podman compose up -d
+podman-compose down -v
+podman-compose pull && podman-compose up -d
 ```
 
 </TabItem>
@@ -160,7 +160,7 @@ For the complete list, run `claude-self-test` inside the container (section 7 ch
 <TabItem label="Podman">
 
    ```bash
-   podman compose pull && podman compose up -d
+   podman-compose pull && podman-compose up -d
    ```
 
 </TabItem>

--- a/docs/troubleshooting.mdx
+++ b/docs/troubleshooting.mdx
@@ -24,7 +24,7 @@ docker compose up -d
 
 ```bash
 podman rm -f devcontainer
-podman compose up -d
+podman-compose up -d
 ```
 
 </TabItem>
@@ -48,8 +48,8 @@ docker compose up -d
 <TabItem label="Podman">
 
 ```bash
-podman compose pull
-podman compose up -d
+podman-compose pull
+podman-compose up -d
 ```
 
 </TabItem>
@@ -90,7 +90,7 @@ Common causes:
 </TabItem>
 <TabItem label="Podman">
 
-  Then restart: `podman compose up -d`.
+  Then restart: `podman-compose up -d`.
 
 </TabItem>
 </Tabs>
@@ -302,7 +302,7 @@ docker compose logs dev | grep -i vnc
 <TabItem label="Podman">
 
 ```bash
-podman compose logs dev | grep -i vnc
+podman-compose logs dev | grep -i vnc
 ```
 
 </TabItem>
@@ -333,10 +333,10 @@ docker compose up -d
 <TabItem label="Podman">
 
 ```bash
-podman compose down -v
+podman-compose down -v
 podman rm -f devcontainer 2>/dev/null
-podman compose pull
-podman compose up -d
+podman-compose pull
+podman-compose up -d
 ```
 
 </TabItem>

--- a/docs/vnc.mdx
+++ b/docs/vnc.mdx
@@ -57,8 +57,8 @@ docker compose up -d
 <TabItem label="Podman">
 
 ```bash
-podman compose down
-podman compose up -d
+podman-compose down
+podman-compose up -d
 ```
 
 </TabItem>


### PR DESCRIPTION
## Summary

- Replaced all `podman compose` occurrences with `podman-compose` across 6 docs files
- Avoids the noisy "Executing external compose provider" banner that `podman compose` prints when delegating to `podman-compose`
- No changes to `docker compose` references, `docker-compose.yml` filenames, or Podman Compose project name mentions

## Test plan

- [ ] `grep -r "podman compose" docs/` returns no matches
- [ ] `grep -r "podman-compose" docs/` shows replacements in all 6 files
- [ ] CI super-linter passes
- [ ] Docs site builds successfully

Closes #266

🤖 Generated with [Claude Code](https://claude.com/claude-code)