### PR TITLE
fix: correct oh-my-opencode source filename from .jsonc to .json

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1055,7 +1055,7 @@ RUN npx -y oh-my-opencode install --no-tui \
 # Preserve oh-my-opencode config as fallback template
 # (entrypoint re-seeds if ~/.config/opencode/ is volume-mounted empty)
 RUN sudo mkdir -p /opt/opencode-config \
-    && sudo cp ~/.config/opencode/oh-my-opencode.jsonc \
+    && sudo cp ~/.config/opencode/oh-my-opencode.json \
         /opt/opencode-config/oh-my-opencode.jsonc 2>/dev/null || true
 RUN if [ -f /opt/opencode-config/oh-my-opencode.jsonc ]; then \
       jq '. + {"claude_code":{"plugins":true,"skills":true,"commands":true,"agents":true,"hooks":true,"mcp":true}}' \


### PR DESCRIPTION
## Summary

- Fix source filename in Dockerfile `sudo cp` from `oh-my-opencode.jsonc` to `oh-my-opencode.json` (the actual file generated by the installer)
- This was a pre-existing bug that silently failed, preventing the build-time Anthropic config from being preserved

## Test plan

- [ ] Build image and verify `/opt/opencode-config/oh-my-opencode.jsonc` exists and contains `claude_code` block
- [ ] Run with `CLAUDE_CODE_OAUTH_TOKEN` and verify the entrypoint seeds the config
- [ ] Run with `OPENAI_API_KEY` and verify proxy config still works

Closes #313

🤖 Generated with [Claude Code](https://claude.com/claude-code)