### PR TITLE
feat: switch to oh-my-opencode fork and add bun runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -759,6 +759,12 @@ RUN npm install -g \
     markdownlint-cli \
     asciinema-player
 
+# Bun JavaScript runtime and package manager
+# hadolint ignore=DL3059
+RUN curl -fsSL https://bun.sh/install | bash \
+    && ln -s /home/vscode/.bun/bin/bun /usr/local/bin/bun \
+    && ln -s /home/vscode/.bun/bin/bunx /usr/local/bin/bunx
+
 # ============================================================
 # 12. pip tools
 # ============================================================
@@ -1049,8 +1055,8 @@ RUN claude install --force \
 
 # oh-my-opencode (OpenCode plugin system — "ultrawork" / "ulw" command)
 # hadolint ignore=DL3059
-RUN npx -y oh-my-opencode install --no-tui \
-    --claude=max20 --openai=no --gemini=no --copilot=no \
+RUN npx -y github:robinmordasiewicz/oh-my-openagent#fix/claude-code-plugin-v3-array-format \
+    install --no-tui --claude=max20 --openai=no --gemini=no --copilot=no \
     && rm -f ~/.config/opencode/*.bak.*
 
 # Preserve oh-my-opencode config as fallback template

--- a/opencode-config/opencode-anthropic.json
+++ b/opencode-config/opencode-anthropic.json
@@ -2,5 +2,5 @@
   "$schema": "https://opencode.ai/config.json",
   "permission": "allow",
   "model": "anthropic/claude-opus-4-6",
-  "plugin": ["oh-my-opencode@latest"]
+  "plugin": ["oh-my-opencode@github:robinmordasiewicz/oh-my-openagent#fix/claude-code-plugin-v3-array-format"]
 }

--- a/opencode-config/opencode.json
+++ b/opencode-config/opencode.json
@@ -65,5 +65,5 @@
       "*.env.*": "allow"
     }
   },
-  "plugin": ["oh-my-opencode@latest"]
+  "plugin": ["oh-my-opencode@github:robinmordasiewicz/oh-my-openagent#fix/claude-code-plugin-v3-array-format"]
 }


### PR DESCRIPTION
## Summary

- Switch oh-my-opencode to fork `robinmordasiewicz/oh-my-openagent#fix/claude-code-plugin-v3-array-format` (fixes Claude Code plugin v3 array format bug)
- Add bun JavaScript runtime and package manager (`bun`, `bunx`)
- Update both proxy and Anthropic opencode configs

## Test plan

- [ ] Docker build succeeds with fork and bun installation
- [ ] `bun --version` and `bunx` work in container
- [ ] oh-my-opencode loads correctly from the fork
- [ ] `opencode.json` references the fork plugin in both modes

Closes #319

🤖 Generated with [Claude Code](https://claude.com/claude-code)