### PR TITLE
feat: replace SearXNG with Tavily for web search

### DIFF
--- a/.devcontainer/scripts/post-start.sh
+++ b/.devcontainer/scripts/post-start.sh
@@ -28,16 +28,11 @@ if [ -n "$OPENAI_API_KEY" ]; then
   else
     echo "not reachable (check VPN / network connectivity)"
   fi
-  SEARXNG_URL="${SEARXNG_BASE_URL:-http://searxng:8080}"
-  echo -n "  Checking SearXNG MCP ($SEARXNG_URL)... "
-  if [ -f /opt/searxng-mcp/server.py ]; then
-    if curl -sf --connect-timeout 3 "${SEARXNG_URL}/" >/dev/null 2>&1; then
-      echo "MCP installed, backend reachable"
-    else
-      echo "MCP installed, backend not reachable (enable with COMPOSE_PROFILES=search)"
-    fi
+  echo -n "  Checking Tavily web search... "
+  if [ -n "${TAVILY_API_KEY:-}" ]; then
+    echo "API key configured"
   else
-    echo "MCP server not installed"
+    echo "TAVILY_API_KEY not set (add to .env for web search)"
   fi
 else
   echo "  Mode: direct API (no proxy)"

--- a/.env.example
+++ b/.env.example
@@ -84,13 +84,16 @@ ANTHROPIC_API_KEY=sk-ant-your-api-key-here
 # REQUEST_TIMEOUT=120
 
 # =============================================================================
-# Web Search (SearXNG MCP) — OPTIONAL
+# Tavily Web Search — OPTIONAL
 # =============================================================================
-# Web search uses a SearXNG MCP server (stdio) that works with any provider.
-# Enable the SearXNG backend sidecar and the MCP server connects automatically.
+# Tavily provides AI-optimized web search for Claude Code (via skills plugin)
+# and OpenCode (via MCP server). Get a free API key at https://app.tavily.com
+# @auto-detect: printenv TAVILY_API_KEY
+# @requires: TAVILY_API_KEY set in host environment
+# @check: printenv TAVILY_API_KEY
+# @manual: get a free API key at https://app.tavily.com
 
-# COMPOSE_PROFILES=search
-# SEARXNG_BASE_URL=http://searxng:8080
+# TAVILY_API_KEY=tvly-your-api-key-here
 
 # =============================================================================
 # Timezone — OPTIONAL

--- a/Dockerfile
+++ b/Dockerfile
@@ -849,17 +849,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # all require a C compiler.
 
 # ============================================================
-# 12c. SearXNG MCP server (web search for Claude Code)
+# 12c. Tavily web search (skills for Claude Code, MCP for OpenCode)
 # ============================================================
-# stdio MCP server — Claude Code discovers this via settings.json,
-# so it always appears in the tool schema regardless of provider type.
+# Claude Code: Tavily skills plugin installed via npx
+# OpenCode: tavily-mcp package pre-installed for MCP server
 # hadolint ignore=DL3059
-RUN git clone --depth=1 https://github.com/The-AI-Workshops/searxng-mcp-server.git /opt/searxng-mcp
-
-WORKDIR /opt/searxng-mcp
-RUN uv venv .venv \
-    && uv pip install --python .venv/bin/python -r requirements.txt \
-    && chown -R $USERNAME:$USERNAME /opt/searxng-mcp
+RUN npx -y skills add tavily-ai/skills \
+    && npm install -g tavily-mcp@0.1.3
 
 # ============================================================
 # 12d. Ruby linters (rubocop + extensions)

--- a/claude-config/self-test.sh
+++ b/claude-config/self-test.sh
@@ -54,18 +54,17 @@ check "home directory writable" test -w "$HOME"
 check "TERM is set" test -n "${TERM:-}"
 
 echo ""
-echo "5. Web Search (SearXNG MCP)"
-if [ -f /opt/searxng-mcp/server.py ]; then
-  check "SearXNG MCP server installed" true
-  SEARXNG_URL="${SEARXNG_BASE_URL:-http://searxng:8080}"
-  if curl -sf --connect-timeout 3 "${SEARXNG_URL}/" >/dev/null 2>&1; then
-    check "SearXNG backend reachable" true
-  else
-    echo "  SKIP: SearXNG not reachable (enable with COMPOSE_PROFILES=search)"
-  fi
+echo "5. Web Search (Tavily)"
+if [ -d "$HOME/.claude/skills" ] && ls "$HOME/.claude/skills"/*tavily* >/dev/null 2>&1; then
+  check "Tavily skills installed" true
 else
-  echo "  FAIL: SearXNG MCP server not installed at /opt/searxng-mcp"
+  echo "  FAIL: Tavily skills not found in ~/.claude/skills"
   FAIL=$((FAIL + 1))
+fi
+if [ -n "${TAVILY_API_KEY:-}" ]; then
+  check "TAVILY_API_KEY is set" true
+else
+  echo "  SKIP: TAVILY_API_KEY not set (add to .env for web search)"
 fi
 
 echo ""

--- a/claude-config/settings.json
+++ b/claude-config/settings.json
@@ -24,18 +24,10 @@
     "claude-code-setup@claude-plugins-official": true,
     "hookify@claude-plugins-official": true
   },
-  "mcpServers": {
-    "searxng": {
-      "command": "/opt/searxng-mcp/.venv/bin/python",
-      "args": ["/opt/searxng-mcp/server.py"],
-      "env": {
-        "SEARXNG_BASE_URL": "__SEARXNG_URL__",
-        "TRANSPORT": "stdio"
-      }
-    }
-  },
+  "mcpServers": {},
   "env": {
-    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
+    "TAVILY_API_KEY": "__TAVILY_API_KEY__"
   },
   "preferences": {
     "tmuxSplitPanes": true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,33 +40,6 @@ services:
     init: true
     restart: unless-stopped
 
-  searxng:
-    image: searxng/searxng:latest
-    container_name: devcontainer-searxng
-    hostname: searxng
-    profiles:
-      - search
-    ports:
-      - "127.0.0.1:8888:8080"
-    environment:
-      - SEARXNG_BASE_URL=http://searxng:8080
-    configs:
-      - source: searxng-settings
-        target: /etc/searxng/settings.yml
-    restart: unless-stopped
-
 volumes:
   workspace:
   home:
-
-configs:
-  searxng-settings:
-    content: |
-      use_default_settings: true
-      server:
-        limiter: false
-        public_instance: false
-      search:
-        formats:
-          - html
-          - json

--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -116,28 +116,18 @@ The container includes several AI coding agents in addition to Claude Code:
 
 Aider is installed via `uv tool install` with Python 3.12 (it requires Python &lt;3.13) and includes the `browser`, `help`, and `playwright` extras. Pi is installed as a global npm package. Codex is a standalone binary that self-updates at runtime.
 
-### Web Search (SearXNG MCP)
+### Web Search (Tavily)
 
-Web search is provided by a [SearXNG MCP server](https://github.com/The-AI-Workshops/searxng-mcp-server) that runs as a stdio process managed by Claude Code. Because MCP tools always appear in the tool schema regardless of provider type, this works with both direct Anthropic API connections and OpenAI-compatible proxy mode.
+Web search is provided by [Tavily](https://tavily.com), an AI-optimized search API.
 
-The MCP server is pre-installed at `/opt/searxng-mcp` in the container image. The entrypoint automatically seeds the server configuration into `~/.claude/settings.json` at startup.
+- **Claude Code**: Uses the [Tavily skills plugin](https://docs.tavily.com/documentation/agent-skills) — search, research, crawl, and extract capabilities are available as slash commands (`/search`, `/research`, `/crawl`, `/extract`)
+- **OpenCode**: Uses the [Tavily MCP server](https://docs.tavily.com/documentation/mcp) — search tools appear automatically in the tool schema
 
-To enable web search, start the SearXNG backend by adding `search` to your `COMPOSE_PROFILES`:
+| Variable | Description | How to Get |
+|----------|-------------|------------|
+| `TAVILY_API_KEY` | Tavily API key | Free at [app.tavily.com](https://app.tavily.com) |
 
-```ini
-COMPOSE_PROFILES=search
-```
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `SEARXNG_BASE_URL` | `http://searxng:8080` | SearXNG backend URL passed to the MCP server |
-
-SearXNG is a self-hosted metasearch engine that aggregates results from Google, Bing, DuckDuckGo, and others with no API key required. The SearXNG configuration is defined inline in `docker-compose.yml` using the Docker Compose `configs` block, with two changes from the SearXNG defaults required for API access:
-
-- **`search.formats`** includes `json` (the default only allows `html`, which causes `format=json` requests to return 403)
-- **`server.limiter`** is set to `false` (the default rate limiter blocks automated requests)
-
-To customize SearXNG further, edit the `configs.searxng-settings.content` block in `docker-compose.yml`.
+No sidecar container or compose profile is needed — just set your API key in `.env`.
 
 ### Remote Display (noVNC)
 
@@ -289,6 +279,5 @@ Both persist across container restarts and rebuilds. Run `podman-compose pull` t
 | Host | Container | Service |
 |------|-----------|---------|
 | `127.0.0.1:${NOVNC_HOST_PORT:-6080}` | `6080` | noVNC remote display (localhost only, override with `NOVNC_HOST_PORT`) |
-| `127.0.0.1:8888` | `8080` | SearXNG search engine (localhost only, search profile) |
 
-Ports are bound to `127.0.0.1` so they are only accessible from your machine, not the network. The SearXNG port is only active when the search profile is enabled (`COMPOSE_PROFILES=search`). The AI proxy runs inside the container on `localhost:8082` and is not exposed to the host.
+Ports are bound to `127.0.0.1` so they are only accessible from your machine, not the network. The AI proxy runs inside the container on `localhost:8082` and is not exposed to the host.

--- a/docs/local-development.mdx
+++ b/docs/local-development.mdx
@@ -131,7 +131,7 @@ These layers change more frequently (npm/pip updates, config changes) but rebuil
 | 11. npm global tools | claude-code, prettier, markdownlint-cli2, devcontainers-cli, playwright, pi-coding-agent |
 | 12. pip tools | pre-commit, ansible, black, pylint, yamllint, playwright |
 | 12b. Claude Code Proxy | OpenAI-compatible translation proxy |
-| 12c. SearXNG MCP server | stdio MCP server for web search |
+| 12c. Tavily web search | Skills for Claude Code, MCP for OpenCode |
 | 12d. Ruby linters | rubocop + extensions |
 | 12e. Perl linter modules | Perl::Critic extensions |
 | 12f. Lua linter | luacheck |

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -128,13 +128,13 @@ if [ ! -f "$CODEX_CONFIG_DIR/config.toml" ] || [ ! -s "$CODEX_CONFIG_DIR/config.
 fi
 
 # ============================================================
-# SearXNG MCP server (web search via MCP)
+# Tavily web search (API key injection)
 # ============================================================
-# The full settings.json is pre-baked in the image with a
-# __SEARXNG_URL__ placeholder. Replace it with the actual URL.
-if [ -d /opt/searxng-mcp ]; then
-  SEARXNG_MCP_URL="${SEARXNG_BASE_URL:-http://searxng:8080}"
-  sed -i "s|__SEARXNG_URL__|${SEARXNG_MCP_URL}|" "$HOME/.claude/settings.json"
+if [ -n "$TAVILY_API_KEY" ]; then
+  sed -i "s|__TAVILY_API_KEY__|${TAVILY_API_KEY}|" "$HOME/.claude/settings.json"
+else
+  # Remove placeholder if no key provided
+  sed -i 's|__TAVILY_API_KEY__||' "$HOME/.claude/settings.json"
 fi
 
 # ============================================================

--- a/opencode-config/opencode-anthropic.json
+++ b/opencode-config/opencode-anthropic.json
@@ -2,5 +2,15 @@
   "$schema": "https://opencode.ai/config.json",
   "permission": "allow",
   "model": "anthropic/claude-opus-4-6",
-  "plugin": ["@robinmordasiewicz/oh-my-opencode@3.11.0-fork.1"]
+  "plugin": ["@robinmordasiewicz/oh-my-opencode@3.11.0-fork.1"],
+  "mcp": {
+    "tavily": {
+      "type": "local",
+      "command": ["npx", "-y", "tavily-mcp@0.1.3"],
+      "environment": {
+        "TAVILY_API_KEY": "{env:TAVILY_API_KEY}"
+      },
+      "enabled": false
+    }
+  }
 }

--- a/opencode-config/opencode.json
+++ b/opencode-config/opencode.json
@@ -58,5 +58,15 @@
   },
   "model": "openai-proxy/claude-opus-4-6",
   "small_model": "openai-proxy/claude-sonnet-4-6",
-  "plugin": ["@robinmordasiewicz/oh-my-opencode@3.11.0-fork.1"]
+  "plugin": ["@robinmordasiewicz/oh-my-opencode@3.11.0-fork.1"],
+  "mcp": {
+    "tavily": {
+      "type": "local",
+      "command": ["npx", "-y", "tavily-mcp@0.1.3"],
+      "environment": {
+        "TAVILY_API_KEY": "{env:TAVILY_API_KEY}"
+      },
+      "enabled": false
+    }
+  }
 }


### PR DESCRIPTION
## Summary

- Replace SearXNG web search (Docker Compose sidecar + git-cloned Python MCP server) with Tavily (simple API key)
- Claude Code uses Tavily skills plugin (`tavily-ai/skills`) — no MCP server needed
- OpenCode gets Tavily MCP server as disabled fallback (skills preferred via oh-my-opencode)
- Remove SearXNG service and configs block from `docker-compose.yml`

## Test plan

- [ ] Verify Tavily skills install in Docker build (`npx -y skills add tavily-ai/skills`)
- [ ] Verify `tavily-mcp@0.1.3` installs globally
- [ ] Confirm no SearXNG references remain: `grep -ri searxng .`
- [ ] Run `claude-self-test` inside container
- [ ] Test Tavily search with API key set in `.env`

Closes #345

🤖 Generated with [Claude Code](https://claude.com/claude-code)