### PR TITLE
fix: add openclaw-config/ to .dockerignore allow list

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,7 @@
 *
 !entrypoint.sh
 !claude-config/
+!openclaw-config/
 !opencode-config/
 !codex-config/
 !configs/


### PR DESCRIPTION
## Summary

- Add `!openclaw-config/` to `.dockerignore` allow list so Docker builds can COPY `openclaw-gateway.sh` from its new location

Closes #272

## Test plan

- [ ] Docker Publish workflow passes (both amd64 and arm64)

🤖 Generated with [Claude Code](https://claude.com/claude-code)