### PR TITLE
feat: enable Claude Code notifications passthrough in tmux and iTerm2

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -748,6 +748,7 @@ Configure sensible defaults for developer workflows. These settings are stored i
 | Unlimited scrollback | `Unlimited Scrollback` | `true` | Never lose build output or long log tails |
 | Left Option as Esc+ | `Option Key Sends` | `2` | Enables Alt+B / Alt+F word navigation in the shell |
 | Right Option as Esc+ | `Right Option Key Sends` | `2` | Same for the right Option key |
+| Notification alerts | `BounceIconInDockEnabled` | `true` | Enables Notification Center alerts for escape sequences |
 | Force dark theme | `TabStyleWithAutomaticOption` | `1` | Terminal stays dark regardless of macOS system appearance |
 
 **Option Key Sends values**: 0 = Normal, 1 = Meta, 2 = Esc+
@@ -789,6 +790,9 @@ if [ -f "$PLIST" ]; then
   plist_profile_set "Option Key Sends" integer 2
   plist_profile_set "Right Option Key Sends" integer 2
 
+  # Enable Notification Center alerts (required for Claude Code notifications in tmux)
+  plist_profile_set "BounceIconInDockEnabled" bool true
+
   # --- Global settings (application-level) ---
   # Force dark theme (don't follow system appearance)
   # Values: 0=Light, 1=Dark, 2=Light HC, 3=Dark HC, 4=Automatic, 5=Minimal
@@ -805,6 +809,12 @@ else
   echo "iTerm2 plist not found — skipping settings (run Step 5.3 first)"
 fi
 ```
+
+> **MANUAL STEP**: iTerm2 requires one additional setting for Claude Code notifications that cannot be set via plist:
+>
+> 1. Open **iTerm2 Settings** → **Profiles** → **Terminal**
+> 2. Click **"Filter Alerts"** and check **"Send escape sequence-generated alerts"**
+> 3. Verify iTerm2 has notification permissions in **System Settings** → **Notifications** → **iTerm2**
 
 ### 5.4 — Install Zsh Plugins
 

--- a/configs/.tmux.conf
+++ b/configs/.tmux.conf
@@ -23,6 +23,10 @@ set -g mouse on
 set -g focus-events on
 set -g set-clipboard on
 
+# Allow escape sequence passthrough to outer terminal (iTerm2, Kitty, Ghostty)
+# Required for Claude Code notifications and progress bar in tmux
+set -g allow-passthrough on
+
 # Start window/pane indices at 1 (easier keyboard reach)
 set -g base-index 1
 setw -g pane-base-index 1


### PR DESCRIPTION
## Summary

- Add `set -g allow-passthrough on` to `.tmux.conf` — lets Claude Code escape sequences (notifications, progress bar) reach iTerm2 through tmux
- Add `BounceIconInDockEnabled` plist setting to iTerm2 configuration in INSTALL.md
- Add manual step for iTerm2 "Filter Alerts" → "Send escape sequence-generated alerts"

Closes #527

## Test plan

- [ ] Start tmux in iTerm2, run `claude` — notifications appear in macOS Notification Center
- [ ] Progress bar renders in iTerm2 tab title inside tmux
- [ ] Same behavior works in container with tmux

🤖 Generated with [Claude Code](https://claude.com/claude-code)