### PR TITLE
fix: dynamically resolve Playwright Chromium path for Chrome symlink

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1023,9 +1023,10 @@ RUN npx playwright install --with-deps chromium
 #      mode in container environments without a display server.
 # ============================================================
 # hadolint ignore=DL3059
-RUN mkdir -p /opt/google/chrome \
-    && ln -sf /home/vscode/.cache/ms-playwright/chromium-1208/chrome-linux/chrome \
-              /opt/google/chrome/chrome
+RUN CHROME_BIN=$(find /root/.cache/ms-playwright /home/vscode/.cache/ms-playwright \
+      -name chrome -path '*/chromium-*/chrome-linux/chrome' 2>/dev/null | head -1) \
+    && mkdir -p /opt/google/chrome \
+    && ln -sf "$CHROME_BIN" /opt/google/chrome/chrome
 
 # ============================================================
 # User setup

--- a/claude-config/self-test.sh
+++ b/claude-config/self-test.sh
@@ -226,8 +226,7 @@ check "all enabled plugins cached" \
 echo ""
 echo "9. Chrome DevTools MCP"
 check "Chrome symlink exists" test -L /opt/google/chrome/chrome
-check "Chrome symlink resolves to Playwright Chromium" \
-  readlink /opt/google/chrome/chrome
+check "Chrome symlink target exists" test -e /opt/google/chrome/chrome
 check "Chrome binary responds" /opt/google/chrome/chrome --version
 MCP_MAIN_FILE=$(find /home/vscode/.npm/_npx -name 'chrome-devtools-mcp-main.js' \
   -path '*/bin/*' 2>/dev/null | head -1)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -177,11 +177,25 @@ fi
 start_claude_proxy
 
 # ============================================================
-# Chrome DevTools MCP (headless patch)
+# Chrome DevTools MCP (symlink + headless patch)
 # ============================================================
-# The MCP server is launched by the Claude Code proxy without
-# --headless. Re-apply the patch if npm exec fetched a newer
-# version since image build.
+# Re-resolve the Chrome symlink if the target is dangling (e.g. after
+# a Playwright update changed the chromium-XXXX directory name).
+# Also re-apply the headless patch if npm exec fetched a newer MCP version.
+fix_chrome_symlink() {
+  if [ -L /opt/google/chrome/chrome ] && [ -e /opt/google/chrome/chrome ]; then
+    return 0
+  fi
+  local chrome_bin
+  chrome_bin=$(find "$HOME/.cache/ms-playwright" /root/.cache/ms-playwright \
+    -name chrome -path '*/chromium-*/chrome-linux/chrome' 2>/dev/null | head -1)
+  if [ -n "$chrome_bin" ]; then
+    sudo mkdir -p /opt/google/chrome
+    sudo ln -sf "$chrome_bin" /opt/google/chrome/chrome
+  fi
+}
+fix_chrome_symlink
+
 patch_chrome_devtools_mcp() {
   local mcp_main
   mcp_main=$(find /home/vscode/.npm/_npx -name 'chrome-devtools-mcp-main.js' \


### PR DESCRIPTION
## Summary

Addresses review feedback from #370:

- Replace hardcoded `chromium-1208` path with dynamic `find` that searches both root and vscode Playwright caches
- Add `fix_chrome_symlink()` to entrypoint.sh that re-resolves dangling symlinks at runtime (handles Playwright updates between image builds)
- Update self-test to verify symlink target exists (not just symlink itself)

### Why

1. `npx playwright install --with-deps chromium` runs as root, caching to `/root/.cache/ms-playwright/`. The previous hardcoded path assumed `/home/vscode/.cache/ms-playwright/chromium-1208/` which may not exist.
2. The `chromium-1208` directory name changes with Playwright updates, breaking the symlink.

### How it works now

**Build time (Dockerfile):**
```dockerfile
RUN CHROME_BIN=$(find /root/.cache/ms-playwright /home/vscode/.cache/ms-playwright \
      -name chrome -path '*/chromium-*/chrome-linux/chrome' 2>/dev/null | head -1) \
    && mkdir -p /opt/google/chrome \
    && ln -sf "$CHROME_BIN" /opt/google/chrome/chrome
```

**Runtime (entrypoint.sh):**
- `fix_chrome_symlink()` checks if the symlink target exists; if dangling, re-resolves from available Playwright caches

Closes #371

## Test plan

- [ ] All CI checks pass
- [ ] Docker Publish succeeds (both amd64 and arm64)
- [ ] `claude-self-test` section 9 passes in built image

🤖 Generated with [Claude Code](https://claude.com/claude-code)