### PR TITLE
fix: silence verbose gog auth tokens import output in entrypoint

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -53,7 +53,7 @@ if [ -n "$GOG_CREDENTIALS_JSON" ]; then
     echo "$GOG_TOKEN_JSON" | base64 -d >"$_gog_tmp"
     export GOG_KEYRING_BACKEND=file
     export GOG_KEYRING_PASSWORD="${GOG_KEYRING_PASSWORD:-gogcli-container}"
-    gog auth tokens import "$_gog_tmp" 2>/dev/null || true
+    gog auth tokens import "$_gog_tmp" >/dev/null 2>&1 || true
     rm -f "$_gog_tmp"
   fi
 fi


### PR DESCRIPTION
## Summary

- Redirect both stdout and stderr to `/dev/null` for `gog auth tokens import`
- Previously only stderr was redirected, causing `imported    true`, `email`, and `client` info to print during container startup

Closes #519

## Test plan

- [ ] Start container with `GOG_TOKEN_JSON` set — no `imported`/`email`/`client` lines appear
- [ ] Start container without `GOG_TOKEN_JSON` — no change in behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)