### PR TITLE
fix: ensure Anthropic config always overrides oh-my-opencode's opencode.json

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -78,16 +78,17 @@ if [ -f "$HOME/.claude.json" ] && [ -s "$HOME/.claude.json" ]; then
   fi
 fi
 
-# Seed opencode config if missing (dirs pre-created in image)
+# Seed opencode config (dirs pre-created in image)
+# Anthropic token always wins — overwrite any build-time config from oh-my-opencode
 OPENCODE_CONFIG_DIR="$HOME/.config/opencode"
-if [ ! -f "$OPENCODE_CONFIG_DIR/opencode.json" ] || [ ! -s "$OPENCODE_CONFIG_DIR/opencode.json" ]; then
-  if [ -n "$CLAUDE_CODE_OAUTH_TOKEN" ] && [ -f /opt/opencode-config/opencode-anthropic.json ]; then
-    cp /opt/opencode-config/opencode-anthropic.json "$OPENCODE_CONFIG_DIR/opencode.json"
-    # Seed OAuth credentials for opencode's Anthropic provider
-    cat >"$HOME/.local/share/opencode/auth.json" <<AUTHEOF
+if [ -n "$CLAUDE_CODE_OAUTH_TOKEN" ] && [ -f /opt/opencode-config/opencode-anthropic.json ]; then
+  cp /opt/opencode-config/opencode-anthropic.json "$OPENCODE_CONFIG_DIR/opencode.json"
+  # Seed OAuth credentials for opencode's Anthropic provider
+  cat >"$HOME/.local/share/opencode/auth.json" <<AUTHEOF
 {"anthropic":{"type":"oauth","access":"${CLAUDE_CODE_OAUTH_TOKEN}","refresh":"","expires":9999999999999}}
 AUTHEOF
-  elif [ -n "$OPENAI_API_KEY" ] && [ -f /opt/opencode-config/opencode.json ]; then
+elif [ ! -f "$OPENCODE_CONFIG_DIR/opencode.json" ] || [ ! -s "$OPENCODE_CONFIG_DIR/opencode.json" ]; then
+  if [ -n "$OPENAI_API_KEY" ] && [ -f /opt/opencode-config/opencode.json ]; then
     cp /opt/opencode-config/opencode.json "$OPENCODE_CONFIG_DIR/opencode.json"
   fi
 fi


### PR DESCRIPTION
## Summary

- Restructures entrypoint opencode config seeding so `CLAUDE_CODE_OAUTH_TOKEN` always takes precedence over any existing `opencode.json` (including the one written by oh-my-opencode at build time)
- Moves the file-existence guard to only apply to the OpenAI fallback path
- Fixes regression from PR #304 where oh-my-opencode's build-time config blocked Anthropic config and OAuth credential seeding

## Details

PR #304 correctly moved `oh-my-opencode install` to vscode user context, but `oh-my-opencode install --claude=max20` also writes `opencode.json` to `~/.config/opencode/`. At runtime, the entrypoint's guard (`if [ ! -f opencode.json ]`) saw the existing file and skipped seeding the Anthropic config and `auth.json`.

The fix makes the Anthropic token path unconditional — when `CLAUDE_CODE_OAUTH_TOKEN` is set, the Anthropic config always overwrites whatever exists.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

Closes #305

🤖 Generated with [Claude Code](https://claude.com/claude-code)