### PR TITLE
fix: pin oh-my-opencode fork plugin to commit 0d1d405a

### DIFF
--- a/opencode-config/opencode-anthropic.json
+++ b/opencode-config/opencode-anthropic.json
@@ -2,5 +2,5 @@
   "$schema": "https://opencode.ai/config.json",
   "permission": "allow",
   "model": "anthropic/claude-opus-4-6",
-  "plugin": ["oh-my-opencode@github:robinmordasiewicz/oh-my-openagent#fix/claude-code-plugin-v3-array-format"]
+  "plugin": ["oh-my-opencode@github:robinmordasiewicz/oh-my-openagent#0d1d405a"]
 }

--- a/opencode-config/opencode.json
+++ b/opencode-config/opencode.json
@@ -65,5 +65,5 @@
       "*.env.*": "allow"
     }
   },
-  "plugin": ["oh-my-opencode@github:robinmordasiewicz/oh-my-openagent#fix/claude-code-plugin-v3-array-format"]
+  "plugin": ["oh-my-opencode@github:robinmordasiewicz/oh-my-openagent#0d1d405a"]
 }


### PR DESCRIPTION
## Summary

- Pin oh-my-opencode fork plugin reference to commit `0d1d405a` instead of branch name for stability

Closes #323

🤖 Generated with [Claude Code](https://claude.com/claude-code)