### PR TITLE
fix: propagate host terminal type for Claude Code Shift+Enter support

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -43,7 +43,8 @@
 
   "containerEnv": {
     "EDITOR": "nvim",
-    "TERM": "xterm-256color",
+    "TERM": "${localEnv:TERM:xterm-256color}",
+    "TERM_PROGRAM": "${localEnv:TERM_PROGRAM}",
     "COLORTERM": "truecolor",
     "LANG": "en_US.UTF-8",
     "LC_ALL": "en_US.UTF-8",

--- a/Dockerfile
+++ b/Dockerfile
@@ -247,7 +247,6 @@ RUN ln -sf /usr/bin/fdfind /usr/local/bin/fd \
 
 ENV LANG=en_US.UTF-8
 ENV LC_ALL=en_US.UTF-8
-ENV TERM=xterm-256color
 ENV COLORTERM=truecolor
 
 # PowerShell — Microsoft only publishes amd64 .deb packages;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,8 @@ services:
     environment:
       - GIT_COMMITTER_NAME=${GIT_AUTHOR_NAME:-}
       - GIT_COMMITTER_EMAIL=${GIT_AUTHOR_EMAIL:-}
-      - TERM=xterm-256color
+      - TERM=${TERM:-xterm-256color}
+      - TERM_PROGRAM=${TERM_PROGRAM:-}
       - COLORTERM=truecolor
       - LANG=en_US.UTF-8
       - LC_ALL=en_US.UTF-8

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,6 +3,9 @@
 # Configure user environment (env-var-dependent only)
 # ============================================================
 
+# Fall back to xterm-256color if no TERM inherited from host
+export TERM="${TERM:-xterm-256color}"
+
 if [ -n "$GIT_AUTHOR_NAME" ]; then
   git config --global user.name "$GIT_AUTHOR_NAME"
 fi


### PR DESCRIPTION
## Summary

- Remove hardcoded `ENV TERM=xterm-256color` from Dockerfile
- Add `TERM` fallback in entrypoint.sh (`${TERM:-xterm-256color}`)
- Pass `TERM` and `TERM_PROGRAM` from host in docker-compose.yml and devcontainer.json
- Enables Claude Code to detect the actual terminal (e.g., iTerm2) for native Shift+Enter support

Closes #523

## Test plan

- [ ] `podman run --rm -it --env-file .env ghcr.io/f5xc-salesdemos/devcontainer:latest zsh` — `echo $TERM` shows host terminal
- [ ] Claude Code `/terminal-setup` behavior improves (recognizes terminal or works natively)
- [ ] Shift+Enter works in Claude Code without tmux
- [ ] Shift+Enter still works inside tmux (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)