### PR TITLE
fix: simplify Chrome symlink to search only root Playwright cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1022,15 +1022,13 @@ RUN npx playwright install --with-deps chromium
 #      Chromium and patches the MCP entry point for headless
 #      mode in container environments without a display server.
 # ============================================================
-# hadolint ignore=DL3059,SC2086
-RUN SEARCH="" \
-    && for d in /root/.cache/ms-playwright /home/vscode/.cache/ms-playwright; do \
-        [ -d "$d" ] && SEARCH="$SEARCH $d" || true; \
-      done \
-    && CHROME_BIN="$(find $SEARCH \
-        -name chrome -path '*/chromium-*/chrome-linux/chrome' -print -quit)" \
-    && mkdir -p /opt/google/chrome \
-    && ln -sf "$CHROME_BIN" /opt/google/chrome/chrome
+# hadolint ignore=DL3059
+RUN mkdir -p /opt/google/chrome \
+    && CHROME_BIN="$(find /root/.cache/ms-playwright -name chrome \
+        -path '*/chromium-*/chrome-linux/chrome' -print -quit 2>/dev/null || true)" \
+    && if [ -n "$CHROME_BIN" ]; then \
+        ln -sf "$CHROME_BIN" /opt/google/chrome/chrome; \
+      fi
 
 # ============================================================
 # User setup

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -188,7 +188,7 @@ fix_chrome_symlink() {
   fi
   local chrome_bin
   chrome_bin=$(find "$HOME/.cache/ms-playwright" /root/.cache/ms-playwright \
-    -name chrome -path '*/chromium-*/chrome-linux/chrome' 2>/dev/null | head -1)
+    -name chrome -path '*/chromium-*/chrome-linux/chrome' -print -quit 2>/dev/null || true)
   if [ -n "$chrome_bin" ]; then
     sudo mkdir -p /opt/google/chrome
     sudo ln -sf "$chrome_bin" /opt/google/chrome/chrome


### PR DESCRIPTION
## Summary

- Simplify section 13b to only search `/root/.cache/ms-playwright` (the only Playwright cache at this build stage)
- Use `find ... || true` and `if` guard to make the step non-fatal
- Update entrypoint `fix_chrome_symlink()` to use `-print -quit` consistently
- The entrypoint handles runtime fallback by searching both root and user caches

Previous attempts failed because Docker's `bash -o pipefail` propagates errors when:
- `/home/vscode/.cache/ms-playwright` doesn't exist
- `find` returns non-zero for non-existent paths
- For-loop exit status propagation in `&&` chains

Closes #379

## Test plan

- [ ] All CI checks pass
- [ ] Docker Publish succeeds (both amd64 and arm64)

🤖 Generated with [Claude Code](https://claude.com/claude-code)