### PR TITLE
fix: pre-install opencode provider SDKs into XDG cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1095,17 +1095,20 @@ RUN npm exec chrome-devtools-mcp@latest -- --version 2>/dev/null || true
 RUN npx -y oh-my-opencode install --no-tui \
     --claude=max20 --openai=no --gemini=no --copilot=no \
     && rm -f ~/.config/opencode/*.bak.*
-# Pre-install the forked plugin into opencode's XDG cache so it skips
-# the download on first launch.  Write the cache-version marker ("21")
-# and a package.json with the pinned dependency so BunProc.install()
-# sees the package as already present.
+# Pre-install opencode plugins and provider SDKs into the XDG cache so
+# opencode skips npm downloads on first launch.  Write the cache-version
+# marker ("21") and seed package.json so BunProc.install() sees every
+# package as already present.
 # hadolint ignore=DL3059
 RUN OPENCODE_CACHE="$HOME/.cache/opencode" \
     && mkdir -p "$OPENCODE_CACHE" \
     && printf '21' > "$OPENCODE_CACHE/version" \
     && printf '{"dependencies":{}}\n' > "$OPENCODE_CACHE/package.json" \
     && bun add --cwd "$OPENCODE_CACHE" --force --exact \
-        @robinmordasiewicz/oh-my-opencode@3.11.0-fork.1
+        @robinmordasiewicz/oh-my-opencode@3.11.0-fork.1 \
+        @ai-sdk/anthropic@latest \
+        @ai-sdk/openai-compatible@latest \
+        opencode-anthropic-auth@0.0.13
 
 # Patch oh-my-opencode config in-place with claude_code integration flags
 # hadolint ignore=DL3059


### PR DESCRIPTION
## Summary
Pre-install three additional npm packages into OpenCode's XDG cache at build time:
- `@ai-sdk/anthropic@latest` — Anthropic provider SDK (used by anthropic-proxy)
- `@ai-sdk/openai-compatible@latest` — OpenAI-compatible SDK (used by openai-proxy)
- `opencode-anthropic-auth@0.0.13` — built-in auth plugin (hardcoded in opencode source)

Combined with the oh-my-opencode plugin fix from PR #465, all 4 packages that OpenCode downloads on startup are now pre-baked.