### PR TITLE
fix: add --yes --global flags to Tavily skills install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1048,7 +1048,7 @@ RUN claude install --force \
 
 # Tavily skills for Claude Code (must run as vscode user with ~/.claude present)
 # hadolint ignore=DL3059
-RUN npx -y skills add tavily-ai/skills
+RUN npx -y skills add tavily-ai/skills --yes --global
 
 # oh-my-opencode (OpenCode plugin system — "ultrawork" / "ulw" command)
 # Build-time install uses upstream oh-my-opencode (needs platform binaries).

--- a/claude-config/self-test.sh
+++ b/claude-config/self-test.sh
@@ -55,10 +55,11 @@ check "TERM is set" test -n "${TERM:-}"
 
 echo ""
 echo "5. Web Search (Tavily)"
-if [ -d "$HOME/.claude/skills" ] && ls "$HOME/.claude/skills"/*tavily* >/dev/null 2>&1; then
+if [ -d "$HOME/.agents/skills" ] && ls "$HOME/.agents/skills"/search >/dev/null 2>&1; then
   check "Tavily skills installed" true
+  check "Tavily skills symlinked to Claude Code" test -L "$HOME/.claude/skills/search"
 else
-  echo "  FAIL: Tavily skills not found in ~/.claude/skills"
+  echo "  FAIL: Tavily skills not found in ~/.agents/skills"
   FAIL=$((FAIL + 1))
 fi
 if [ -n "${TAVILY_API_KEY:-}" ]; then


### PR DESCRIPTION
## Summary

- Add `--yes --global` flags to `npx -y skills add tavily-ai/skills` so it installs non-interactively
- Update self-test to check `~/.agents/skills/search` (actual install location) and verify `~/.claude/skills/search` symlink

## Test plan

- [ ] Pull new image and verify `ls ~/.agents/skills/search` exists
- [ ] Verify `~/.claude/skills/search` is a symlink to `../../.agents/skills/search`
- [ ] Run `claude-self-test` inside container

Closes #349

🤖 Generated with [Claude Code](https://claude.com/claude-code)