### PR TITLE
fix: use @ai-sdk/anthropic SDK for opencode anthropic-proxy provider

### DIFF
--- a/opencode-config/opencode.json
+++ b/opencode-config/opencode.json
@@ -2,9 +2,10 @@
   "$schema": "https://opencode.ai/config.json",
   "provider": {
     "anthropic-proxy": {
+      "npm": "@ai-sdk/anthropic",
       "name": "Anthropic Proxy",
       "options": {
-        "baseURL": "{env:ANTHROPIC_BASE_URL}",
+        "baseURL": "{env:ANTHROPIC_BASE_URL}/v1",
         "apiKey": "{env:ANTHROPIC_API_KEY}"
       },
       "models": {


### PR DESCRIPTION
## Summary
- Add `"npm": "@ai-sdk/anthropic"` to anthropic-proxy provider in opencode.json
- Change baseURL template from `{env:ANTHROPIC_BASE_URL}` to `{env:ANTHROPIC_BASE_URL}/v1`
- Without this, OpenCode defaulted to OpenAI-compatible format, sending to /chat/completions instead of /messages

Closes #459