### PR TITLE
fix: pin chrome-devtools-mcp version and fix Playwright require() resolution

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -817,6 +817,10 @@ RUN npm install -g \
     pyright \
     vscode-langservers-extracted
 
+# Ensure Node.js can resolve globally-installed packages at the system prefix
+# even after npm prefix is changed to $HOME/.npm-global later.
+ENV NODE_PATH=/usr/lib/node_modules
+
 # ============================================================
 # 12. pip tools
 # ============================================================
@@ -1044,7 +1048,7 @@ RUN PLUGIN_BASE="/home/${USERNAME}/.claude/plugins" \
 # 13. Playwright system dependencies (requires root for apt)
 # ============================================================
 # hadolint ignore=DL3059
-RUN npx playwright install-deps chromium
+RUN npx playwright install-deps
 
 # ============================================================
 # User setup
@@ -1077,7 +1081,7 @@ RUN claude install --force \
 
 # Playwright Chromium browser binary (runs as vscode — cache to ~/.cache/ms-playwright)
 # hadolint ignore=DL3059
-RUN npx playwright install chromium \
+RUN npx playwright install \
     && CHROME_BIN="$(find ~/.cache/ms-playwright \
         -name chrome -path '*/chromium-*/chrome-linux*/chrome' -print -quit)" \
     && sudo mkdir -p /opt/google/chrome \
@@ -1086,7 +1090,7 @@ RUN npx playwright install chromium \
 # Chrome DevTools MCP: pre-cache the package (runs as vscode so npm caches
 # to ~/.npm/_npx; --headless is passed via .mcp.json args in each content repo)
 # hadolint ignore=DL3059
-RUN npm exec chrome-devtools-mcp@latest -- --version 2>/dev/null || true
+RUN npm exec chrome-devtools-mcp@0.20.2 -- --version 2>/dev/null || true
 
 # oh-my-opencode (OpenCode plugin system — "ultrawork" / "ulw" command)
 # Build-time install uses upstream oh-my-opencode (needs platform binaries).

--- a/claude-config/settings.json
+++ b/claude-config/settings.json
@@ -31,7 +31,7 @@
   "mcpServers": {
     "chrome-devtools": {
       "command": "npx",
-      "args": ["-y", "chrome-devtools-mcp@latest", "--browserUrl=http://localhost:9222"]
+      "args": ["-y", "chrome-devtools-mcp@0.20.2", "--browserUrl=http://localhost:9222"]
     }
   },
   "env": {


### PR DESCRIPTION
## Summary

- Pin `chrome-devtools-mcp@0.20.2` in both `settings.json` and Dockerfile pre-cache to avoid npm registry checks that fail offline
- Add `ENV NODE_PATH=/usr/lib/node_modules` so Node.js can resolve packages installed at the system prefix after npm prefix change to `$HOME/.npm-global`
- Install Playwright system deps and browser binaries for all engines (Chromium, Firefox, WebKit), not just chromium

## Test plan

- [x] `NODE_PATH=/usr/lib/node_modules node -e "require('playwright')"` succeeds
- [x] `npx -y chrome-devtools-mcp@0.20.2 --help` resolves from cache without network
- [ ] Rebuild container image and verify `/mcp` shows chrome-devtools server
- [ ] Rebuild container image and verify `require('playwright')` works without explicit NODE_PATH

Closes #493

🤖 Generated with [Claude Code](https://claude.com/claude-code)