### PR TITLE
fix: run Playwright browser install as vscode user, not root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1011,24 +1011,10 @@ RUN PLUGIN_BASE="/home/${USERNAME}/.claude/plugins" \
     && chown -R ${USERNAME}:${USERNAME} "${PLUGIN_BASE}"
 
 # ============================================================
-# 13. Playwright browsers (Chromium + system deps)
+# 13. Playwright system dependencies (requires root for apt)
 # ============================================================
 # hadolint ignore=DL3059
-RUN npx playwright install --with-deps chromium
-
-# ============================================================
-# 13b. Chrome DevTools MCP (headless browser automation)
-#      Bridges Puppeteer's Chrome lookup to Playwright's
-#      Chromium and patches the MCP entry point for headless
-#      mode in container environments without a display server.
-# ============================================================
-# hadolint ignore=DL3059
-RUN mkdir -p /opt/google/chrome \
-    && CHROME_BIN="$(find /root/.cache/ms-playwright -name chrome \
-        -path '*/chromium-*/chrome-linux/chrome' -print -quit 2>/dev/null || true)" \
-    && if [ -n "$CHROME_BIN" ]; then \
-        ln -sf "$CHROME_BIN" /opt/google/chrome/chrome; \
-      fi
+RUN npx playwright install-deps chromium
 
 # ============================================================
 # User setup
@@ -1064,8 +1050,16 @@ RUN claude install --force \
 # hadolint ignore=DL3059
 RUN npx -y skills add tavily-ai/skills --yes --global
 
+# Playwright Chromium browser binary (runs as vscode — cache to ~/.cache/ms-playwright)
+# hadolint ignore=DL3059
+RUN npx playwright install chromium \
+    && CHROME_BIN="$(find ~/.cache/ms-playwright \
+        -name chrome -path '*/chromium-*/chrome-linux/chrome' -print -quit)" \
+    && sudo mkdir -p /opt/google/chrome \
+    && sudo ln -sf "$CHROME_BIN" /opt/google/chrome/chrome
+
 # Chrome DevTools MCP: pre-cache and apply headless patch (runs as vscode
-# so npm caches to ~/.npm/_npx; the symlink was created as root in 13b)
+# so npm caches to ~/.npm/_npx; symlink created above)
 # hadolint ignore=DL3059
 RUN npm exec chrome-devtools-mcp@latest -- --version 2>/dev/null; \
     MCP_MAIN="$(find ~/.npm/_npx -name 'chrome-devtools-mcp-main.js' \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -187,7 +187,7 @@ fix_chrome_symlink() {
     return 0
   fi
   local chrome_bin
-  chrome_bin=$(find "$HOME/.cache/ms-playwright" /root/.cache/ms-playwright \
+  chrome_bin=$(find "$HOME/.cache/ms-playwright" \
     -name chrome -path '*/chromium-*/chrome-linux/chrome' -print -quit 2>/dev/null || true)
   if [ -n "$chrome_bin" ]; then
     sudo mkdir -p /opt/google/chrome


### PR DESCRIPTION
## Summary

Fix the root cause behind 5 consecutive fix PRs (#370, #372, #374, #376, #378, #380) — Playwright browser install was running as root, caching to a transient npx directory that got discarded between build steps, leaving Chrome broken in the image.

## Related Issue

Closes #381

## Changes

- **Dockerfile**: Split `npx playwright install --with-deps chromium` (root) into `install-deps` (root, apt libs only) and `install` (vscode user, browser binary + symlink)
- **Dockerfile**: Remove section 13b (root symlink block that searched empty paths) — replaced by vscode-context block after `USER $USERNAME`
- **entrypoint.sh**: Remove `/root/.cache/ms-playwright` from `fix_chrome_symlink()` search path

## Checklist

- [x] Linked to a GitHub issue (required — CI will block merge without it)
- [x] Tested locally
- [x] Follows project conventions