### PR TITLE
fix: run Chrome DevTools MCP pre-cache as vscode user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1025,16 +1025,7 @@ RUN npx playwright install --with-deps chromium
 # hadolint ignore=DL3059
 RUN mkdir -p /opt/google/chrome \
     && ln -sf /home/vscode/.cache/ms-playwright/chromium-1208/chrome-linux/chrome \
-              /opt/google/chrome/chrome \
-    && npm exec chrome-devtools-mcp@latest -- --version 2>/dev/null || true \
-    && MCP_MAIN=$(find /home/vscode/.npm/_npx -name 'chrome-devtools-mcp-main.js' \
-                  -path '*/bin/*' 2>/dev/null | head -1) \
-    && if [ -n "$MCP_MAIN" ]; then \
-        sed -i '/^export const args = parseArguments(VERSION);/i \
-// Auto-inject headless mode for container environments without a display server\
-\nif (!process.argv.includes('\''--headless'\'')) {\n    process.argv.push('\''--headless'\'');\n}' \
-          "$MCP_MAIN"; \
-      fi
+              /opt/google/chrome/chrome
 
 # ============================================================
 # User setup
@@ -1069,6 +1060,19 @@ RUN claude install --force \
 # Tavily skills for Claude Code (must run as vscode user with ~/.claude present)
 # hadolint ignore=DL3059
 RUN npx -y skills add tavily-ai/skills --yes --global
+
+# Chrome DevTools MCP: pre-cache and apply headless patch (runs as vscode
+# so npm caches to ~/.npm/_npx; the symlink was created as root in 13b)
+# hadolint ignore=DL3059
+RUN npm exec chrome-devtools-mcp@latest -- --version 2>/dev/null; \
+    MCP_MAIN=$(find ~/.npm/_npx -name 'chrome-devtools-mcp-main.js' \
+      -path '*/bin/*' 2>/dev/null | head -1); \
+    if [ -n "$MCP_MAIN" ]; then \
+      sed -i '/^export const args = parseArguments(VERSION);/i \
+// Auto-inject headless mode for container environments without a display server\
+\nif (!process.argv.includes('\''--headless'\'')) {\n    process.argv.push('\''--headless'\'');\n}' \
+        "$MCP_MAIN"; \
+    fi
 
 # oh-my-opencode (OpenCode plugin system — "ultrawork" / "ulw" command)
 # Build-time install uses upstream oh-my-opencode (needs platform binaries).


### PR DESCRIPTION
## Summary

- Split Dockerfile section 13b: symlink as root, npm exec + headless patch as vscode user
- Fixes Docker Publish failure where `npm exec` as root cached to `/root/.npm/_npx/` instead of `/home/vscode/.npm/_npx/`
- Uses `;` instead of `&&` to isolate npm exec failure from the patch step
- Fixes editorconfig indentation on find continuation line

Closes #369

## Test plan

- [ ] Docker Publish CI passes (both linux/amd64 and linux/arm64)
- [ ] Super-linter passes (editorconfig, shfmt)
- [ ] `claude-self-test` section 9 passes in the built image

🤖 Generated with [Claude Code](https://claude.com/claude-code)