### PR TITLE
feat: add .digrc and enhance .tmux.conf with Shift+Enter, VSCode colors, TPM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1166,6 +1166,7 @@ RUN mkdir -p "$HOME/.npm-global" \
     && git clone --depth=1 https://github.com/tfutils/tfenv.git "$HOME/.tfenv" \
     && "$HOME/.tfenv/bin/tfenv" install latest \
     && "$HOME/.tfenv/bin/tfenv" use latest \
+    && git clone --depth=1 https://github.com/tmux-plugins/tpm "$HOME/.tmux/plugins/tpm" \
     && zsh -c "autoload -U compinit && compinit" 2>/dev/null || true
 
 COPY --chown=${USERNAME}:${USERNAME} configs/.p10k.zsh /home/${USERNAME}/.p10k.zsh
@@ -1179,6 +1180,7 @@ COPY --chown=${USERNAME}:${USERNAME} configs/.inputrc /home/${USERNAME}/.inputrc
 COPY --chown=${USERNAME}:${USERNAME} configs/.tmux.conf /home/${USERNAME}/.tmux.conf
 COPY --chown=${USERNAME}:${USERNAME} configs/.nanorc /home/${USERNAME}/.nanorc
 COPY --chown=${USERNAME}:${USERNAME} configs/.lessfilter /home/${USERNAME}/.lessfilter
+COPY --chown=${USERNAME}:${USERNAME} configs/.digrc /home/${USERNAME}/.digrc
 RUN chmod +x /home/${USERNAME}/.lessfilter
 
 # ============================================================

--- a/configs/.digrc
+++ b/configs/.digrc
@@ -1,0 +1,1 @@
++nostats +nocomments +nocmd +noquestion +recurse +search

--- a/configs/.tmux.conf
+++ b/configs/.tmux.conf
@@ -10,6 +10,14 @@ set -as terminal-overrides ",xterm-256color:Smulx=\E[4::%p1%dm"
 
 # Colored underlines (separate underline color — neovim, editors)
 set -as terminal-overrides ",xterm-256color:Setulc=\E[58::2::%p1%{65536}%/%d::%p1%{256}%/%{255}%&%d::%p1%{255}%&%d%;m"
+
+# Extended keys for Shift+Enter pass-through (Claude Code, kitty protocol)
+set -s extended-keys always
+set -as terminal-features ",xterm-256color:extkeys"
+
+# Fallback: explicit Shift+Enter → CSI u binding
+bind-key -n S-Enter send-keys Escape "[13;2u"
+
 set -g history-limit 50000
 set -g mouse on
 set -g focus-events on
@@ -56,10 +64,24 @@ setw -g mode-keys vi
 bind -T copy-mode-vi v send-keys -X begin-selection
 bind -T copy-mode-vi y send-keys -X copy-selection-and-cancel
 
-# ── Status bar ───────────────────────────────────────────
+# ── Plugins (TPM) ─────────────────────────────────────────
+set -g @plugin 'tmux-plugins/tpm'
+set -g @plugin 'tmux-plugins/tmux-sensible'
+
+# ── Appearance (VSCode Dark+ inspired) ────────────────────
+set -g window-active-style 'bg=colour235,fg=colour253'
+set -g window-style 'bg=colour235,fg=colour253'
+set -g pane-border-style 'bg=colour235,fg=colour59'
+set -g pane-active-border-style 'bg=colour235,fg=colour59'
+
+# ── Status bar ─────────────────────────────────────────────
 set -g status-position bottom
 set -g status-interval 5
-set -g status-style "bg=colour235,fg=colour248"
-set -g status-left "#[fg=colour34,bold] #S "
-set -g status-right "#[fg=colour248] %H:%M "
-setw -g window-status-current-style "fg=colour34,bold"
+set -g status-style 'bg=colour32,fg=colour15'
+set -g status-left "#[fg=colour15,bold] #S "
+set -g status-right "#[fg=colour15] %H:%M "
+set -g window-status-style 'bg=default,fg=default'
+setw -g window-status-current-style 'bg=colour39,fg=colour15,bold'
+
+# ── TPM bootstrap (must be last line) ─────────────────────
+run '~/.tmux/plugins/tpm/tpm'


### PR DESCRIPTION
## Summary

- Add `configs/.digrc` for cleaner `dig` output (suppresses stats, comments, cmd, question sections)
- Enhance `.tmux.conf` with extended-keys `always` + CSI u fallback for Shift+Enter pass-through (Claude Code support)
- Add VSCode Dark+ inspired color scheme (pane borders, status bar, window styles)
- Add TPM plugin manager with `tmux-sensible` plugin
- Install TPM in Dockerfile via `git clone --depth=1`

Closes #417

## Test plan

- [ ] Docker build succeeds
- [ ] `~/.digrc` exists in container with correct content
- [ ] `~/.tmux.conf` contains `extended-keys`, `tpm`, and VSCode colour settings
- [ ] `~/.tmux/plugins/tpm/tpm` exists in container
- [ ] tmux starts without errors inside the container
- [ ] Shift+Enter works in Claude Code inside tmux

🤖 Generated with [Claude Code](https://claude.com/claude-code)