### PR TITLE
fix: correct statusLine config for devcontainer

### DIFF
--- a/claude-config/settings.json
+++ b/claude-config/settings.json
@@ -1,5 +1,5 @@
 {
-  "statusline": { "command": "/opt/claude-config/statusline.sh" },
+  "statusLine": { "type": "command", "command": "/opt/claude-config/statusline.sh" },
   "defaultMode": "bypassPermissions",
   "skipDangerousModePermissionPrompt": true,
   "enabledPlugins": {


### PR DESCRIPTION
## Summary

- Fix statusline not appearing in devcontainer by correcting key casing (`statusline` → `statusLine`) and adding the required `type: "command"` field

Closes #285

## Test plan

- [ ] Rebuild devcontainer image
- [ ] Start Claude Code in container and verify statusline appears at the bottom of the terminal
- [ ] Verify `jq .statusLine ~/.claude/settings.json` returns the correct config inside the container

🤖 Generated with [Claude Code](https://claude.com/claude-code)