### PR TITLE
feat: disable spinner tips in devcontainer

### DIFF
--- a/claude-config/settings.json
+++ b/claude-config/settings.json
@@ -1,5 +1,6 @@
 {
   "statusLine": { "type": "command", "command": "/opt/claude-config/statusline.sh" },
+  "spinnerTipsEnabled": false,
   "defaultMode": "bypassPermissions",
   "skipDangerousModePermissionPrompt": true,
   "enabledPlugins": {


### PR DESCRIPTION
## Summary

- Adds `"spinnerTipsEnabled": false` to `claude-config/settings.json` to disable spinner tips in the devcontainer, reducing visual noise during processing

Closes #287

## Test plan

- [ ] Verify `jq .spinnerTipsEnabled ~/.claude/settings.json` returns `false` in the rebuilt container
- [ ] Start Claude Code in the container and confirm no tips appear in the spinner

🤖 Generated with [Claude Code](https://claude.com/claude-code)