### PR TITLE
fix: remove FORCE_AUTOUPDATE_PLUGINS to use pre-baked plugins

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1258,7 +1258,6 @@ RUN chmod +x /usr/local/bin/entrypoint.sh \
     && chown -R ${USERNAME}:${USERNAME} /home/${USERNAME}
 
 USER $USERNAME
-ENV FORCE_AUTOUPDATE_PLUGINS=true
 ENV SHELL=/bin/zsh
 WORKDIR /workspace
 


### PR DESCRIPTION
## Summary
Remove `ENV FORCE_AUTOUPDATE_PLUGINS=true` from Dockerfile to stop Claude Code from re-fetching plugins on every container launch.

## Problem
Claude Code shows "Plugins updated: 9 plugins" on every startup, adding latency before the session is ready.

## Root Cause
`FORCE_AUTOUPDATE_PLUGINS=true` tells Claude Code to re-fetch plugins regardless of whether they are already installed. All 14 plugins are pre-installed at build time (section 12l) via `install-plugins.sh`.

## Change
Single line removal: `ENV FORCE_AUTOUPDATE_PLUGINS=true`

## Verified
All 14 enabled plugins in `settings.json` have valid build-time sources:
| Plugin | Source |
|--------|--------|
| frontend-design | plugins/ (marketplace) |
| code-review | plugins/ (marketplace) |
| code-simplifier | plugins/ (marketplace) |
| feature-dev | plugins/ (marketplace) |
| ralph-loop | plugins/ (marketplace) |
| typescript-lsp | plugins/ (marketplace) |
| commit-commands | plugins/ (marketplace) |
| security-guidance | plugins/ (marketplace) |
| claude-md-management | plugins/ (marketplace) |
| pr-review-toolkit | plugins/ (marketplace) |
| skill-creator | plugins/ (marketplace) |
| claude-code-setup | plugins/ (marketplace) |
| hookify | plugins/ (marketplace) |
| superpowers | git clone obra/superpowers |

Closes #455