### PR TITLE
feat: add missing dotfiles, zsh plugins, and opencode completion to laptop install

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -874,14 +874,14 @@ grep '^plugins=' ~/.zshrc       # VERIFY: output includes zsh-claudecode-complet
 | `terraform` | OMZ built-in | Terraform completions and aliases |
 | `fluxcd` | OMZ built-in | FluxCD completions |
 | `azure` | OMZ built-in | Azure CLI completions |
-| `git-auto-fetch` | OMZ built-in | Auto-fetches git remotes in background |
+| `git-auto-fetch` | OMZ built-in | Auto-fetches Git remotes in background |
 | `helm` | OMZ built-in | Helm completions |
 | `istioctl` | OMZ built-in | Istio CLI completions |
 | `iterm2` | OMZ built-in | iTerm2 shell integration |
 | `kube-ps1` | OMZ built-in | Kubernetes context/namespace in prompt |
 | `kubectl` | OMZ built-in | kubectl completions and aliases |
 | `sudo` | OMZ built-in | Press Escape twice to prepend `sudo` to current command |
-| `vscode` | OMZ built-in | VS Code aliases (`code .`, etc.) |
+| `vscode` | OMZ built-in | Visual Studio Code aliases (`code .`, etc.) |
 | `aws` | OMZ built-in | AWS CLI completions |
 | `fzf` | OMZ built-in | Fuzzy finder integration (Ctrl+R history, Ctrl+T files) |
 | `docker` | OMZ built-in | Docker completions |
@@ -890,7 +890,7 @@ grep '^plugins=' ~/.zshrc       # VERIFY: output includes zsh-claudecode-complet
 | `command-not-found` | OMZ built-in | Suggests packages when a command is not found |
 | `tmux` | OMZ built-in | Tmux aliases and completions |
 | `zsh-claudecode-completion` | Custom clone | Tab completions for Claude Code CLI |
-| `zsh-eza` | Custom clone | Enhanced `ls` using `eza` with icons and git status |
+| `zsh-eza` | Custom clone | Enhanced `ls` using `eza` with icons and Git status |
 
 **Note**: The devcontainer also includes the `ubuntu` plugin which is Linux-only and not applicable to macOS.
 


### PR DESCRIPTION
## Summary

- Add 5 missing custom zsh plugin clones to match devcontainer Dockerfile
- Expand `plugins=()` from 5 to 31 plugins matching container (minus `ubuntu`)
- Replace manual `p10k configure` wizard with pre-built `configs/.p10k.zsh` copy
- Add dotfile install step: `.tmux.conf`, `.digrc`, `.inputrc`, `.nanorc`, `.lessfilter`, `.hushlogin`
- Add tmux plugin manager (tpm) clone required by `.tmux.conf`
- Add Oh My Zsh settings: `HYPHEN_INSENSITIVE`, `COMPLETION_WAITING_DOTS`, `HIST_STAMPS`
- Add environment exports: `HISTSIZE`, `SAVEHIST`, `LESS`, `LESSHISTFILE`, `LESSOPEN`, `MANPAGER`, `BAT_THEME`, `vim` alias
- Add `opencode completion` registration to zsh site-functions
- Remove `nuclei` (SIGSEGV crash on macOS, unusable)

Closes #513

## Test plan

- [ ] Run Step 5.4 plugin clones — all 8 directories exist under `~/.oh-my-zsh/custom/plugins/`
- [ ] Run Step 5.5 sed commands — `grep '^plugins=' ~/.zshrc` shows full 31-plugin list
- [ ] Run Step 5.6 — `~/.p10k.zsh` exists and matches `configs/.p10k.zsh`
- [ ] Run Step 5.7 — all 7 dotfiles exist in `~/`, `.lessfilter` is executable
- [ ] Run Step 14.2 — `HYPHEN_INSENSITIVE`, `COMPLETION_WAITING_DOTS`, `HIST_STAMPS` set in `~/.zshrc`
- [ ] Run Step 14.3 — environment exports present in `~/.zshrc`
- [ ] `opencode <TAB>` shows completion suggestions in new iTerm2 session
- [ ] `nuclei` no longer referenced in install or verify steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)