### PR TITLE
feat: update Claude context limits to 1M tokens for Opus 4.6 and Sonnet 4.6

### DIFF
--- a/opencode-config/opencode.json
+++ b/opencode-config/opencode.json
@@ -16,7 +16,7 @@
             "output": ["text"]
           },
           "limit": {
-            "context": 200000,
+            "context": 1000000,
             "output": 128000
           }
         },
@@ -27,8 +27,8 @@
             "output": ["text"]
           },
           "limit": {
-            "context": 200000,
-            "output": 64000
+            "context": 1000000,
+            "output": 128000
           }
         },
         "gpt-5.4": {


### PR DESCRIPTION
## Summary

Update OpenCode model configuration to reflect Anthropic's March 13, 2026 announcement that 1M context windows are now GA for Claude Opus 4.6 and Sonnet 4.6 at standard pricing.

## Changes

- `claude-opus-4-6` context: 200,000 → 1,000,000 tokens
- `claude-sonnet-4-6` context: 200,000 → 1,000,000 tokens
- `claude-sonnet-4-6` output: 64,000 → 128,000 tokens

## Verification

- Confirmed the Open WebUI proxy at `f5ai.pd.f5net.com` accepts large context payloads (~57k tokens tested successfully)
- No proxy-side configuration changes needed — context limits are enforced upstream by Anthropic

Closes #357