### PR TITLE
fix: use proxy-compatible model names for subagents

### DIFF
--- a/claude-config/settings.json
+++ b/claude-config/settings.json
@@ -36,7 +36,10 @@
   },
   "env": {
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
-    "ANTHROPIC_1M_CONTEXT": "true"
+    "ANTHROPIC_SMALL_FAST_MODEL": "claude-haiku-4-5",
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL": "claude-haiku-4-5",
+    "ANTHROPIC_DEFAULT_SONNET_MODEL": "claude-sonnet-4-6",
+    "ANTHROPIC_DEFAULT_OPUS_MODEL": "claude-opus-4-6"
   },
   "preferences": {
     "tmuxSplitPanes": true

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -52,7 +52,14 @@ if [ -n "$OPENAI_API_KEY" ]; then
   export ANTHROPIC_API_KEY="${ANTHROPIC_API_KEY:-$OPENAI_API_KEY}"
 fi
 
-export ANTHROPIC_1M_CONTEXT="true"
+# When running behind a proxy that requires short model names (no date suffixes),
+# override Claude Code's default model IDs to use proxy-compatible names.
+if [ -n "$ANTHROPIC_BASE_URL" ]; then
+  export ANTHROPIC_SMALL_FAST_MODEL="${ANTHROPIC_SMALL_FAST_MODEL:-claude-haiku-4-5}"
+  export ANTHROPIC_DEFAULT_HAIKU_MODEL="${ANTHROPIC_DEFAULT_HAIKU_MODEL:-claude-haiku-4-5}"
+  export ANTHROPIC_DEFAULT_SONNET_MODEL="${ANTHROPIC_DEFAULT_SONNET_MODEL:-claude-sonnet-4-6}"
+  export ANTHROPIC_DEFAULT_OPUS_MODEL="${ANTHROPIC_DEFAULT_OPUS_MODEL:-claude-opus-4-6}"
+fi
 
 # ============================================================
 # Auto-approve ANTHROPIC_API_KEY in Claude Code state


### PR DESCRIPTION
## Summary

- Override Claude Code's default date-suffixed model IDs with short names the corporate proxy accepts
- Add model override env vars to `settings.json` and conditional exports in `entrypoint.sh`
- Remove unused `ANTHROPIC_1M_CONTEXT` env var (not read by Claude Code binary)

Closes #481

## Test plan

- [x] Verified `ANTHROPIC_1M_CONTEXT` does not appear in Claude Code v2.1.80 binary (only `CLAUDE_CODE_DISABLE_1M_CONTEXT` exists)
- [x] Verified all 4 model override env vars are picked up by Claude Code after restart
- [x] Spawned a haiku subagent through the F5 AI proxy — no more `400: Invalid model name`
- [x] `entrypoint.sh` exports are conditional on `ANTHROPIC_BASE_URL` being set, with `${VAR:-default}` for user overrides

🤖 Generated with [Claude Code](https://claude.com/claude-code)