### PR TITLE
feat: update Claude Code settings defaults

### DIFF
--- a/claude-config/settings.json
+++ b/claude-config/settings.json
@@ -1,8 +1,12 @@
 {
   "statusLine": { "type": "command", "command": "/opt/claude-config/statusline.sh" },
-  "model": "claude-opus-4-6",
+  "model": "opus[1m]",
   "spinnerTipsEnabled": false,
-  "terminalProgressBarEnabled": true,
+  "terminalProgressBarEnabled": false,
+  "showTurnDuration": false,
+  "prefersReducedMotion": true,
+  "companyAnnouncements": [],
+  "teammateMode": "tmux",
   "defaultMode": "bypassPermissions",
   "skipDangerousModePermissionPrompt": true,
   "permissions": {


### PR DESCRIPTION
## Summary

- Use `opus[1m]` model alias for 1M context window
- Disable `terminalProgressBarEnabled`, `showTurnDuration`
- Enable `prefersReducedMotion`
- Set `teammateMode: "tmux"`
- Add empty `companyAnnouncements`

## Test plan

- [ ] Verify settings.json is valid JSON
- [ ] Pull image and confirm `jq .model ~/.claude/settings.json` returns `opus[1m]`

Closes #361

🤖 Generated with [Claude Code](https://claude.com/claude-code)