### PR TITLE
feat: add pyright and gopls language servers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -538,7 +538,7 @@ RUN ghlatest() { curl -fsSL -o /dev/null -w '%{url_effective}' "https://github.c
     && curl ${CURL_RETRY} -fsSL "https://github.com/dotenv-linter/dotenv-linter/releases/latest/download/dotenv-linter-linux-${DL_ARCH}.tar.gz" \
       | tar -xz -C /usr/local/bin dotenv-linter \
     # gopls (Go LSP server)
-    && GOBIN=/usr/local/bin go install golang.org/x/tools/gopls@latest \
+    && GOBIN=/usr/local/bin go install golang.org/x/tools/gopls@v0.21.1 \
     # golangci-lint (install script auto-detects arch)
     && curl ${CURL_RETRY} -sSfL https://golangci-lint.run/install.sh | sh -s -- -b /usr/local/bin \
     # goreleaser


### PR DESCRIPTION
## Summary
- Add `pyright` to global npm packages for Python LSP support
- Add `gopls` via `go install` for Go LSP support
- Both servers are used by Claude Code and OpenCode for code intelligence

Closes #429

## Test plan
- [ ] Dockerfile builds successfully
- [ ] `pyright --version` works in container
- [ ] `gopls version` works in container
- [ ] OpenCode and Claude Code can use Python/Go LSP for code intelligence

🤖 Generated with [Claude Code](https://claude.com/claude-code)