### PR TITLE
feat: symlink plugin skills into opencode skill directory

### DIFF
--- a/claude-config/install-plugins.sh
+++ b/claude-config/install-plugins.sh
@@ -13,6 +13,12 @@ GIT_SHA=$(cd "$MARKETPLACE" && git rev-parse HEAD)
 
 mkdir -p "$CACHE"
 
+# Opencode skill directory — symlinks are created per-plugin below
+# Uses opencode-only path to avoid duplicate discovery in Claude Code
+HOME_DIR=$(dirname "$(dirname "$PLUGIN_BASE")")
+OPENCODE_SKILLS="${HOME_DIR}/.config/opencode/skill"
+mkdir -p "$OPENCODE_SKILLS"
+
 # Start building installed_plugins.json
 echo '[' >"$INSTALLED_JSON"
 FIRST=true
@@ -55,6 +61,18 @@ for NAME in $PLUGINS; do
     echo "WARNING: no source found for plugin '$NAME', skipping"
     rm -rf "$DEST"
     continue
+  fi
+
+  # Symlink plugin skills into opencode's skill directory
+  # (Claude Code already loads these via its plugin system)
+  if [ -d "${DEST}/skills" ]; then
+    for SKILL_PATH in "${DEST}"/skills/*/SKILL.md; do
+      [ -f "$SKILL_PATH" ] || continue
+      SKILL_NAME=$(basename "$(dirname "$SKILL_PATH")")
+      if [ ! -e "${OPENCODE_SKILLS}/${SKILL_NAME}" ]; then
+        ln -s "$(dirname "$SKILL_PATH")" "${OPENCODE_SKILLS}/${SKILL_NAME}"
+      fi
+    done
   fi
 
   # Append entry to installed_plugins.json


### PR DESCRIPTION
## Summary

- Symlink Claude Code plugin skills into `~/.config/opencode/skill/` so opencode can discover them
- Uses opencode-only path to avoid duplicate skill loading in Claude Code
- Derives home directory from `$PLUGIN_BASE` to avoid hardcoding username

## Changes

- `claude-config/install-plugins.sh`: After each plugin is installed, iterate over its `skills/*/SKILL.md` files and create symlinks in `~/.config/opencode/skill/<skill-name>` pointing to the skill directory in the plugin cache

## Why opencode-only path?

Claude Code already discovers plugin skills from its cache directory. Symlinking into `~/.claude/skills/` would cause Claude Code to see each skill twice — once as a plugin skill and once as a personal skill. Using `~/.config/opencode/skill/` is only searched by opencode, avoiding duplication.

## Test plan

- [ ] `shellcheck claude-config/install-plugins.sh` passes (verified locally)
- [ ] Docker Publish workflow builds successfully
- [ ] Inside container: `ls -la ~/.config/opencode/skill/` shows symlinks to plugin skill directories
- [ ] Inside container: `cat ~/.config/opencode/skill/frontend-design/SKILL.md` resolves correctly

Closes #301

🤖 Generated with [Claude Code](https://claude.com/claude-code)