### PR TITLE
feat: split opencode proxy config into anthropic and openai providers

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -87,12 +87,16 @@ AUTHEOF
 elif [ -n "$OPENAI_API_KEY" ]; then
   _esc_base_url=$(printf '%s' "$OPENAI_BASE_URL" | sed 's/[&\\/]/\\&/g')
   _esc_api_key=$(printf '%s' "$OPENAI_API_KEY" | sed 's/[&\\/]/\\&/g')
+  _esc_anthropic_base_url=$(printf '%s' "$ANTHROPIC_BASE_URL" | sed 's/[&\\/]/\\&/g')
+  _esc_anthropic_api_key=$(printf '%s' "$ANTHROPIC_API_KEY" | sed 's/[&\\/]/\\&/g')
   sed -e "s|{env:OPENAI_BASE_URL}|${_esc_base_url}|g" \
     -e "s|{env:OPENAI_API_KEY}|${_esc_api_key}|g" \
+    -e "s|{env:ANTHROPIC_BASE_URL}|${_esc_anthropic_base_url}|g" \
+    -e "s|{env:ANTHROPIC_API_KEY}|${_esc_anthropic_api_key}|g" \
     "$OPENCODE_CONFIG_DIR/opencode.json" \
     >"$OPENCODE_CONFIG_DIR/opencode.json.tmp" &&
     mv "$OPENCODE_CONFIG_DIR/opencode.json.tmp" "$OPENCODE_CONFIG_DIR/opencode.json"
-  unset _esc_base_url _esc_api_key
+  unset _esc_base_url _esc_api_key _esc_anthropic_base_url _esc_anthropic_api_key
   cp "$OPENCODE_CONFIG_DIR/oh-my-opencode-proxy.json" \
     "$OPENCODE_CONFIG_DIR/oh-my-opencode.json"
 fi

--- a/opencode-config/oh-my-opencode-proxy.json
+++ b/opencode-config/oh-my-opencode-proxy.json
@@ -1,18 +1,18 @@
 {
   "$schema": "https://raw.githubusercontent.com/code-yeongyu/oh-my-opencode/master/assets/oh-my-opencode.schema.json",
   "agents": {
-    "sisyphus": { "model": "openai-proxy/claude-opus-4-6" },
-    "oracle": { "model": "openai-proxy/claude-opus-4-6" },
-    "librarian": { "model": "openai-proxy/claude-opus-4-6" },
+    "sisyphus": { "model": "anthropic-proxy/claude-opus-4-6" },
+    "oracle": { "model": "anthropic-proxy/claude-opus-4-6" },
+    "librarian": { "model": "anthropic-proxy/claude-opus-4-6" },
     "explore": { "model": "openai-proxy/grok-code-fast-1" },
-    "multimodal-looker": { "model": "openai-proxy/claude-opus-4-6" },
-    "prometheus": { "model": "openai-proxy/claude-opus-4-6" },
-    "metis": { "model": "openai-proxy/claude-opus-4-6" },
+    "multimodal-looker": { "model": "anthropic-proxy/claude-opus-4-6" },
+    "prometheus": { "model": "anthropic-proxy/claude-opus-4-6" },
+    "metis": { "model": "anthropic-proxy/claude-opus-4-6" },
     "hephaestus": { "model": "openai-proxy/gpt-5.4" },
-    "momus": { "model": "openai-proxy/claude-opus-4-6" },
-    "atlas": { "model": "openai-proxy/claude-sonnet-4-6" },
+    "momus": { "model": "anthropic-proxy/claude-opus-4-6" },
+    "atlas": { "model": "anthropic-proxy/claude-sonnet-4-6" },
     "frontend-ui-ux-engineer": { "model": "openai-proxy/gpt-5.4" },
-    "document-writer": { "model": "openai-proxy/claude-opus-4-6" }
+    "document-writer": { "model": "anthropic-proxy/claude-opus-4-6" }
   },
   "categories": {
     "visual-engineering": { "model": "openai-proxy/gpt-5.4" },
@@ -20,15 +20,16 @@
     "ultrabrain": { "model": "openai-proxy/gpt-5.4" },
     "deep": { "model": "openai-proxy/gpt-5.4" },
     "artistry": { "model": "openai-proxy/gpt-5.4" },
-    "quick": { "model": "openai-proxy/claude-sonnet-4-6" },
-    "unspecified-low": { "model": "openai-proxy/claude-opus-4-6" },
-    "unspecified-high": { "model": "openai-proxy/claude-opus-4-6" },
-    "writing": { "model": "openai-proxy/claude-opus-4-6" }
+    "quick": { "model": "anthropic-proxy/claude-sonnet-4-6" },
+    "unspecified-low": { "model": "anthropic-proxy/claude-opus-4-6" },
+    "unspecified-high": { "model": "anthropic-proxy/claude-opus-4-6" },
+    "writing": { "model": "anthropic-proxy/claude-opus-4-6" }
   },
   "background_task": {
     "defaultConcurrency": 5,
     "providerConcurrency": {
-      "openai-proxy": 5
+      "openai-proxy": 5,
+      "anthropic-proxy": 5
     }
   },
   "claude_code": {

--- a/opencode-config/opencode-permissions.json
+++ b/opencode-config/opencode-permissions.json
@@ -2,6 +2,7 @@
   "$schema": "https://opencode.ai/config.json",
   "permission": {
     "read": {
+      "*": "allow",
       "*.env": "allow",
       "*.env.*": "allow"
     }

--- a/opencode-config/opencode.json
+++ b/opencode-config/opencode.json
@@ -1,12 +1,11 @@
 {
   "$schema": "https://opencode.ai/config.json",
   "provider": {
-    "openai-proxy": {
-      "npm": "@ai-sdk/openai-compatible",
-      "name": "OpenAI Proxy",
+    "anthropic-proxy": {
+      "name": "Anthropic Proxy",
       "options": {
-        "baseURL": "{env:OPENAI_BASE_URL}",
-        "apiKey": "{env:OPENAI_API_KEY}"
+        "baseURL": "{env:ANTHROPIC_BASE_URL}",
+        "apiKey": "{env:ANTHROPIC_API_KEY}"
       },
       "models": {
         "claude-opus-4-6": {
@@ -28,22 +27,35 @@
           },
           "limit": {
             "context": 1000000,
-            "output": 128000
+            "output": 64000
           }
-        },
+        }
+      }
+    },
+    "openai-proxy": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "OpenAI Proxy",
+      "options": {
+        "baseURL": "{env:OPENAI_BASE_URL}",
+        "apiKey": "{env:OPENAI_API_KEY}"
+      },
+      "models": {
         "gpt-5.4": {
-          "name": "GPT-5.4",
+          "name": "GPT 5.4",
           "modalities": {
             "input": ["text", "image"],
             "output": ["text"]
           },
           "limit": {
-            "context": 1050000,
+            "context": 1000000,
             "output": 128000
+          },
+          "options": {
+            "reasoningSummary": null
           }
         },
         "grok-code-fast-1": {
-          "name": "Grok Code Fast 1",
+          "name": "Explore",
           "modalities": {
             "input": ["text"],
             "output": ["text"]
@@ -56,8 +68,8 @@
       }
     }
   },
-  "model": "openai-proxy/claude-opus-4-6",
-  "small_model": "openai-proxy/claude-sonnet-4-6",
+  "model": "anthropic-proxy/claude-opus-4-6",
+  "small_model": "anthropic-proxy/claude-sonnet-4-6",
   "plugin": ["@robinmordasiewicz/oh-my-opencode@3.11.0-fork.1"],
   "mcp": {},
   "lsp": {


### PR DESCRIPTION
## Summary

- Split single `openai-proxy` provider into `anthropic-proxy` (Claude) + `openai-proxy` (GPT/Grok) matching the macbook's tested configuration
- Updated agent/category model routing in oh-my-opencode-proxy.json (Claude agents → `anthropic-proxy/`, GPT agents → `openai-proxy/`)
- Added blanket read permission (`"*": "allow"`) to opencode-permissions.json
- Extended entrypoint.sh to inject `ANTHROPIC_BASE_URL` and `ANTHROPIC_API_KEY` via sed at runtime

## Testing Done

- All JSON files validated with `jq empty`
- Shell syntax checked with `bash -n entrypoint.sh`
- Model limits verified: Sonnet output=64000, GPT-5.4 context=1000000
- No hardcoded secrets (grep clean)
- Cross-file consistency: all model references in oh-my-opencode-proxy.json match providers in opencode.json
- 4 independent reviewers (Oracle compliance audit, code quality, manual QA, scope fidelity) all APPROVED

Closes #439