### PR TITLE
feat: pre-bake Claude Code plugin marketplace cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -995,6 +995,28 @@ RUN apt-get purge -y build-essential \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # ============================================================
+# 12l. Claude Code plugins (pre-bake marketplace cache)
+#      Clones the official plugin marketplace so Claude Code
+#      skips the initial download on first launch. The .git
+#      directory is kept because FORCE_AUTOUPDATE_PLUGINS
+#      needs it for incremental pulls.
+# ============================================================
+# hadolint ignore=DL3059
+RUN PLUGIN_BASE="/home/${USERNAME}/.claude/plugins" \
+    && mkdir -p "${PLUGIN_BASE}/marketplaces" \
+    && git clone --depth=1 --single-branch --branch main \
+        https://github.com/anthropics/claude-plugins-official.git \
+        "${PLUGIN_BASE}/marketplaces/claude-plugins-official" \
+    && printf '{"claude-plugins-official":{"source":{"source":"github","repo":"anthropics/claude-plugins-official"},"installLocation":"%s","lastUpdated":"%s"}}' \
+        "${PLUGIN_BASE}/marketplaces/claude-plugins-official" \
+        "$(date -u +%Y-%m-%dT%H:%M:%S.000Z)" \
+        > "${PLUGIN_BASE}/known_marketplaces.json" \
+    && printf '{"fetchedAt":"%s","plugins":[]}' \
+        "$(date -u +%Y-%m-%dT%H:%M:%S.000Z)" \
+        > "${PLUGIN_BASE}/blocklist.json" \
+    && chown -R ${USERNAME}:${USERNAME} "${PLUGIN_BASE}"
+
+# ============================================================
 # 13. Playwright browsers (Chromium + system deps)
 # ============================================================
 # hadolint ignore=DL3059

--- a/claude-config/self-test.sh
+++ b/claude-config/self-test.sh
@@ -208,6 +208,12 @@ check "enabledPlugins in settings.json" \
 check "16 plugins configured" \
   test "$(jq '.enabledPlugins | length' "$HOME/.claude/settings.json")" -eq 16
 check "FORCE_AUTOUPDATE_PLUGINS set" test "$FORCE_AUTOUPDATE_PLUGINS" = "true"
+check "plugin marketplace cached" \
+  test -d "$HOME/.claude/plugins/marketplaces/claude-plugins-official"
+check "marketplace.json in cache" \
+  test -f "$HOME/.claude/plugins/marketplaces/claude-plugins-official/.claude-plugin/marketplace.json"
+check "known_marketplaces.json exists" \
+  test -f "$HOME/.claude/plugins/known_marketplaces.json"
 
 echo ""
 echo "=== Results: $PASS passed, $FAIL failed, $WARN warnings ==="


### PR DESCRIPTION
## Summary

- Clone `anthropics/claude-plugins-official` into `~/.claude/plugins/marketplaces/` at Docker build time so Claude Code skips the initial marketplace download on first launch
- Seed `known_marketplaces.json` and `blocklist.json` for cache recognition
- Add 3 self-test checks validating the plugin cache is present

Closes #280

## Test plan

- [ ] Docker image builds successfully with the new section 12l
- [ ] `~/.claude/plugins/marketplaces/claude-plugins-official/` exists in the container
- [ ] `known_marketplaces.json` is valid JSON with correct paths
- [ ] `claude-self-test` passes all section 8 checks
- [ ] Claude Code launches without re-fetching the marketplace

🤖 Generated with [Claude Code](https://claude.com/claude-code)