### PR TITLE
docs: update recommended Podman machine memory to 12 GB

### DIFF
--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -61,7 +61,7 @@ systemctl --user enable --now podman.socket
 | Resource | Minimum | Recommended |
 |----------|---------|-------------|
 | Disk | 5 GB | 10 GB+ |
-| RAM | 4 GB allocated to container runtime | 8 GB+ |
+| RAM | 8 GB allocated to container runtime | 12 GB+ |
 | CPU | 2 cores | 4+ cores |
 
 <Tabs syncKey="runtime">
@@ -75,7 +75,7 @@ Adjust resource limits in Docker Desktop &rarr; Settings &rarr; Resources.
 On **macOS/Windows**, adjust resource limits in Podman Desktop &rarr; Settings &rarr; Resources, or via the CLI:
 
 ```bash
-podman machine set --cpus 4 --memory 8192
+podman machine set --cpus 4 --memory 12288
 podman machine stop && podman machine start
 ```
 


### PR DESCRIPTION
## Summary

- Updates minimum RAM from 4 GB to 8 GB (the devcontainer alone needs 8 GB)
- Updates recommended RAM from 8 GB+ to 12 GB+ (accounts for docs-builder + VM overhead)
- Updates `podman machine set --memory` example from 8192 to 12288

Closes #295

## Test plan

- [ ] Verify docs site builds and the getting-started page renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)