### PR TITLE
feat: add tmux split panes and agent teams settings

### DIFF
--- a/claude-config/settings.json
+++ b/claude-config/settings.json
@@ -33,5 +33,11 @@
         "TRANSPORT": "stdio"
       }
     }
+  },
+  "env": {
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+  },
+  "preferences": {
+    "tmuxSplitPanes": true
   }
 }


### PR DESCRIPTION
## Summary

Add `env` and `preferences` keys to `claude-config/settings.json` to enable experimental agent teams and tmux split panes for subagent output.

## Related Issue

Closes #299

## Changes

- Added `env.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS = "1"` to enable the experimental agent teams feature
- Added `preferences.tmuxSplitPanes = true` to use tmux split panes for subagent output

## Checklist

- [x] Linked to a GitHub issue (required — CI will block merge without it)
- [x] Tested locally
- [x] Follows project conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)