### PR TITLE
fix: set SHELL=/bin/zsh for opencode completion in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1202,7 +1202,7 @@ RUN mkdir -p "$HOME/.npm-global" \
     && "$HOME/.tfenv/bin/tfenv" install latest \
     && "$HOME/.tfenv/bin/tfenv" use latest \
     && git clone --depth=1 https://github.com/tmux-plugins/tpm "$HOME/.tmux/plugins/tpm" \
-    && opencode completion >> "$HOME/.zshrc" \
+    && SHELL=/bin/zsh opencode completion >> "$HOME/.zshrc" \
     && gog completion zsh > /usr/local/share/zsh/site-functions/_gog \
     && zsh -c "autoload -U compinit && compinit" 2>/dev/null || true
 


### PR DESCRIPTION
## Summary

- Dockerfile `RUN` executes in `/bin/sh`, so `opencode completion` auto-detects bash and outputs bash-specific completions (`mapfile`, `COMPREPLY`)
- These bash builtins cause `zsh: command not found: mapfile` errors when `.zshrc` is sourced
- Fix: `SHELL=/bin/zsh opencode completion >> "$HOME/.zshrc"` forces zsh-compatible output

Closes #517

## Test plan

- [ ] Build container: `docker build -t test .`
- [ ] Start shell: `docker run --rm -it test zsh`
- [ ] Type `opencode <TAB>` — shows subcommands without `mapfile` errors
- [ ] `grep compdef ~/.zshrc` — returns match (zsh format, not bash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)