### PR TITLE
feat: pre-install oh-my-opencode fork in container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1055,11 +1055,13 @@ RUN claude install --force \
 
 # oh-my-opencode (OpenCode plugin system — "ultrawork" / "ulw" command)
 # Build-time install uses upstream oh-my-opencode (needs platform binaries).
-# Runtime plugin uses the fork (@robinmordasiewicz/oh-my-opencode) via opencode.json.
+# The forked runtime plugin is pre-installed so opencode skips download.
 # hadolint ignore=DL3059
 RUN npx -y oh-my-opencode install --no-tui \
     --claude=max20 --openai=no --gemini=no --copilot=no \
     && rm -f ~/.config/opencode/*.bak.*
+# hadolint ignore=DL3016,DL3059
+RUN sudo npm install -g @robinmordasiewicz/oh-my-opencode@3.11.0-fork.1
 
 # Preserve oh-my-opencode config as fallback template
 # (entrypoint re-seeds if ~/.config/opencode/ is volume-mounted empty)


### PR DESCRIPTION
## Summary

- Pre-install `@robinmordasiewicz/oh-my-opencode@3.11.0-fork.1` via `npm install -g`
- Fork is cached in the image so opencode doesn't download at runtime

## Test plan

- [ ] Docker build succeeds
- [ ] Fork package is pre-installed (`npm list -g @robinmordasiewicz/oh-my-opencode`)
- [ ] opencode doesn't download the plugin at startup

Closes #331

🤖 Generated with [Claude Code](https://claude.com/claude-code)