### PR TITLE
feat: add anti-bot detection tools to devcontainer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -758,6 +758,9 @@ RUN npm install -g \
     @googleworkspace/cli \
     html2canvas \
     playwright \
+    puppeteer \
+    puppeteer-extra \
+    puppeteer-extra-plugin-stealth \
     eslint \
     @biomejs/biome \
     standard \
@@ -791,6 +794,10 @@ RUN pip install --no-cache-dir --break-system-packages --ignore-installed \
     pylint \
     yamllint \
     playwright \
+    playwright-stealth \
+    undetected-chromedriver \
+    nodriver \
+    browserforge \
     "markitdown[all]" \
     progressbar2 \
     checkov \

--- a/claude-config/self-test.sh
+++ b/claude-config/self-test.sh
@@ -247,6 +247,16 @@ check "it2copy installed" command -v it2copy
 check "it2check installed" command -v it2check
 
 echo ""
+echo "11. Anti-Bot Detection Tools"
+check "puppeteer installed (npm)" node -e "require('puppeteer')"
+check "puppeteer-extra installed (npm)" node -e "require('puppeteer-extra')"
+check "puppeteer-extra-plugin-stealth installed (npm)" node -e "require('puppeteer-extra-plugin-stealth')"
+check "playwright-stealth installed (pip)" python3 -c "import playwright_stealth"
+check "undetected-chromedriver installed (pip)" python3 -c "import undetected_chromedriver"
+check "nodriver installed (pip)" python3 -c "import nodriver"
+check "browserforge installed (pip)" python3 -c "import browserforge"
+
+echo ""
 echo "=== Results: $PASS passed, $FAIL failed, $WARN warnings ==="
 
 if [ "$FAIL" -gt 0 ]; then


### PR DESCRIPTION
## Summary

- Add Node.js anti-bot tools: `puppeteer`, `puppeteer-extra`, `puppeteer-extra-plugin-stealth` (npm global)
- Add Python anti-bot tools: `playwright-stealth`, `undetected-chromedriver`, `nodriver`, `browserforge` (pip)
- Add self-test section 11 verifying all 7 packages are importable

## Test plan

- [ ] Docker Publish CI passes on both linux/amd64 and linux/arm64
- [ ] Self-test section 11 reports all 7 packages installed
- [ ] `node -e "require('puppeteer-extra-plugin-stealth')"` succeeds
- [ ] `python3 -c "import playwright_stealth"` succeeds

Closes #387

🤖 Generated with [Claude Code](https://claude.com/claude-code)