### PR TITLE
fix: make jq patch of oh-my-opencode config conditional

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1054,11 +1054,14 @@ RUN npx -y oh-my-opencode install --no-tui \
 
 # Preserve oh-my-opencode config as fallback template
 # (entrypoint re-seeds if ~/.config/opencode/ is volume-mounted empty)
-RUN sudo cp ~/.config/opencode/oh-my-opencode.jsonc \
-    /opt/opencode-config/oh-my-opencode.jsonc 2>/dev/null || true \
-    && jq '. + {"claude_code":{"plugins":true,"skills":true,"commands":true,"agents":true,"hooks":true,"mcp":true}}' \
-        /opt/opencode-config/oh-my-opencode.jsonc > /tmp/omc-patched.jsonc \
-    && sudo mv /tmp/omc-patched.jsonc /opt/opencode-config/oh-my-opencode.jsonc
+RUN sudo mkdir -p /opt/opencode-config \
+    && sudo cp ~/.config/opencode/oh-my-opencode.jsonc \
+        /opt/opencode-config/oh-my-opencode.jsonc 2>/dev/null || true
+RUN if [ -f /opt/opencode-config/oh-my-opencode.jsonc ]; then \
+      jq '. + {"claude_code":{"plugins":true,"skills":true,"commands":true,"agents":true,"hooks":true,"mcp":true}}' \
+          /opt/opencode-config/oh-my-opencode.jsonc > /tmp/omc-patched.jsonc \
+      && sudo mv /tmp/omc-patched.jsonc /opt/opencode-config/oh-my-opencode.jsonc; \
+    fi
 COPY opencode-config/oh-my-opencode-proxy.json \
     /opt/opencode-config/oh-my-opencode-proxy.json
 


### PR DESCRIPTION
## Summary

- Split the oh-my-opencode config copy + jq patch into separate RUN layers
- Guard the jq patch with a file existence check to prevent build failures when the source config doesn't exist
- Add `mkdir -p` to ensure `/opt/opencode-config/` exists before copying

## Test plan

- [ ] Docker build succeeds on both amd64 and arm64
- [ ] When oh-my-opencode generates a config, it gets patched with `claude_code`
- [ ] When oh-my-opencode doesn't generate a config (edge case), build still succeeds

Closes #311

🤖 Generated with [Claude Code](https://claude.com/claude-code)