### PR TITLE
feat: add iTerm2 image utilities to devcontainer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -491,7 +491,19 @@ RUN ghlatest() { curl -fsSL -o /dev/null -w '%{url_effective}' "https://github.c
     && chown ${USERNAME}:${USERNAME} /usr/local/bin/codex
 
 # ============================================================
-# 10c. Super-linter binary tools (linters + formatters)
+# 10c. iTerm2 terminal image utilities
+#      Standalone scripts — display images, transfer files,
+#      and copy to clipboard via OSC 1337 escape sequences.
+# ============================================================
+# hadolint ignore=DL3059
+RUN for util in imgcat imgls it2dl it2ul it2copy it2check; do \
+      curl ${CURL_RETRY} -fsSL "https://iterm2.com/utilities/${util}" \
+        -o "/usr/local/bin/${util}" \
+      && chmod +x "/usr/local/bin/${util}"; \
+    done
+
+# ============================================================
+# 10d. Super-linter binary tools (linters + formatters)
 #      All resolve latest versions at build time.
 # ============================================================
 # hadolint ignore=DL3059

--- a/claude-config/self-test.sh
+++ b/claude-config/self-test.sh
@@ -238,6 +238,15 @@ else
 fi
 
 echo ""
+echo "10. iTerm2 Utilities"
+check "imgcat installed" command -v imgcat
+check "imgls installed" command -v imgls
+check "it2dl installed" command -v it2dl
+check "it2ul installed" command -v it2ul
+check "it2copy installed" command -v it2copy
+check "it2check installed" command -v it2check
+
+echo ""
 echo "=== Results: $PASS passed, $FAIL failed, $WARN warnings ==="
 
 if [ "$FAIL" -gt 0 ]; then


### PR DESCRIPTION
## Summary

- Install 6 iTerm2 utilities (`imgcat`, `imgls`, `it2dl`, `it2ul`, `it2copy`, `it2check`) as standalone scripts in `/usr/local/bin`
- Add self-test section 10 to verify all utilities are present
- All runtime dependencies already satisfied by base image

## Test plan

- [ ] Docker Publish CI passes on both linux/amd64 and linux/arm64
- [ ] Self-test section 10 reports all 6 utilities installed
- [ ] `imgcat --version` runs successfully in built container
- [ ] Utilities work from iTerm2 via SSH/docker exec

Closes #385

🤖 Generated with [Claude Code](https://claude.com/claude-code)