### PR TITLE
fix: use built-in model shorthand to avoid duplicate Opus menu entry

### DIFF
--- a/claude-config/settings.json
+++ b/claude-config/settings.json
@@ -1,6 +1,6 @@
 {
   "statusLine": { "type": "command", "command": "/opt/claude-config/statusline.sh" },
-  "model": "claude-opus-4-6",
+  "model": "opus",
   "spinnerTipsEnabled": false,
   "terminalProgressBarEnabled": false,
   "showTurnDuration": false,


### PR DESCRIPTION
## Summary
- Changes `"model": "claude-opus-4-6"` to `"model": "opus"` in `claude-config/settings.json`
- The raw API model ID caused Claude Code to show a duplicate "Opus 4.6" entry in the `/model` menu alongside the built-in "Opus (1M context)" entry
- Using the built-in shorthand `"opus"` resolves the duplication

Closes #469

## Test plan
- [ ] Rebuild the container (or manually update `~/.claude/settings.json`)
- [ ] Run `claude --dangerously-skip-permissions` and type `/model`
- [ ] Confirm Opus appears only once with a ✔ checkmark
- [ ] Confirm the startup banner still shows "Opus 4.6"

🤖 Generated with [Claude Code](https://claude.com/claude-code)