### PR TITLE
fix: add missing provider field to OpenClaw auth profile

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -129,7 +129,8 @@ if [ ! -f "$OPENCLAW_CONFIG" ] || [ ! -s "$OPENCLAW_CONFIG" ]; then
   "auth": {
     "profiles": {
       "anthropic:oauth": {
-        "mode": "oauth"
+        "mode": "oauth",
+        "provider": "anthropic"
       }
     }
   },


### PR DESCRIPTION
## Linked Issue

Closes #274

## Changes

Adds the missing `"provider": "anthropic"` field to the OpenClaw gateway auth profile in `entrypoint.sh`.

## What is the current behavior?

After PR #271, the config validator rejects the auth profile because `provider` is a required field:
```
auth.profiles.anthropic:oauth.provider: Invalid input: expected string, received undefined
```
The gateway fails to start, printing "Warning: OpenClaw gateway failed to start".

## What is the new behavior?

The auth profile includes both required fields (`mode` and `provider`), passing config validation and allowing the gateway to start successfully.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document.
- [x] My change follows the code style of this project.
- [x] I have updated the documentation accordingly. (N/A)
- [x] I have added tests to cover my changes. (N/A — config change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)