### PR TITLE
feat: auto-derive proxy defaults when OPENAI_API_KEY is set

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,14 +33,17 @@
 # =============================================================================
 
 # =============================================================================
-# AI Provider — REQUIRED
+# AI Provider — REQUIRED (choose ONE mode)
 # =============================================================================
-# Direct mode: Set your Anthropic API key and leave OPENAI_* unset.
-# Get a key at https://console.anthropic.com/ (keys start with "sk-ant-").
+# Three mutually exclusive authentication modes:
 #
-# Proxy mode: Set OPENAI_API_KEY and OPENAI_BASE_URL to route Claude Code
-# through the built-in proxy to any OpenAI-compatible endpoint. Set
-# ANTHROPIC_API_KEY to any non-empty value (the proxy authenticates upstream).
+#   Direct mode:  Set ANTHROPIC_API_KEY only.
+#                 Get a key at https://console.anthropic.com/ (starts with "sk-ant-").
+#
+#   OAuth mode:   Set CLAUDE_CODE_OAUTH_TOKEN only (see Claude Max section below).
+#
+#   Proxy mode:   Set OPENAI_API_KEY + OPENAI_BASE_URL only (see AI Proxy section below).
+#                 ANTHROPIC_API_KEY and model mappings are auto-derived — no need to set them.
 # @auto-detect: printenv ANTHROPIC_API_KEY
 # @requires: ANTHROPIC_API_KEY set in host environment
 # @check: printenv ANTHROPIC_API_KEY
@@ -67,16 +70,14 @@ ANTHROPIC_API_KEY=sk-ant-your-api-key-here
 # Uncomment these lines to route Claude Code through the built-in proxy.
 # The proxy translates Anthropic Messages API calls to OpenAI Chat Completions
 # format and runs as a background process inside the container (localhost:8082).
+#
+# ANTHROPIC_API_KEY and model mappings (BIG_MODEL, MIDDLE_MODEL, SMALL_MODEL)
+# are auto-derived when OPENAI_API_KEY is set — you do not need to add them.
 
 # @manual: get an API key from your OpenAI-compatible provider
 # OPENAI_API_KEY=sk-your-api-key-here
 # @manual: set to your provider's API endpoint
 # OPENAI_BASE_URL=https://your-api-endpoint.example.com/v1
-
-# --- Model mapping (proxy mode only) ---
-# BIG_MODEL=gpt-4o
-# MIDDLE_MODEL=gpt-4o
-# SMALL_MODEL=gpt-4o-mini
 
 # --- Proxy tuning (proxy mode only) ---
 # LOG_LEVEL=WARNING

--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -17,7 +17,13 @@ All configuration lives in the `.env` file at the project root. This file is git
 |----------|-------------|---------|
 | `ANTHROPIC_API_KEY` | API key passed to Claude Code | `sk-ant-abc123...` |
 
-In **direct mode** (default), set this to your Anthropic API key (`sk-ant-...`). In **proxy mode**, this can be any non-empty value — the proxy authenticates upstream with `OPENAI_API_KEY` instead.
+The container supports three **mutually exclusive** authentication modes:
+
+- **Direct mode** (default) — set `ANTHROPIC_API_KEY` to your Anthropic API key (`sk-ant-...`).
+- **OAuth mode** — set `CLAUDE_CODE_OAUTH_TOKEN` only (see below).
+- **Proxy mode** — set `OPENAI_API_KEY` + `OPENAI_BASE_URL` only. `ANTHROPIC_API_KEY` and model mappings are auto-derived (see below).
+
+Do not combine modes — use exactly one.
 
 ### Claude Max (OAuth)
 
@@ -29,7 +35,13 @@ When set, both Claude Code and OpenCode authenticate directly with Anthropic usi
 
 ### AI Proxy (OpenAI-compatible providers)
 
-When `OPENAI_API_KEY` is set, the container automatically starts a built-in proxy process on `localhost:8082` that translates Claude Code's native Anthropic Messages API calls to OpenAI Chat Completions format. No separate container or compose profile is needed.
+When `OPENAI_API_KEY` is set (and `CLAUDE_CODE_OAUTH_TOKEN` is **not**), the container automatically:
+
+1. Starts a built-in proxy on `localhost:8082` that translates Claude Code's Anthropic Messages API calls to OpenAI Chat Completions format.
+2. Sets `ANTHROPIC_API_KEY` to `openai-proxy` (so Claude Code accepts the proxy connection).
+3. Sets `BIG_MODEL`, `MIDDLE_MODEL`, and `SMALL_MODEL` to Claude model names.
+
+You only need two variables in `.env`:
 
 | Variable | Description | Example |
 |----------|-------------|---------|
@@ -38,13 +50,13 @@ When `OPENAI_API_KEY` is set, the container automatically starts a built-in prox
 
 #### Model Mapping (proxy mode only)
 
-The proxy maps Claude Code's model requests to your backend's model identifiers:
+The proxy maps Claude Code's model requests to your backend's model identifiers. These are auto-set and only need overriding for non-Claude providers:
 
 | Variable | Default | Used For |
 |----------|---------|----------|
-| `BIG_MODEL` | `gpt-4o` | Primary model for complex tasks |
-| `MIDDLE_MODEL` | `gpt-4o` | General-purpose model |
-| `SMALL_MODEL` | `gpt-4o-mini` | Fast model for simple tasks |
+| `BIG_MODEL` | `claude-opus-4-6` | Primary model for complex tasks |
+| `MIDDLE_MODEL` | `claude-sonnet-4-6` | General-purpose model |
+| `SMALL_MODEL` | `claude-haiku-4-5` | Fast model for simple tasks |
 
 #### Proxy Tuning (proxy mode only)
 

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -113,7 +113,14 @@ CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-your-token-here
 
 ### Option C: OpenAI-compatible provider
 
-See [Configuration](./configuration) for proxy setup with any OpenAI-compatible endpoint.
+Route through any OpenAI-compatible endpoint (Open WebUI, LiteLLM, etc.) — only two variables needed:
+
+```ini
+OPENAI_API_KEY=sk-your-api-key-here
+OPENAI_BASE_URL=https://your-api-endpoint.example.com/v1
+```
+
+The container auto-derives `ANTHROPIC_API_KEY` and model mappings. See [Configuration](./configuration) for advanced proxy tuning.
 
 ### Auto-populate from local credentials
 

--- a/docs/troubleshooting.mdx
+++ b/docs/troubleshooting.mdx
@@ -74,12 +74,17 @@ echo "$ANTHROPIC_API_KEY"
 Common causes:
 
 - **Placeholder not replaced** — `.env` still has `sk-ant-your-api-key-here`. Replace it with your real key from [console.anthropic.com](https://console.anthropic.com/).
-- **Using an OpenAI-compatible provider without proxy vars** — If your key is not an Anthropic key, you need to set `OPENAI_API_KEY` and `OPENAI_BASE_URL` in `.env` so the built-in proxy activates. Set `ANTHROPIC_API_KEY` to any non-empty value.
+- **Using an OpenAI-compatible provider without proxy vars** — If your key is not an Anthropic key, set `OPENAI_API_KEY` and `OPENAI_BASE_URL` in `.env` so the built-in proxy activates. `ANTHROPIC_API_KEY` is auto-set to `openai-proxy` — you only need:
+
+  ```text
+  OPENAI_API_KEY=<your-provider-key>
+  OPENAI_BASE_URL=<your-provider-url>
+  ```
+
+  If auto-detection isn't working, you can set it manually as a fallback:
 
   ```text
   ANTHROPIC_API_KEY=openai-proxy
-  OPENAI_API_KEY=<your-provider-key>
-  OPENAI_BASE_URL=<your-provider-url>
   ```
 
 <Tabs syncKey="runtime">

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -138,6 +138,20 @@ else
 fi
 
 # ============================================================
+# Proxy mode defaults (OPENAI_API_KEY without OAuth)
+# ============================================================
+# When connecting through an OpenAI-compatible proxy, auto-set
+# ANTHROPIC_API_KEY and model mappings so users only need to
+# configure OPENAI_API_KEY and OPENAI_BASE_URL.
+# These are mutually exclusive with CLAUDE_CODE_OAUTH_TOKEN.
+if [ -n "$OPENAI_API_KEY" ] && [ -z "$CLAUDE_CODE_OAUTH_TOKEN" ]; then
+  export ANTHROPIC_API_KEY="${ANTHROPIC_API_KEY:-openai-proxy}"
+  export BIG_MODEL="${BIG_MODEL:-claude-opus-4-6}"
+  export MIDDLE_MODEL="${MIDDLE_MODEL:-claude-sonnet-4-6}"
+  export SMALL_MODEL="${SMALL_MODEL:-claude-haiku-4-5}"
+fi
+
+# ============================================================
 # Claude Code Proxy (Anthropic Messages API -> OpenAI)
 # ============================================================
 # Source the shared proxy startup function, then invoke it.


### PR DESCRIPTION
## Summary

- Auto-set `ANTHROPIC_API_KEY=openai-proxy` and Claude model mappings (`BIG_MODEL`, `MIDDLE_MODEL`, `SMALL_MODEL`) in `entrypoint.sh` when `OPENAI_API_KEY` is set and `CLAUDE_CODE_OAUTH_TOKEN` is not
- Remove model mapping lines from `.env.example` and document three mutually exclusive auth modes (direct, OAuth, proxy)
- Update docs (`configuration.mdx`, `getting-started.mdx`, `troubleshooting.mdx`) to reflect simplified proxy configuration

## Change Details

| File | Change |
|------|--------|
| `entrypoint.sh` | Add proxy-mode auto-defaults block using `${VAR:-default}` pattern |
| `.env.example` | Remove `BIG_MODEL`/`MIDDLE_MODEL`/`SMALL_MODEL`, add mutual exclusivity docs |
| `docs/configuration.mdx` | Update model defaults to Claude names, document auto-derivation |
| `docs/getting-started.mdx` | Simplify Option C to only two required variables |
| `docs/troubleshooting.mdx` | Update proxy troubleshooting to reflect auto-defaults |

## Test plan

- [x] shellcheck passes on `entrypoint.sh` (no warnings)
- [x] bash syntax check passes (`bash -n entrypoint.sh`)
- [x] Unit tests pass: auto-derive, OAuth exclusivity, explicit overrides preserved, no-OPENAI_API_KEY skipped
- [ ] CI checks pass

Closes #353

🤖 Generated with [Claude Code](https://claude.com/claude-code)