### PR TITLE
fix: switch to npm-published oh-my-opencode fork and pre-install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1054,9 +1054,11 @@ RUN claude install --force \
     && echo '{"hasCompletedOnboarding":true,"theme":"dark-daltonized","projects":{"/workspace":{"hasTrustDialogAccepted":true}}}' > ~/.claude.json
 
 # oh-my-opencode (OpenCode plugin system — "ultrawork" / "ulw" command)
-# hadolint ignore=DL3059
-RUN npx -y oh-my-opencode install --no-tui \
-    --claude=max20 --openai=no --gemini=no --copilot=no \
+# Pre-install the forked package so it's cached in the image
+# hadolint ignore=DL3016,DL3059
+RUN sudo npm install -g @robinmordasiewicz/oh-my-opencode@3.11.0-fork.1 \
+    && npx -y @robinmordasiewicz/oh-my-opencode install --no-tui \
+        --claude=max20 --openai=no --gemini=no --copilot=no \
     && rm -f ~/.config/opencode/*.bak.*
 
 # Preserve oh-my-opencode config as fallback template

--- a/opencode-config/opencode-anthropic.json
+++ b/opencode-config/opencode-anthropic.json
@@ -2,5 +2,5 @@
   "$schema": "https://opencode.ai/config.json",
   "permission": "allow",
   "model": "anthropic/claude-opus-4-6",
-  "plugin": ["oh-my-opencode@github:robinmordasiewicz/oh-my-openagent#0d1d405a"]
+  "plugin": ["@robinmordasiewicz/oh-my-opencode@3.11.0-fork.1"]
 }

--- a/opencode-config/opencode.json
+++ b/opencode-config/opencode.json
@@ -65,5 +65,5 @@
       "*.env.*": "allow"
     }
   },
-  "plugin": ["oh-my-opencode@github:robinmordasiewicz/oh-my-openagent#0d1d405a"]
+  "plugin": ["@robinmordasiewicz/oh-my-opencode@3.11.0-fork.1"]
 }


### PR DESCRIPTION
## Summary

- Switch to `@robinmordasiewicz/oh-my-opencode@3.11.0-fork.1` from npm
- Pre-install globally via `npm install -g` so it's cached in the image
- Update both `opencode.json` and `opencode-anthropic.json` plugin refs

## Test plan

- [ ] Docker build succeeds
- [ ] oh-my-opencode is pre-installed (`which oh-my-opencode`)
- [ ] No download at runtime when opencode starts
- [ ] `bun --version` works
- [ ] `claude_code` block present in oh-my-opencode config

Closes #327

🤖 Generated with [Claude Code](https://claude.com/claude-code)