### PR TITLE
fix: bust Docker cache for claude-code-proxy git clone

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -853,8 +853,8 @@ RUN UV_TOOL_DIR=/opt/uv-tools UV_TOOL_BIN_DIR=/usr/local/bin \
 # ============================================================
 # Runs as a background process in entrypoint.sh when OPENAI_API_KEY is set.
 # Build tools are needed for C extensions (httptools, uvloop) on Python 3.13.
-# Cache-bust: ADD fetches latest commit metadata; when HEAD changes the
-# API response changes, invalidating the Docker layer cache.
+# Cache-bust (2026-03-16): ADD fetches latest commit metadata; when HEAD
+# changes the API response changes, invalidating the Docker layer cache.
 # hadolint ignore=DL3008,DL3020,DL3059
 #checkov:skip=CKV_DOCKER_4:ADD from URL is intentional for Docker layer cache busting
 ADD https://api.github.com/repos/f5xc-salesdemos/claude-code-proxy/commits/main \


### PR DESCRIPTION
## Summary
- Trigger Docker image rebuild to pick up latest `claude-code-proxy` code changes
- Updates the cache-bust comment timestamp to force a new layer

## Test plan
- [ ] Docker Publish workflow succeeds on both linux/amd64 and linux/arm64
- [ ] New image includes latest claude-code-proxy code

Closes #399

🤖 Generated with [Claude Code](https://claude.com/claude-code)