### PR TITLE
feat: pre-install OpenCode provider SDK packages to eliminate first-launch downloads

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1095,17 +1095,20 @@ RUN npm exec chrome-devtools-mcp@latest -- --version 2>/dev/null || true
 RUN npx -y oh-my-opencode install --no-tui \
     --claude=max20 --openai=no --gemini=no --copilot=no \
     && rm -f ~/.config/opencode/*.bak.*
-# Pre-install the forked plugin into opencode's XDG cache so it skips
-# the download on first launch.  Write the cache-version marker ("21")
-# and a package.json with the pinned dependency so BunProc.install()
-# sees the package as already present.
+# Pre-install npm packages into opencode's XDG cache so it skips
+# downloads on first launch.  Write the cache-version marker ("21")
+# and a package.json with pinned dependencies so BunProc.install()
+# sees each package as already present.
 # hadolint ignore=DL3059
 RUN OPENCODE_CACHE="$HOME/.cache/opencode" \
     && mkdir -p "$OPENCODE_CACHE" \
     && printf '21' > "$OPENCODE_CACHE/version" \
     && printf '{"dependencies":{}}\n' > "$OPENCODE_CACHE/package.json" \
     && bun add --cwd "$OPENCODE_CACHE" --force --exact \
-        @robinmordasiewicz/oh-my-opencode@3.11.0-fork.1
+        @robinmordasiewicz/oh-my-opencode@3.11.0-fork.1 \
+        @ai-sdk/anthropic \
+        @ai-sdk/openai-compatible \
+        opencode-anthropic-auth@0.0.13
 
 # Patch oh-my-opencode config in-place with claude_code integration flags
 # hadolint ignore=DL3059


### PR DESCRIPTION
## Summary
- Add `@ai-sdk/anthropic`, `@ai-sdk/openai-compatible`, and `opencode-anthropic-auth@0.0.13` to the existing `bun add` command that pre-populates `~/.cache/opencode/node_modules/`
- Eliminates ~15-30s of npm downloads on first OpenCode launch
- Extends the approach from PR #465 (which pre-installed only the oh-my-opencode plugin) to cover all 4 packages OpenCode needs

## Test plan
- [ ] Build the Docker image: `docker build -t test .`
- [ ] Verify all 4 packages exist in `~/.cache/opencode/node_modules/`
- [ ] Confirm `~/.cache/opencode/package.json` lists all 4 dependencies
- [ ] Launch `opencode` and confirm no npm download activity on startup

Closes #471

🤖 Generated with [Claude Code](https://claude.com/claude-code)