### PR TITLE
fix: add oh-my-opencode plugin to Anthropic config and clean up .bak files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1050,7 +1050,8 @@ RUN claude install --force \
 # oh-my-opencode (OpenCode plugin system — "ultrawork" / "ulw" command)
 # hadolint ignore=DL3059
 RUN npx -y oh-my-opencode install --no-tui \
-    --claude=max20 --openai=no --gemini=no --copilot=no
+    --claude=max20 --openai=no --gemini=no --copilot=no \
+    && rm -f ~/.config/opencode/*.bak.*
 
 # Preserve oh-my-opencode config as fallback template
 # (entrypoint re-seeds if ~/.config/opencode/ is volume-mounted empty)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -104,8 +104,9 @@ elif [ -f /opt/opencode-config/oh-my-opencode.json ]; then
   cp /opt/opencode-config/oh-my-opencode.json \
     "$OPENCODE_CONFIG_DIR/oh-my-opencode.json"
 fi
-# Remove stale .jsonc if present (old builds used wrong extension)
+# Remove stale files (old .jsonc extension, oh-my-opencode .bak artifacts)
 rm -f "$OPENCODE_CONFIG_DIR/oh-my-opencode.jsonc"
+rm -f "$OPENCODE_CONFIG_DIR"/*.bak.*
 
 # Seed codex config if missing (dir pre-created in image)
 CODEX_CONFIG_DIR="$HOME/.codex"

--- a/opencode-config/opencode-anthropic.json
+++ b/opencode-config/opencode-anthropic.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://opencode.ai/config.json",
   "permission": "allow",
-  "model": "anthropic/claude-opus-4-6"
+  "model": "anthropic/claude-opus-4-6",
+  "plugin": ["oh-my-opencode@latest"]
 }


### PR DESCRIPTION
## Summary

- Add `"plugin": ["oh-my-opencode@latest"]` to `opencode-anthropic.json` (proxy config already had it)
- Clean up `.bak.*` artifacts left by `oh-my-opencode install` in both Dockerfile and entrypoint

## Test plan

- [ ] Build image and verify no `.bak.*` files in `~/.config/opencode/`
- [ ] Run with Anthropic mode and verify `opencode.json` has `plugin` array
- [ ] Run with proxy mode and verify existing behavior unchanged

Closes #317

🤖 Generated with [Claude Code](https://claude.com/claude-code)