### PR TITLE
fix: filter non-existent paths before find in Chrome symlink step

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1022,9 +1022,13 @@ RUN npx playwright install --with-deps chromium
 #      Chromium and patches the MCP entry point for headless
 #      mode in container environments without a display server.
 # ============================================================
-# hadolint ignore=DL3059
-RUN CHROME_BIN="$(find /root/.cache/ms-playwright /home/vscode/.cache/ms-playwright \
-      -name chrome -path '*/chromium-*/chrome-linux/chrome' -print -quit 2>/dev/null)" \
+# hadolint ignore=DL3059,SC2086
+RUN SEARCH="" \
+    && for d in /root/.cache/ms-playwright /home/vscode/.cache/ms-playwright; do \
+        [ -d "$d" ] && SEARCH="$SEARCH $d"; \
+      done \
+    && CHROME_BIN="$(find $SEARCH \
+        -name chrome -path '*/chromium-*/chrome-linux/chrome' -print -quit)" \
     && mkdir -p /opt/google/chrome \
     && ln -sf "$CHROME_BIN" /opt/google/chrome/chrome
 


### PR DESCRIPTION
## Summary

- Build search path list from only existing directories before passing to `find`
- `/home/vscode/.cache/ms-playwright` doesn't exist when section 13b runs (root context, before USER switch)
- `find` exits non-zero when given a non-existent starting path, failing the Docker build

Closes #375

## Test plan

- [ ] All CI checks pass
- [ ] Docker Publish succeeds (both amd64 and arm64)

🤖 Generated with [Claude Code](https://claude.com/claude-code)