### PR TITLE
feat: pre-install Claude Code plugins in devcontainer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1170,6 +1170,7 @@ COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh
 
 USER $USERNAME
+ENV FORCE_AUTOUPDATE_PLUGINS=true
 ENV SHELL=/bin/zsh
 WORKDIR /workspace
 

--- a/claude-config/self-test.sh
+++ b/claude-config/self-test.sh
@@ -202,6 +202,14 @@ if [ "$DPKG_ARCH" = "amd64" ]; then
 fi
 
 echo ""
+echo "8. Claude Code Plugins"
+check "enabledPlugins in settings.json" \
+  jq -e '.enabledPlugins' "$HOME/.claude/settings.json"
+check "16 plugins configured" \
+  test "$(jq '.enabledPlugins | length' "$HOME/.claude/settings.json")" -eq 16
+check "FORCE_AUTOUPDATE_PLUGINS set" test "$FORCE_AUTOUPDATE_PLUGINS" = "true"
+
+echo ""
 echo "=== Results: $PASS passed, $FAIL failed, $WARN warnings ==="
 
 if [ "$FAIL" -gt 0 ]; then

--- a/claude-config/settings.json
+++ b/claude-config/settings.json
@@ -2,6 +2,24 @@
   "statusline": { "command": "/opt/claude-config/statusline.sh" },
   "defaultMode": "bypassPermissions",
   "skipDangerousModePermissionPrompt": true,
+  "enabledPlugins": {
+    "frontend-design@claude-plugins-official": true,
+    "superpowers@claude-plugins-official": true,
+    "code-review@claude-plugins-official": true,
+    "code-simplifier@claude-plugins-official": true,
+    "feature-dev@claude-plugins-official": true,
+    "ralph-loop@claude-plugins-official": true,
+    "typescript-lsp@claude-plugins-official": true,
+    "commit-commands@claude-plugins-official": true,
+    "security-guidance@claude-plugins-official": true,
+    "claude-md-management@claude-plugins-official": true,
+    "pr-review-toolkit@claude-plugins-official": true,
+    "skill-creator@claude-plugins-official": true,
+    "claude-code-setup@claude-plugins-official": true,
+    "greptile@claude-plugins-official": true,
+    "hookify@claude-plugins-official": true,
+    "postman@claude-plugins-official": true
+  },
   "mcpServers": {
     "searxng": {
       "command": "/opt/searxng-mcp/.venv/bin/python",


### PR DESCRIPTION
## Summary

- Declare 16 plugins from `anthropics/claude-plugins-official` in `settings.json` `enabledPlugins` so Claude Code discovers them on first launch
- Add `FORCE_AUTOUPDATE_PLUGINS=true` env var to keep plugins auto-updated at runtime
- Add self-test section 8 to verify plugin configuration (enabledPlugins exists, 16 count, env var set)

## Test plan

- [ ] Build container image and verify `jq .enabledPlugins ~/.claude/settings.json` shows 16 plugins
- [ ] Verify `FORCE_AUTOUPDATE_PLUGINS=true` is set in environment
- [ ] Run `claude-self-test` and confirm section 8 passes

Closes #278

🤖 Generated with [Claude Code](https://claude.com/claude-code)