### PR TITLE
fix: revert dotnet-sdk to 8.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -136,7 +136,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     lua5.4 liblua5.4-dev luarocks \
     r-base \
     dart \
-    dotnet-sdk-9.0 \
+    dotnet-sdk-8.0 \
     # AI assistant tool dependencies
     libbrotli-dev \
     libc-ares-dev \


### PR DESCRIPTION
## Summary
- Revert `dotnet-sdk-9.0` back to `dotnet-sdk-8.0` — the Microsoft packages repo for Ubuntu 24.04 noble does not provide dotnet-sdk-9.0
- This fixes the Docker Publish failure from #392

## Test plan
- [ ] Docker Publish workflow succeeds on both linux/amd64 and linux/arm64

Closes #393

🤖 Generated with [Claude Code](https://claude.com/claude-code)