### PR TITLE
fix: whitelist pi-config and post-start.sh in .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,4 +3,6 @@
 !claude-config/
 !opencode-config/
 !codex-config/
+!pi-config/
+!.devcontainer/scripts/
 !configs/


### PR DESCRIPTION
## Summary

- Add `!pi-config/` and `!.devcontainer/scripts/` to `.dockerignore` whitelist

## Why

Docker build from #409 fails on both amd64 and arm64 because `.dockerignore` starts with `*` (ignore all) and the new paths weren't whitelisted:

```
ERROR: "/pi-config/settings.json": not found
ERROR: "/.devcontainer/scripts/post-start.sh": not found
```

Closes #411