### PR TITLE
fix: move MCP server config to ~/.claude.json for Claude Code detection

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1234,9 +1234,8 @@ RUN chmod +x /opt/claude-config/self-test.sh \
     && ln -s /opt/claude-config/self-test.sh /usr/local/bin/claude-self-test \
     && mkdir -p /etc/claude-code/.claude/rules
 
-# --- Claude Code: settings.json + settings.local.json + claude.json → final $HOME paths ---
+# --- Claude Code: settings.json + claude.json → final $HOME paths ---
 COPY --chown=${USERNAME}:${USERNAME} claude-config/settings.json /home/${USERNAME}/.claude/settings.json
-COPY --chown=${USERNAME}:${USERNAME} claude-config/settings.local.json /home/${USERNAME}/.claude/settings.local.json
 COPY --chown=${USERNAME}:${USERNAME} claude-config/claude.json /home/${USERNAME}/.claude.json
 
 # --- OpenCode: bake all config variants to final paths ---

--- a/claude-config/claude.json
+++ b/claude-config/claude.json
@@ -10,6 +10,12 @@
   "officialMarketplaceAutoInstallAttempted": true,
   "officialMarketplaceAutoInstalled": true,
   "cachedChromeExtensionInstalled": false,
+  "mcpServers": {
+    "chrome-devtools": {
+      "command": "npx",
+      "args": ["-y", "chrome-devtools-mcp@0.20.2", "--browserUrl=http://localhost:9222"]
+    }
+  },
   "projects": {
     "/workspace": {
       "hasTrustDialogAccepted": true,

--- a/claude-config/settings.local.json
+++ b/claude-config/settings.local.json
@@ -1,8 +1,0 @@
-{
-  "mcpServers": {
-    "chrome-devtools": {
-      "command": "npx",
-      "args": ["-y", "chrome-devtools-mcp@0.20.2", "--browserUrl=http://localhost:9222"]
-    }
-  }
-}


### PR DESCRIPTION
## Summary

- Move `mcpServers` config from `settings.local.json` to `claude.json` (`~/.claude.json`), the correct file for MCP server configuration per [Claude Code docs](https://code.claude.com/docs/en/settings)
- Delete orphaned `claude-config/settings.local.json` and its Dockerfile `COPY`
- Verified: `/mcp` now shows chrome-devtools as configured

Closes #499

## Context

Third attempt to fix MCP config placement. Previous attempts (#494, #496) placed `mcpServers` in `settings.json` and `settings.local.json` respectively — both silently ignore the key. Only `~/.claude.json` (user scope) or `.mcp.json` (project scope) are read for MCP config.

Reference: [anthropics/claude-code#4976](https://github.com/anthropics/claude-code/issues/4976)

## Test plan

- [x] `~/.claude.json` contains top-level `mcpServers.chrome-devtools`
- [x] `~/.claude/settings.local.json` no longer exists
- [x] `/mcp` in Claude Code shows chrome-devtools server
- [ ] Container build succeeds (no broken COPY for deleted file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)