### PR TITLE
fix: truncate API key to last 20 chars for Claude Code auto-approval

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -68,7 +68,7 @@ fi
 if [ -n "$ANTHROPIC_API_KEY" ] && [ -f "$HOME/.claude.json" ]; then
   jq --arg key "$ANTHROPIC_API_KEY" '
     .customApiKeyResponses.approved = (
-      (.customApiKeyResponses.approved // []) + [$key] | unique
+      (.customApiKeyResponses.approved // []) + [$key[-20:]] | unique
     )' "$HOME/.claude.json" >"$HOME/.claude.json.tmp" &&
     mv "$HOME/.claude.json.tmp" "$HOME/.claude.json"
 fi


### PR DESCRIPTION
## Summary

- Fixed the `jq` expression in `entrypoint.sh` that auto-approves the Claude Code API key
- Changed `[$key]` → `[$key[-20:]]` to store the last 20 characters, matching Claude Code's `normalizeApiKeyForConfig` lookup format

## Problem

When starting Claude Code in proxy mode, the user was always prompted to accept the detected `ANTHROPIC_API_KEY`. The entrypoint had an auto-approve block but it stored the full key while Claude Code's lookup uses only the last 20 characters (`apiKey.slice(-20)`), so the lookup never matched.

## Testing

- jq dry-run confirmed `$key[-20:]` produces correct 20-char suffix
- `bash -n` syntax check passes
- Exactly 1 line changed, no scope creep

Closes #443