### PR TITLE
fix: remove chrome-devtools-mcp headless patch, use --headless arg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1106,18 +1106,10 @@ RUN npx playwright install chromium \
     && sudo mkdir -p /opt/google/chrome \
     && sudo ln -sf "$CHROME_BIN" /opt/google/chrome/chrome
 
-# Chrome DevTools MCP: pre-cache and apply headless patch (runs as vscode
-# so npm caches to ~/.npm/_npx; symlink created above)
+# Chrome DevTools MCP: pre-cache the package (runs as vscode so npm caches
+# to ~/.npm/_npx; --headless is passed via .mcp.json args in each content repo)
 # hadolint ignore=DL3059
-RUN npm exec chrome-devtools-mcp@latest -- --version 2>/dev/null; \
-    MCP_MAIN="$(find ~/.npm/_npx -name 'chrome-devtools-mcp-main.js' \
-      -path '*/bin/*' -print -quit 2>/dev/null)"; \
-    if [ -n "$MCP_MAIN" ]; then \
-      sed -i '/^export const args = parseArguments(VERSION);/i \
-// Auto-inject headless mode for container environments without a display server\
-\nif (!process.argv.includes('\''--headless'\'')) {\n    process.argv.push('\''--headless'\'');\n}' \
-        "$MCP_MAIN"; \
-    fi
+RUN npm exec chrome-devtools-mcp@latest -- --version 2>/dev/null || true
 
 # oh-my-opencode (OpenCode plugin system — "ultrawork" / "ulw" command)
 # Build-time install uses upstream oh-my-opencode (needs platform binaries).

--- a/claude-config/self-test.sh
+++ b/claude-config/self-test.sh
@@ -217,9 +217,8 @@ MCP_MAIN_FILE=$(find /home/vscode/.npm/_npx -name 'chrome-devtools-mcp-main.js' 
   -path '*/bin/*' 2>/dev/null | head -1)
 if [ -n "$MCP_MAIN_FILE" ]; then
   check "chrome-devtools-mcp pre-cached" true
-  check "Headless patch applied" grep -q 'Auto-inject headless' "$MCP_MAIN_FILE"
 else
-  echo "  SKIP: chrome-devtools-mcp not yet cached (will be patched on first use)"
+  echo "  SKIP: chrome-devtools-mcp not yet cached (will download on first use)"
 fi
 
 echo ""

--- a/docs/chrome.mdx
+++ b/docs/chrome.mdx
@@ -11,7 +11,7 @@ The container includes a pre-configured [Chrome DevTools MCP](https://github.com
 
 The Chrome DevTools MCP server connects Claude Code to a headless Chromium browser via the Chrome DevTools Protocol. The server is registered as an MCP plugin and launched automatically by the Claude Code proxy when browser tools are needed.
 
-The container patches the MCP server to run in headless mode, since there is no physical display. If VNC is enabled, you can switch to headed mode for visual debugging.
+Content repositories pass `--headless` to the MCP server via `.mcp.json` args, since there is no physical display in the container. If VNC is enabled, you can switch to headed mode for visual debugging.
 
 ## Available Tools
 
@@ -34,7 +34,7 @@ The browser stack uses three components that work together:
 
 1. **Playwright Chromium** — ARM64-compatible Chromium binary installed at build time via `npx playwright install --with-deps chromium`
 2. **Chrome symlink** — bridges Puppeteer's expected path (`/opt/google/chrome/chrome`) to the Playwright binary
-3. **Headless patch** — injects `--headless` into the MCP server's argument parser before launch, since the Claude Code proxy does not pass this flag
+3. **`--headless` flag** — passed via `.mcp.json` args in each content repository, since the container has no physical display
 
 Google Chrome has no ARM64 `.deb` package, and Ubuntu 24.04's `chromium-browser` apt package redirects to snap (which doesn't work in containers). Playwright's bundled Chromium is the only reliable option for ARM64 containers.
 
@@ -68,12 +68,29 @@ ENABLE_VNC=true
 
 Open `http://localhost:6080/vnc.html` to see the virtual display. See [Remote Display (noVNC)](./vnc) for details.
 
-The Chrome DevTools MCP server runs in headless mode by default. For headed debugging, launch Chromium manually:
+When `--headless` is passed via `.mcp.json` args, the MCP server runs without a display. For headed debugging, remove the `--headless` arg and launch Chromium manually:
 
 ```bash
 chromium --no-sandbox &
 ```
 
+## Configuring `--headless` in `.mcp.json`
+
+Each content repository must pass `--headless` to the MCP server via its `.mcp.json` configuration. This is the upstream-supported mechanism and survives package updates via `npx`.
+
+```json
+{
+  "mcpServers": {
+    "chrome-devtools-mcp": {
+      "command": "npx",
+      "args": ["-y", "chrome-devtools-mcp@latest", "--headless"]
+    }
+  }
+}
+```
+
+Without `--headless`, the MCP server attempts to launch a headed browser, which fails inside containers that have no display server.
+
 ## Troubleshooting
 
-See [Troubleshooting — Chrome DevTools MCP](./troubleshooting#chrome-devtools-mcp) for solutions to common issues including missing Chrome executable, headless patch errors, and MCP update handling.
+See [Troubleshooting — Chrome DevTools MCP](./troubleshooting#chrome-devtools-mcp) for solutions to common issues including missing Chrome executable and headless configuration.

--- a/docs/troubleshooting.mdx
+++ b/docs/troubleshooting.mdx
@@ -387,26 +387,20 @@ If the symlink doesn't exist, pull the latest image and restart.
 
 ### "Missing X server to start the headful browser"
 
-The headless patch may not be applied. Check:
+The `--headless` flag is missing from the MCP server configuration. Ensure your `.mcp.json` passes `--headless` in the args:
 
-```bash
-grep 'Auto-inject headless' \
-  "$(find ~/.npm/_npx -name 'chrome-devtools-mcp-main.js' -path '*/bin/*' | head -1)"
+```json
+{
+  "mcpServers": {
+    "chrome-devtools-mcp": {
+      "command": "npx",
+      "args": ["-y", "chrome-devtools-mcp@latest", "--headless"]
+    }
+  }
+}
 ```
 
-If no output, restart the container — the entrypoint re-applies the patch automatically.
-
-### MCP tools fail after chrome-devtools-mcp update
-
-When `npm exec` fetches a newer version, the patch needs to be reapplied. Restart the container or run the entrypoint's patch function manually:
-
-```bash
-# Find the MCP entry point
-MCP_MAIN=$(find ~/.npm/_npx -name 'chrome-devtools-mcp-main.js' -path '*/bin/*' | head -1)
-echo "$MCP_MAIN"
-```
-
-Then restart the container to re-apply the patch. Reconnect with `/mcp` in Claude Code.
+Without `--headless`, the MCP server tries to launch a headed browser, which requires a display server. See [Chrome DevTools MCP — Configuring `--headless`](./chrome#configuring---headless-in-mcpjson) for details.
 
 ## Reset Everything
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -118,7 +118,7 @@ unset _is_litellm_direct
 start_claude_proxy
 
 # ============================================================
-# Chrome DevTools MCP (symlink + headless patch)
+# Chrome DevTools MCP (symlink fix)
 # ============================================================
 fix_chrome_symlink() {
   if [ -L /opt/google/chrome/chrome ] && [ -e /opt/google/chrome/chrome ]; then
@@ -133,19 +133,6 @@ fix_chrome_symlink() {
   fi
 }
 fix_chrome_symlink
-
-patch_chrome_devtools_mcp() {
-  local mcp_main
-  mcp_main=$(find /home/vscode/.npm/_npx -name 'chrome-devtools-mcp-main.js' \
-    -path '*/bin/*' 2>/dev/null | head -1)
-  if [ -n "$mcp_main" ] && ! grep -q 'Auto-inject headless' "$mcp_main"; then
-    sed -i '/^export const args = parseArguments(VERSION);/i \
-// Auto-inject headless mode for container environments without a display server\
-\nif (!process.argv.includes('\''--headless'\'')) {\n    process.argv.push('\''--headless'\'');\n}' \
-      "$mcp_main"
-  fi
-}
-patch_chrome_devtools_mcp
 
 # ============================================================
 # VNC stack (Xvfb + fluxbox + x11vnc + noVNC)


### PR DESCRIPTION
## Summary

- Removes the build-time and runtime sed patches that injected headless mode into `chrome-devtools-mcp`, which were lost when `npx` re-downloaded the package
- Replaces with the upstream-supported `--headless` argument passed via `.mcp.json` args in each content repository
- Updates documentation to explain the new `.mcp.json` configuration approach

## Changes

| File | Change |
|------|--------|
| `Dockerfile` | Remove sed patch block, keep pre-cache only |
| `entrypoint.sh` | Remove `patch_chrome_devtools_mcp()` function and call |
| `claude-config/self-test.sh` | Remove headless patch check |
| `docs/chrome.mdx` | Update architecture docs, add `.mcp.json` config section |
| `docs/troubleshooting.mdx` | Rewrite headless error section, remove obsolete update section |

## Test plan

- [ ] `grep -r 'Auto-inject headless' Dockerfile entrypoint.sh` returns nothing
- [ ] `grep -r 'patch_chrome_devtools_mcp' entrypoint.sh` returns nothing
- [ ] `grep -r 'Headless patch applied' claude-config/self-test.sh` returns nothing
- [ ] CI linting passes
- [ ] Docs build succeeds

Closes #431

🤖 Generated with [Claude Code](https://claude.com/claude-code)