### PR TITLE
fix: add missing config directories to Docker Publish trigger paths

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -9,6 +9,9 @@ on:
       - entrypoint.sh
       - configs/**
       - claude-config/**
+      - opencode-config/**
+      - codex-config/**
+      - pi-config/**
       - docker-compose.yml
       - .devcontainer/**
       - .github/workflows/docker-publish.yml


### PR DESCRIPTION
## Summary
Add three missing directories to Docker Publish workflow trigger paths:
- `opencode-config/**` — OpenCode JSON configs (4 files)
- `codex-config/**` — Codex TOML config (1 file)
- `pi-config/**` — Pi agent settings (1 file)

All three directories contain files COPY'd into the Docker image but were not triggering rebuilds when changed. This also triggers a rebuild now to pick up the opencode SDK fix from PR #460.

Closes #461