### PR TITLE
feat: add language servers and upgrade dotnet to 9.0

### DIFF
--- a/.devcontainer/scripts/post-start.sh
+++ b/.devcontainer/scripts/post-start.sh
@@ -80,7 +80,9 @@ echo "  Installed tools:"
 for cmd in node python3 go rustc javac git gh kubectl helm terraform \
   pre-commit uv claude opencode codex prettier markdownlint-cli2 \
   actionlint act terraform-docs ansible black pylint yamllint yt-dlp \
-  aws az pwsh devcontainer brew playwright; do
+  aws az pwsh devcontainer brew playwright \
+  marksman terraform-ls taplo yaml-language-server bash-language-server \
+  vscode-json-language-server mdx-language-server; do
   if command -v $cmd &>/dev/null; then
     ver=$($cmd --version 2>&1 | head -1 | sed 's/^[[:space:]]*//')
     printf "    %-20s %s\n" "$cmd" "$ver"

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && curl ${CURL_RETRY} -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" | bash - \
     # deadsnakes (Python)
     && add-apt-repository -y ppa:deadsnakes/ppa \
+    # .NET backports (dotnet 9.0+ for Ubuntu 24.04)
+    && add-apt-repository -y ppa:dotnet/backports \
     # HashiCorp
     && curl ${CURL_RETRY} -fsSL https://apt.releases.hashicorp.com/gpg | gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg \
     && echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" \
@@ -136,7 +138,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     lua5.4 liblua5.4-dev luarocks \
     r-base \
     dart \
-    dotnet-sdk-8.0 \
+    dotnet-sdk-9.0 \
     # AI assistant tool dependencies
     libbrotli-dev \
     libc-ares-dev \
@@ -746,6 +748,32 @@ RUN if [ "$(dpkg --print-architecture)" = "amd64" ]; then \
     fi
 
 # ============================================================
+# 10k. Language server binaries (LSP)
+#      Pre-installed for faster editor startup. All resolve
+#      latest versions at build time.
+# ============================================================
+# hadolint ignore=DL3059
+RUN ghlatest() { curl -fsSL -o /dev/null -w '%{url_effective}' "https://github.com/$1/releases/latest" | sed 's|.*/||;s|^v||'; } \
+    && DPKG_ARCH=$(dpkg --print-architecture) && UNAME_ARCH=$(uname -m) \
+    # marksman (Markdown/MDX LSP — self-contained binary, no runtime deps)
+    && if [ "$DPKG_ARCH" = "amd64" ]; then MK_ARCH="x64"; else MK_ARCH="arm64"; fi \
+    && curl ${CURL_RETRY} -fsSLo /usr/local/bin/marksman \
+      "https://github.com/artempyanykh/marksman/releases/latest/download/marksman-linux-${MK_ARCH}" \
+    && chmod +x /usr/local/bin/marksman \
+    # terraform-ls (Terraform LSP — version in asset name)
+    && TFLS_VERSION=$(ghlatest hashicorp/terraform-ls) \
+    && curl ${CURL_RETRY} -fsSL \
+      "https://github.com/hashicorp/terraform-ls/releases/latest/download/terraform-ls_${TFLS_VERSION}_linux_${DPKG_ARCH}.zip" \
+      -o /tmp/terraform-ls.zip \
+    && unzip -q /tmp/terraform-ls.zip -d /usr/local/bin && rm /tmp/terraform-ls.zip \
+    # taplo (TOML LSP — gzip'd binary)
+    && if [ "$UNAME_ARCH" = "x86_64" ]; then TAPLO_ARCH="x86_64"; else TAPLO_ARCH="aarch64"; fi \
+    && curl ${CURL_RETRY} -fsSL \
+      "https://github.com/tamasfe/taplo/releases/latest/download/taplo-linux-${TAPLO_ARCH}.gz" \
+      | gzip -d > /usr/local/bin/taplo \
+    && chmod +x /usr/local/bin/taplo
+
+# ============================================================
 # 11. npm global tools
 # ============================================================
 # hadolint ignore=DL3016,DL3059
@@ -778,7 +806,11 @@ RUN npm install -g \
     asl-validator \
     renovate \
     markdownlint-cli \
-    asciinema-player
+    asciinema-player \
+    yaml-language-server \
+    bash-language-server \
+    @mdx-js/language-server \
+    vscode-langservers-extracted
 
 # ============================================================
 # 12. pip tools

--- a/opencode-config/opencode-anthropic.json
+++ b/opencode-config/opencode-anthropic.json
@@ -3,5 +3,31 @@
   "permission": "allow",
   "model": "anthropic/claude-opus-4-6",
   "plugin": ["@robinmordasiewicz/oh-my-opencode@3.11.0-fork.1"],
-  "mcp": {}
+  "mcp": {},
+  "lsp": {
+    "marksman": {
+      "command": ["marksman", "server"],
+      "extensions": [".md", ".mdx"]
+    },
+    "mdx": {
+      "command": ["mdx-language-server", "--stdio"],
+      "extensions": [".mdx"]
+    },
+    "json": {
+      "command": ["vscode-json-language-server", "--stdio"],
+      "extensions": [".json", ".jsonc"]
+    },
+    "css": {
+      "command": ["vscode-css-language-server", "--stdio"],
+      "extensions": [".css", ".less", ".scss"]
+    },
+    "html": {
+      "command": ["vscode-html-language-server", "--stdio"],
+      "extensions": [".html", ".htm"]
+    },
+    "toml": {
+      "command": ["taplo", "lsp", "stdio"],
+      "extensions": [".toml"]
+    }
+  }
 }

--- a/opencode-config/opencode.json
+++ b/opencode-config/opencode.json
@@ -59,5 +59,31 @@
   "model": "openai-proxy/claude-opus-4-6",
   "small_model": "openai-proxy/claude-sonnet-4-6",
   "plugin": ["@robinmordasiewicz/oh-my-opencode@3.11.0-fork.1"],
-  "mcp": {}
+  "mcp": {},
+  "lsp": {
+    "marksman": {
+      "command": ["marksman", "server"],
+      "extensions": [".md", ".mdx"]
+    },
+    "mdx": {
+      "command": ["mdx-language-server", "--stdio"],
+      "extensions": [".mdx"]
+    },
+    "json": {
+      "command": ["vscode-json-language-server", "--stdio"],
+      "extensions": [".json", ".jsonc"]
+    },
+    "css": {
+      "command": ["vscode-css-language-server", "--stdio"],
+      "extensions": [".css", ".less", ".scss"]
+    },
+    "html": {
+      "command": ["vscode-html-language-server", "--stdio"],
+      "extensions": [".html", ".htm"]
+    },
+    "toml": {
+      "command": ["taplo", "lsp", "stdio"],
+      "extensions": [".toml"]
+    }
+  }
 }


### PR DESCRIPTION
## Summary

- Pre-install language server binaries (marksman, terraform-ls, taplo) and npm packages (yaml-language-server, bash-language-server, @mdx-js/language-server, vscode-langservers-extracted) for LSP intelligence across all editors
- Add OpenCode LSP configuration for non-built-in servers (marksman, mdx, json, css, html, toml)
- Upgrade dotnet-sdk-8.0 to 9.0 via `ppa:dotnet/backports` (required for Ubuntu 24.04)
- Add new tools to post-start.sh verification loop

## Test plan

- [ ] Build the Docker image successfully
- [ ] Verify all new binaries exist: `which marksman terraform-ls taplo yaml-language-server bash-language-server vscode-json-language-server mdx-language-server`
- [ ] Verify `dotnet --version` shows 9.x
- [ ] Verify OpenCode LSP config includes all 6 non-built-in servers
- [ ] Start container and confirm post-start.sh reports all new tools

Closes #421

🤖 Generated with [Claude Code](https://claude.com/claude-code)