### PR TITLE
fix: add || true to for-loop body in Chrome symlink step

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1025,7 +1025,7 @@ RUN npx playwright install --with-deps chromium
 # hadolint ignore=DL3059,SC2086
 RUN SEARCH="" \
     && for d in /root/.cache/ms-playwright /home/vscode/.cache/ms-playwright; do \
-        [ -d "$d" ] && SEARCH="$SEARCH $d"; \
+        [ -d "$d" ] && SEARCH="$SEARCH $d" || true; \
       done \
     && CHROME_BIN="$(find $SEARCH \
         -name chrome -path '*/chromium-*/chrome-linux/chrome' -print -quit)" \


### PR DESCRIPTION
## Summary

- Add `|| true` after `[ -d "$d" ] && SEARCH="$SEARCH $d"` in the for-loop
- When a directory doesn't exist, `[ -d ]` returns 1, which propagates through `done` to the outer `&&` chain, failing the Docker build
- The `|| true` ensures each iteration returns 0 regardless

Closes #377

## Test plan

- [ ] All CI checks pass
- [ ] Docker Publish succeeds (both amd64 and arm64)

🤖 Generated with [Claude Code](https://claude.com/claude-code)