### PR TITLE
fix: rename chrome-devtools-mcp to chrome-devtools

### DIFF
--- a/claude-config/self-test.sh
+++ b/claude-config/self-test.sh
@@ -215,13 +215,13 @@ check "Chrome symlink target exists" test -e /opt/google/chrome/chrome
 check "Chrome binary responds" /opt/google/chrome/chrome --version
 check "chrome-browser.sh installed" test -f /usr/local/lib/chrome-browser.sh
 check "Chrome remote debugging active" curl -sf --connect-timeout 2 http://localhost:9222/json/version
-check "chrome-devtools-mcp in settings" grep -q 'chrome-devtools-mcp' "$HOME/.claude/settings.json"
+check "chrome-devtools in settings" grep -q '"chrome-devtools"' "$HOME/.claude/settings.json"
 MCP_MAIN_FILE=$(find /home/vscode/.npm/_npx -name 'chrome-devtools-mcp-main.js' \
   -path '*/bin/*' 2>/dev/null | head -1)
 if [ -n "$MCP_MAIN_FILE" ]; then
-  check "chrome-devtools-mcp pre-cached" true
+  check "chrome-devtools pre-cached" true
 else
-  echo "  SKIP: chrome-devtools-mcp not yet cached (will download on first use)"
+  echo "  SKIP: chrome-devtools not yet cached (will download on first use)"
 fi
 
 echo ""

--- a/claude-config/settings.json
+++ b/claude-config/settings.json
@@ -29,7 +29,7 @@
     "hookify@claude-plugins-official": true
   },
   "mcpServers": {
-    "chrome-devtools-mcp": {
+    "chrome-devtools": {
       "command": "npx",
       "args": ["-y", "chrome-devtools-mcp@latest", "--browserUrl=http://localhost:9222"]
     }


### PR DESCRIPTION
## Summary

- Renames MCP server key from `chrome-devtools-mcp` to `chrome-devtools` in `settings.json` to match per-repo `.mcp.json` naming convention
- Updates self-test grep patterns to match the new key name
- Prevents Claude Code from registering two separate MCP servers that conflict on Chrome's profile lock

Closes #435

## Test plan

- [ ] CI passes (linting, self-test)
- [ ] Build devcontainer image
- [ ] Verify `claude mcp list` shows one `chrome-devtools` server with `--browserUrl`
- [ ] Verify no `SingletonLock` errors when per-repo `.mcp.json` also defines `chrome-devtools`

🤖 Generated with [Claude Code](https://claude.com/claude-code)