### PR TITLE
fix: use proxy-compatible model names and remove unused ANTHROPIC_1M_CONTEXT

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1169,9 +1169,6 @@ grep -q 'iTerm.app' ~/.zshrc || \
 grep -q 'LITELLM_API_KEY' ~/.zshrc || \
   echo "export LITELLM_API_KEY=\"${LITELLM_API_KEY}\"" >> ~/.zshrc
 
-# Enable 1M token context for Anthropic models
-grep -q 'ANTHROPIC_1M_CONTEXT' ~/.zshrc || \
-  echo 'export ANTHROPIC_1M_CONTEXT=true' >> ~/.zshrc
 ```
 
 ### Activate Environment for Current Session
@@ -1330,7 +1327,6 @@ All four runtime packages should be pre-installed. If any are missing, re-run `(
 ```bash
 echo $BUN_INSTALL            # VERIFY: output is /Users/<username>/.bun (not empty)
 echo $LITELLM_API_KEY        # VERIFY: output is your API key (not empty, not a placeholder)
-echo $ANTHROPIC_1M_CONTEXT   # VERIFY: output is "true"
 ```
 
 ### 16.9 — Claude Code Plugins

--- a/claude-config/settings.json
+++ b/claude-config/settings.json
@@ -36,7 +36,10 @@
   },
   "env": {
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
-    "ANTHROPIC_1M_CONTEXT": "true"
+    "ANTHROPIC_SMALL_FAST_MODEL": "claude-haiku-4-5",
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL": "claude-haiku-4-5",
+    "ANTHROPIC_DEFAULT_SONNET_MODEL": "claude-sonnet-4-6",
+    "ANTHROPIC_DEFAULT_OPUS_MODEL": "claude-opus-4-6"
   },
   "preferences": {
     "tmuxSplitPanes": true

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -57,7 +57,16 @@ if [ -n "$LITELLM_BASE_URL" ]; then
   export ANTHROPIC_BASE_URL="${LITELLM_BASE_URL}/anthropic"
 fi
 
-export ANTHROPIC_1M_CONTEXT="true"
+# ============================================================
+# Override Claude Code's default date-suffixed model IDs with
+# short names the LiteLLM proxy accepts.
+# ============================================================
+if [ -n "$LITELLM_BASE_URL" ]; then
+  export ANTHROPIC_SMALL_FAST_MODEL="claude-haiku-4-5"
+  export ANTHROPIC_DEFAULT_HAIKU_MODEL="claude-haiku-4-5"
+  export ANTHROPIC_DEFAULT_SONNET_MODEL="claude-sonnet-4-6"
+  export ANTHROPIC_DEFAULT_OPUS_MODEL="claude-opus-4-6"
+fi
 
 # ============================================================
 # Auto-approve ANTHROPIC_API_KEY in Claude Code state


### PR DESCRIPTION
## Summary
- Override Claude Code's default date-suffixed model IDs with short names the LiteLLM proxy accepts
- Remove unused `ANTHROPIC_1M_CONTEXT` env var (not read by Claude Code binary)
- No `${VAR:-default}` fallback patterns — clean break

## Issue
Closes #485
Supersedes #481 / PR #482 (closed due to conflicts with LITELLM consolidation)

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
- [x] `bash -n entrypoint.sh` passes
- [x] `jq . claude-config/settings.json` valid JSON
- [x] Zero `ANTHROPIC_1M_CONTEXT` references remaining
- [x] Model overrides guarded by `LITELLM_BASE_URL` presence

## Checklist
- [x] I have performed a self-review of my code
- [x] My changes follow the existing code style
- [x] I have made corresponding changes to the documentation