### PR TITLE
fix: move MCP config to settings.local.json for detection

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1234,8 +1234,9 @@ RUN chmod +x /opt/claude-config/self-test.sh \
     && ln -s /opt/claude-config/self-test.sh /usr/local/bin/claude-self-test \
     && mkdir -p /etc/claude-code/.claude/rules
 
-# --- Claude Code: settings.json + claude.json → final $HOME paths ---
+# --- Claude Code: settings.json + settings.local.json + claude.json → final $HOME paths ---
 COPY --chown=${USERNAME}:${USERNAME} claude-config/settings.json /home/${USERNAME}/.claude/settings.json
+COPY --chown=${USERNAME}:${USERNAME} claude-config/settings.local.json /home/${USERNAME}/.claude/settings.local.json
 COPY --chown=${USERNAME}:${USERNAME} claude-config/claude.json /home/${USERNAME}/.claude.json
 
 # --- OpenCode: bake all config variants to final paths ---

--- a/claude-config/settings.json
+++ b/claude-config/settings.json
@@ -28,12 +28,6 @@
     "claude-code-setup@claude-plugins-official": true,
     "hookify@claude-plugins-official": true
   },
-  "mcpServers": {
-    "chrome-devtools": {
-      "command": "npx",
-      "args": ["-y", "chrome-devtools-mcp@0.20.2", "--browserUrl=http://localhost:9222"]
-    }
-  },
   "env": {
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
     "ANTHROPIC_SMALL_FAST_MODEL": "claude-haiku-4-5",

--- a/claude-config/settings.local.json
+++ b/claude-config/settings.local.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "chrome-devtools": {
+      "command": "npx",
+      "args": ["-y", "chrome-devtools-mcp@0.20.2", "--browserUrl=http://localhost:9222"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Move `mcpServers` block from `claude-config/settings.json` to new `claude-config/settings.local.json`
- Add Dockerfile COPY for `settings.local.json` → `~/.claude/settings.local.json`
- Claude Code ignores `mcpServers` in `settings.json` — only reads MCP config from `settings.local.json`, `~/.claude.json`, or `.mcp.json`

## Context

PR #494 pinned `chrome-devtools-mcp@0.20.2` in `settings.json`, but the MCP server was never detected because `~/.claude/settings.json` is not a valid MCP config location. Confirmed via [claude-code#4976](https://github.com/anthropics/claude-code/issues/4976).

Closes #495

## Test plan

- [ ] Rebuild container and verify `~/.claude/settings.local.json` exists
- [ ] Run `claude mcp list` — should show `chrome-devtools`
- [ ] Run `/mcp` in a Claude session — should show chrome-devtools as configured
- [ ] Verify `settings.json` no longer contains `mcpServers` block

🤖 Generated with [Claude Code](https://claude.com/claude-code)