### PR TITLE
feat: add bubblewrap to container apt packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -96,7 +96,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     # Tailscale VPN
     tailscale \
     # Shell tools
-    bat fd-find ripgrep htop tree tmux file xxd \
+    bat bubblewrap fd-find ripgrep htop tree tmux file xxd \
     # Node.js
     nodejs \
     # Python


### PR DESCRIPTION
## Summary

- Add `bubblewrap` (bwrap) sandbox utility to container apt install
- `socat` was already present (line 208)

Closes #525

## Test plan

- [ ] Container builds successfully
- [ ] `bwrap --version` works inside container

🤖 Generated with [Claude Code](https://claude.com/claude-code)