### PR TITLE
fix: derive ANTHROPIC_API_KEY from OPENAI_API_KEY before sed substitution

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -54,6 +54,16 @@ if [ -n "$ANTHROPIC_BASE_URL" ]; then
   esac
 fi
 
+# ============================================================
+# Derive ANTHROPIC_API_KEY from OPENAI_API_KEY when not set.
+# Both providers share the same LiteLLM server and API key.
+# Must happen before apiKeyHelper (~line 68), auto-approve
+# (~line 77), and the opencode.json sed substitution (~line 96).
+# ============================================================
+if [ -n "$OPENAI_API_KEY" ]; then
+  export ANTHROPIC_API_KEY="${ANTHROPIC_API_KEY:-$OPENAI_API_KEY}"
+fi
+
 if [ "$_is_litellm_direct" = true ]; then
   export ANTHROPIC_1M_CONTEXT="false"
   sed -i 's|"ANTHROPIC_1M_CONTEXT": "true"|"ANTHROPIC_1M_CONTEXT": "false"|' \


### PR DESCRIPTION
## Summary

Fixes a variable ordering bug in `entrypoint.sh` where `ANTHROPIC_API_KEY` is consumed
before it's ever set when only `OPENAI_API_KEY` is passed in `.env`.

## Related Issue

Closes #447

## Changes

- Insert early derivation block in `entrypoint.sh` after `_is_litellm_direct` detection
  (line 55), before the three consumer blocks (apiKeyHelper at ~68, auto-approve at ~77,
  sed substitution at ~96)
- Both providers use the same LiteLLM server at `f5ai.pd.f5net.com` — same key

## Validation

All 5 auth mode scenarios validated with shell dry-run:
- LiteLLM Direct: ANTHROPIC_API_KEY derives from OPENAI_API_KEY ✅
- Pure Proxy: ANTHROPIC_API_KEY derives from OPENAI_API_KEY ✅
- Direct Anthropic: explicit ANTHROPIC_API_KEY preserved ✅
- OAuth: no keys set, ANTHROPIC_API_KEY stays empty ✅
- Both keys: explicit ANTHROPIC_API_KEY wins ✅

## Checklist

- [x] Linked to a GitHub issue (required — CI will block merge without it)
- [x] Tested locally
- [x] Follows project conventions