### PR TITLE
fix: use chrome-linux* glob to match chrome-linux64 directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1054,7 +1054,7 @@ RUN npx -y skills add tavily-ai/skills --yes --global
 # hadolint ignore=DL3059
 RUN npx playwright install chromium \
     && CHROME_BIN="$(find ~/.cache/ms-playwright \
-        -name chrome -path '*/chromium-*/chrome-linux/chrome' -print -quit)" \
+        -name chrome -path '*/chromium-*/chrome-linux*/chrome' -print -quit)" \
     && sudo mkdir -p /opt/google/chrome \
     && sudo ln -sf "$CHROME_BIN" /opt/google/chrome/chrome
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -188,7 +188,7 @@ fix_chrome_symlink() {
   fi
   local chrome_bin
   chrome_bin=$(find "$HOME/.cache/ms-playwright" \
-    -name chrome -path '*/chromium-*/chrome-linux/chrome' -print -quit 2>/dev/null || true)
+    -name chrome -path '*/chromium-*/chrome-linux*/chrome' -print -quit 2>/dev/null || true)
   if [ -n "$chrome_bin" ]; then
     sudo mkdir -p /opt/google/chrome
     sudo ln -sf "$chrome_bin" /opt/google/chrome/chrome


### PR DESCRIPTION
## Summary

Fix Chrome find pattern to match `chrome-linux64/` directory name used by Playwright's Chrome for Testing downloads.

## Related Issue

Closes #383

## Changes

- **Dockerfile**: Change find path from `chrome-linux/chrome` to `chrome-linux*/chrome`
- **entrypoint.sh**: Same pattern fix in `fix_chrome_symlink()`

## Checklist

- [x] Linked to a GitHub issue (required — CI will block merge without it)
- [x] Tested locally
- [x] Follows project conventions