### PR TITLE
feat: add /home/vscode as trusted workspace and enable hooks trust

### DIFF
--- a/claude-config/claude.json
+++ b/claude-config/claude.json
@@ -13,6 +13,14 @@
   "projects": {
     "/workspace": {
       "hasTrustDialogAccepted": true,
+      "hasTrustDialogHooksAccepted": true,
+      "projectOnboardingSeenCount": 1,
+      "hasClaudeMdExternalIncludesApproved": true,
+      "hasClaudeMdExternalIncludesWarningShown": true
+    },
+    "/home/vscode": {
+      "hasTrustDialogAccepted": true,
+      "hasTrustDialogHooksAccepted": true,
       "projectOnboardingSeenCount": 1,
       "hasClaudeMdExternalIncludesApproved": true,
       "hasClaudeMdExternalIncludesWarningShown": true


### PR DESCRIPTION
## Summary
- Add /home/vscode to trusted workspaces in claude.json
- Add hasTrustDialogHooksAccepted: true to /workspace entry
- Claude Code will no longer prompt for trust in either directory

Note: Claude Code does not support wildcard trust patterns yet (anthropics/claude-code#23109). Pre-populating known directories is the current workaround.

Closes #457