### PR TITLE
fix: replace find|head with find -print -quit to avoid pipefail

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1023,8 +1023,8 @@ RUN npx playwright install --with-deps chromium
 #      mode in container environments without a display server.
 # ============================================================
 # hadolint ignore=DL3059
-RUN CHROME_BIN=$(find /root/.cache/ms-playwright /home/vscode/.cache/ms-playwright \
-      -name chrome -path '*/chromium-*/chrome-linux/chrome' 2>/dev/null | head -1) \
+RUN CHROME_BIN="$(find /root/.cache/ms-playwright /home/vscode/.cache/ms-playwright \
+      -name chrome -path '*/chromium-*/chrome-linux/chrome' -print -quit 2>/dev/null)" \
     && mkdir -p /opt/google/chrome \
     && ln -sf "$CHROME_BIN" /opt/google/chrome/chrome
 
@@ -1066,8 +1066,8 @@ RUN npx -y skills add tavily-ai/skills --yes --global
 # so npm caches to ~/.npm/_npx; the symlink was created as root in 13b)
 # hadolint ignore=DL3059
 RUN npm exec chrome-devtools-mcp@latest -- --version 2>/dev/null; \
-    MCP_MAIN=$(find ~/.npm/_npx -name 'chrome-devtools-mcp-main.js' \
-      -path '*/bin/*' 2>/dev/null | head -1); \
+    MCP_MAIN="$(find ~/.npm/_npx -name 'chrome-devtools-mcp-main.js' \
+      -path '*/bin/*' -print -quit 2>/dev/null)"; \
     if [ -n "$MCP_MAIN" ]; then \
       sed -i '/^export const args = parseArguments(VERSION);/i \
 // Auto-inject headless mode for container environments without a display server\


### PR DESCRIPTION
## Summary

- Replace `find ... | head -1` with `find ... -print -quit` in Chrome symlink and MCP pre-cache steps
- The Dockerfile's `SHELL ["/bin/bash", "-o", "pipefail", "-c"]` causes `find|head` to fail with SIGPIPE, breaking the Docker build

Closes #373

## Test plan

- [ ] All CI checks pass
- [ ] Docker Publish succeeds (both amd64 and arm64)

🤖 Generated with [Claude Code](https://claude.com/claude-code)