### PR TITLE
fix: opencode zsh completion uses .zshrc append instead of site-functions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1202,7 +1202,7 @@ RUN mkdir -p "$HOME/.npm-global" \
     && "$HOME/.tfenv/bin/tfenv" install latest \
     && "$HOME/.tfenv/bin/tfenv" use latest \
     && git clone --depth=1 https://github.com/tmux-plugins/tpm "$HOME/.tmux/plugins/tpm" \
-    && opencode completion > /usr/local/share/zsh/site-functions/_opencode \
+    && opencode completion >> "$HOME/.zshrc" \
     && gog completion zsh > /usr/local/share/zsh/site-functions/_gog \
     && zsh -c "autoload -U compinit && compinit" 2>/dev/null || true
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -2314,9 +2314,9 @@ grep -q 'BUN_INSTALL/bin' ~/.zshrc || \
 grep -q '_bun' ~/.zshrc || \
   echo '[ -s "$HOME/.bun/_bun" ] && source "$HOME/.bun/_bun"'  >> ~/.zshrc
 
-# gogcli (gog) zsh completion
-# OpenCode zsh completion
-opencode completion > /opt/homebrew/share/zsh/site-functions/_opencode 2>/dev/null || true
+# OpenCode zsh completion (append to .zshrc — site-functions doesn't work with yargs completions)
+grep -q 'opencode-completions' ~/.zshrc || \
+  opencode completion >> ~/.zshrc
 
 # gogcli (gog) zsh completion
 gog completion zsh > /opt/homebrew/share/zsh/site-functions/_gog 2>/dev/null || true


### PR DESCRIPTION
## Summary

- Fix opencode completion on both macOS (INSTALL.md) and container (Dockerfile)
- Yargs completions don't work via `site-functions/_opencode` due to function name mismatch (`_opencode_yargs_completions` vs `_opencode`)
- Append to `.zshrc` instead (yargs' recommended approach)
- Verified on macOS: `${_comps[opencode]}` resolves to `_opencode_yargs_completions`

Closes #515

## Test plan

- [ ] Open new iTerm2 tab, type `opencode <TAB>` — shows subcommands (completion, acp, mcp, run, etc.)
- [ ] Build container, start shell, type `opencode <TAB>` — shows subcommands
- [ ] `grep 'opencode-completions' ~/.zshrc` — returns match (guard prevents duplicates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)