### PR TITLE
fix: move bun install after USER vscode and pin plugin to commit hash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -759,12 +759,6 @@ RUN npm install -g \
     markdownlint-cli \
     asciinema-player
 
-# Bun JavaScript runtime and package manager
-# hadolint ignore=DL3059
-RUN curl -fsSL https://bun.sh/install | bash \
-    && ln -s /home/vscode/.bun/bin/bun /usr/local/bin/bun \
-    && ln -s /home/vscode/.bun/bin/bunx /usr/local/bin/bunx
-
 # ============================================================
 # 12. pip tools
 # ============================================================
@@ -1046,6 +1040,12 @@ RUN mkdir -p ~/.cache ~/.local/bin ~/.claude ~/.config/nvim \
     ~/.codex \
     ~/.pi/agent \
     ~/.ssh
+
+# Bun JavaScript runtime and package manager
+# hadolint ignore=DL3059
+RUN curl -fsSL https://bun.sh/install | bash \
+    && sudo ln -s /home/vscode/.bun/bin/bun /usr/local/bin/bun \
+    && sudo ln -s /home/vscode/.bun/bin/bunx /usr/local/bin/bunx
 
 # Install native Claude Code binary (replaces npm package)
 # hadolint ignore=DL3059


### PR DESCRIPTION
## Summary

- Move bun install from root context to after `USER $USERNAME` so it installs to `/home/vscode/.bun/`
- Symlinks at `/usr/local/bin/bun` and `/usr/local/bin/bunx` now point to correct target
- Pin oh-my-opencode plugin to commit `0d1d405a`

## Test plan

- [ ] Docker build succeeds
- [ ] `bun --version` works in container
- [ ] `bunx` works in container
- [ ] opencode.json references commit hash `0d1d405a`

Closes #325

🤖 Generated with [Claude Code](https://claude.com/claude-code)