### PR TITLE
fix: replace F5-specific URLs with generic test targets

### DIFF
--- a/docs/tests/screen-recording.mdx
+++ b/docs/tests/screen-recording.mdx
@@ -19,7 +19,7 @@ This test verifies the full VNC/browser stack by recording a headed browser sess
 1. Polls `xdpyinfo -display :99` until the X display is ready (same pattern as the entrypoint)
 2. Starts ffmpeg recording the display at 10 fps
 3. Launches headed Chromium via Playwright's `sync_api`
-4. Navigates to `https://docs.cloud.f5.com` (3 s pause), then `https://www.f5.com` (3 s pause)
+4. Navigates to `https://example.com` (3 s pause), then `https://httpbin.org` (3 s pause)
 5. Sends SIGTERM to ffmpeg for clean MP4 finalization
 6. Reports the output path and file size
 
@@ -51,8 +51,8 @@ RESOLUTION = "1280x1024"
 FRAMERATE = "10"
 XVFB_TIMEOUT = 50  # iterations (~5 s at 0.1 s each)
 SITES = [
-    ("https://docs.cloud.f5.com", 3),
-    ("https://www.f5.com", 3),
+    ("https://example.com", 3),
+    ("https://httpbin.org", 3),
 ]
 
 
@@ -184,8 +184,8 @@ podman run --rm \
 Waiting for Xvfb on :99 ...
   Display ready after 0.3s
 Starting ffmpeg recording -> /tmp/recording.mp4
-  Navigating to https://docs.cloud.f5.com ...
-  Navigating to https://www.f5.com ...
+  Navigating to https://example.com ...
+  Navigating to https://httpbin.org ...
 Stopping ffmpeg ...
 
 SUCCESS: /tmp/recording.mp4 (1,234,567 bytes)


### PR DESCRIPTION
## Summary

- Replaces `docs.cloud.f5.com` and `www.f5.com` URLs in `docs/tests/screen-recording.mdx` with `example.com` and `httpbin.org`
- These were used as test navigation targets in the screen recording test script and documentation
- Since this repo is public, F5-specific URLs should not appear in test content

Closes #343

## Test plan

- [ ] Verify no `f5.com` domain references remain in `docs/` (excluding org name)
- [ ] Confirm `example.com` and `httpbin.org` are accessible and suitable as test targets
- [ ] CI passes (linting, docs build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)