### PR TITLE
fix: use explicit prefix for oh-my-opencode fork npm install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1061,10 +1061,9 @@ RUN npx -y oh-my-opencode install --no-tui \
     --claude=max20 --openai=no --gemini=no --copilot=no \
     && rm -f ~/.config/opencode/*.bak.*
 # Pre-install the forked plugin under vscode's npm prefix so opencode
-# finds it at startup without downloading (sudo installs to /usr/lib,
-# but opencode resolves from the user's npm prefix).
+# finds it at startup without downloading.
 # hadolint ignore=DL3016,DL3059
-RUN npm install -g @robinmordasiewicz/oh-my-opencode@3.11.0-fork.1
+RUN npm install --prefix ~/.npm-global -g @robinmordasiewicz/oh-my-opencode@3.11.0-fork.1
 
 # Preserve oh-my-opencode config as fallback template
 # (entrypoint re-seeds if ~/.config/opencode/ is volume-mounted empty)


### PR DESCRIPTION
## Summary

- Use `--prefix ~/.npm-global` for the fork npm install to avoid EACCES
- Ensures the fork is installed where opencode can find it

Closes #335

🤖 Generated with [Claude Code](https://claude.com/claude-code)