### PR TITLE
docs: add Chrome Headless + DevTools MCP setup guide

### DIFF
--- a/CHROME.md
+++ b/CHROME.md
@@ -183,7 +183,7 @@ RUN npm exec chrome-devtools-mcp@latest -- --version 2>/dev/null || true \
        fi
 ```
 
-### Option B: entrypoint.sh (run-time)
+### Option B: entrypoint.sh (runtime)
 
 Add a function that patches the file on first launch:
 


### PR DESCRIPTION
## Summary

- Add `CHROME.md` documenting the exact changes needed to make the Chrome DevTools MCP server work in the headless ARM64 dev container
- Covers the Chrome symlink (bridging Puppeteer's lookup to Playwright Chromium) and the headless injection patch for the MCP entry point
- Includes problem statement, architecture constraints, implementation options, and verification steps

Closes #365

## Test plan

- [ ] Verify all paths in the document match the current container layout
- [ ] Confirm the symlink command works: `mkdir -p /opt/google/chrome && ln -sf /home/vscode/.cache/ms-playwright/chromium-1208/chrome-linux/chrome /opt/google/chrome/chrome`
- [ ] Confirm the headless patch works when applied to `chrome-devtools-mcp-main.js`
- [ ] Validate MCP tools (navigate_page, take_screenshot, take_snapshot) work after both changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)