### PR TITLE
feat: enable 1M context for OpenCode Anthropic mode

### DIFF
--- a/claude-config/settings.json
+++ b/claude-config/settings.json
@@ -31,7 +31,8 @@
   "mcpServers": {},
   "env": {
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
-    "TAVILY_API_KEY": "__TAVILY_API_KEY__"
+    "TAVILY_API_KEY": "__TAVILY_API_KEY__",
+    "ANTHROPIC_1M_CONTEXT": "true"
   },
   "preferences": {
     "tmuxSplitPanes": true

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -60,6 +60,9 @@ if [ -n "$CLAUDE_CODE_OAUTH_TOKEN" ] && [ -z "$ANTHROPIC_OAUTH_TOKEN" ]; then
   export ANTHROPIC_OAUTH_TOKEN="$CLAUDE_CODE_OAUTH_TOKEN"
 fi
 
+# Enable 1M context window for OpenCode's Anthropic provider
+export ANTHROPIC_1M_CONTEXT="true"
+
 # Seed Pi settings if missing (dirs pre-created in image)
 PI_AGENT_DIR="$HOME/.pi/agent"
 if [ ! -f "$PI_AGENT_DIR/settings.json" ] || [ ! -s "$PI_AGENT_DIR/settings.json" ]; then


### PR DESCRIPTION
## Summary

Enable 1M context window support for OpenCode when using the Anthropic-native provider by exporting `ANTHROPIC_1M_CONTEXT=true`.

## Related Issue

Closes #363

## Changes

- `entrypoint.sh`: Export `ANTHROPIC_1M_CONTEXT=true` unconditionally after the Anthropic env var block
- `claude-config/settings.json`: Add `ANTHROPIC_1M_CONTEXT` to the `env` object for subprocess propagation

The proxy config (`opencode.json`) already has `"context": 1000000` hardcoded — this change covers the Anthropic-native path only.

## Checklist

- [x] Linked to a GitHub issue (required — CI will block merge without it)
- [x] Tested locally
- [x] Follows project conventions