### PR TITLE
fix: revert oh-my-opencode install to upstream npm package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1055,8 +1055,8 @@ RUN claude install --force \
 
 # oh-my-opencode (OpenCode plugin system — "ultrawork" / "ulw" command)
 # hadolint ignore=DL3059
-RUN npx -y github:robinmordasiewicz/oh-my-openagent#fix/claude-code-plugin-v3-array-format \
-    install --no-tui --claude=max20 --openai=no --gemini=no --copilot=no \
+RUN npx -y oh-my-opencode install --no-tui \
+    --claude=max20 --openai=no --gemini=no --copilot=no \
     && rm -f ~/.config/opencode/*.bak.*
 
 # Preserve oh-my-opencode config as fallback template


### PR DESCRIPTION
## Summary

- Revert Dockerfile `npx` install back to `oh-my-opencode` from npm
- The fork is only needed as the runtime plugin in `opencode.json`, not for build-time install

## Test plan

- [ ] Docker build succeeds on both amd64 and arm64
- [ ] bun and bunx available in container
- [ ] opencode.json still references the fork plugin

Closes #321

🤖 Generated with [Claude Code](https://claude.com/claude-code)