### PR TITLE
fix: recreate Tavily skills symlinks in final Docker layer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1181,10 +1181,8 @@ RUN chmod +x /opt/claude-config/self-test.sh /usr/local/lib/claude-proxy.sh /opt
     && cp /opt/claude-config/settings.json /home/${USERNAME}/.claude/settings.json \
     && chown ${USERNAME}:${USERNAME} /home/${USERNAME}/.claude/settings.json \
     && mkdir -p /home/${USERNAME}/.claude/skills \
-    && for skill in /home/${USERNAME}/.agents/skills/*/; do \
-         name=$(basename "$skill"); \
-         ln -sf "../../.agents/skills/$name" "/home/${USERNAME}/.claude/skills/$name"; \
-       done \
+    && find /home/${USERNAME}/.agents/skills -mindepth 1 -maxdepth 1 -type d \
+      -exec sh -c 'name=$(basename "$1"); ln -sf "../../.agents/skills/$name" "/home/'"${USERNAME}"'/.claude/skills/$name"' _ {} \; \
     && chown -R ${USERNAME}:${USERNAME} /home/${USERNAME}/.claude/skills
 
 # Shell hooks: source the proxy function in every interactive shell.


### PR DESCRIPTION
## Summary

- Recreate `~/.claude/skills/` symlinks in section 17 (final layer) after all other `~/.claude/` operations
- Skills are installed to `~/.agents/skills/` but symlinks in `~/.claude/skills/` were lost during build

## Test plan

- [ ] Pull new image and verify `ls -la ~/.claude/skills/` shows symlinks
- [ ] Verify `ls ~/.agents/skills/search/SKILL.md` exists
- [ ] Run `claude-self-test`

Closes #351

🤖 Generated with [Claude Code](https://claude.com/claude-code)