### PR TITLE
fix: bust Docker cache for claude-code-proxy git clone

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -856,6 +856,7 @@ RUN UV_TOOL_DIR=/opt/uv-tools UV_TOOL_BIN_DIR=/usr/local/bin \
 # Cache-bust: ADD fetches latest commit metadata; when HEAD changes the
 # API response changes, invalidating the Docker layer cache.
 # hadolint ignore=DL3008,DL3020,DL3059
+#checkov:skip=CKV_DOCKER_4:ADD from URL is intentional for Docker layer cache busting
 ADD https://api.github.com/repos/f5xc-salesdemos/claude-code-proxy/commits/main \
     /tmp/claude-proxy-head.json
 RUN git clone --depth=1 https://github.com/f5xc-salesdemos/claude-code-proxy.git /opt/claude-code-proxy


### PR DESCRIPTION
## Summary

- Adds a Docker `ADD` instruction that fetches the latest commit metadata from the GitHub API before cloning `claude-code-proxy`
- When the upstream repo HEAD changes, the API response changes, invalidating the Docker layer cache and forcing a fresh clone
- Prevents stale cached versions of the proxy from being served after upstream updates

## Test plan

- [ ] Docker Publish CI passes on both linux/amd64 and linux/arm64
- [ ] Container starts and proxy runs when `OPENAI_API_KEY` is set
- [ ] When claude-code-proxy has a new commit, rebuild shows cache miss on the ADD layer

Closes #389

🤖 Generated with [Claude Code](https://claude.com/claude-code)