### PR TITLE
feat: add TypeScript language server for OpenCode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -810,6 +810,8 @@ RUN npm install -g \
     yaml-language-server \
     bash-language-server \
     @mdx-js/language-server \
+    typescript-language-server \
+    typescript \
     vscode-langservers-extracted
 
 # ============================================================


### PR DESCRIPTION
## Summary
- Add `typescript-language-server` and `typescript` to global npm packages
- Provides TypeScript/JavaScript LSP support needed by OpenCode for code intelligence
- Per [upstream docs](https://github.com/typescript-language-server/typescript-language-server), both packages are required

Closes #427

## Test plan
- [ ] Dockerfile builds successfully
- [ ] `typescript-language-server --version` works in container
- [ ] `tsc --version` works in container
- [ ] OpenCode can use TypeScript LSP for JS/TS files

🤖 Generated with [Claude Code](https://claude.com/claude-code)