### PR TITLE
feat: add aider config and macOS install, fix OPENAI_API_BASE for proxy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1220,6 +1220,7 @@ COPY --chown=${USERNAME}:${USERNAME} configs/.tmux.conf /home/${USERNAME}/.tmux.
 COPY --chown=${USERNAME}:${USERNAME} configs/.nanorc /home/${USERNAME}/.nanorc
 COPY --chown=${USERNAME}:${USERNAME} configs/.lessfilter /home/${USERNAME}/.lessfilter
 COPY --chown=${USERNAME}:${USERNAME} configs/.digrc /home/${USERNAME}/.digrc
+COPY --chown=${USERNAME}:${USERNAME} configs/.aider.conf.yml /home/${USERNAME}/.aider.conf.yml
 RUN chmod +x /home/${USERNAME}/.lessfilter
 
 # ============================================================

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -216,6 +216,7 @@ brew_install go                # Go compiler (build terraform providers, CLI too
 brew_install terraform         # Infrastructure as Code for cloud resources
 brew_install neovim            # Terminal editor with LSP support
 brew_install uv                # Fast Python package manager (10-100x faster than pip)
+brew_install aider             # AI pair programming in your terminal
 brew_install dos2unix          # Convert Windows CRLF line endings to Unix LF
 
 # Cloud CLI
@@ -287,6 +288,7 @@ sslscan --version      # VERIFY: output contains "sslscan version"
 trufflehog --version   # VERIFY: output contains a version number
 ffmpeg -version        # VERIFY: output starts with "ffmpeg version"
 yt-dlp --version       # VERIFY: output contains a version string
+aider --version        # VERIFY: output contains a version number
 ```
 
 ---
@@ -946,6 +948,7 @@ cp configs/.nanorc ~/.nanorc
 cp configs/.lessfilter ~/.lessfilter
 chmod +x ~/.lessfilter
 touch ~/.hushlogin
+cp configs/.aider.conf.yml ~/.aider.conf.yml
 ```
 
 | File | Purpose |
@@ -956,6 +959,7 @@ touch ~/.hushlogin
 | `.lessfilter` | Syntax highlighting when viewing files with `less` |
 | `.nanorc` | Nano editor defaults |
 | `.hushlogin` | Suppress the "Last login" banner on new terminal sessions |
+| `.aider.conf.yml` | Aider AI pair programming defaults (model, dark mode) |
 
 ### Verify Terminal Environment
 
@@ -978,6 +982,7 @@ test -f ~/.inputrc && echo "OK: inputrc"                              # Expected
 test -x ~/.lessfilter && echo "OK: lessfilter (executable)"           # Expected: OK
 test -f ~/.nanorc && echo "OK: nanorc"                                # Expected: OK
 test -f ~/.hushlogin && echo "OK: hushlogin"                          # Expected: OK
+test -f ~/.aider.conf.yml && echo "OK: aider config"                  # Expected: OK
 ls ~/Library/Fonts/MesloLGS\ NF\ Regular.ttf                          # Expected: file exists (p10k font)
 ls ~/Library/Fonts/MesloLGSNerdFont-Regular.ttf 2>/dev/null \
   || ls ~/Library/Fonts/MesloLGLNerdFont-Regular.ttf                   # Expected: Nerd Font installed

--- a/configs/.aider.conf.yml
+++ b/configs/.aider.conf.yml
@@ -1,0 +1,2 @@
+model: anthropic/claude-opus-4-6
+dark-mode: true

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -101,6 +101,7 @@ if [ -n "$LITELLM_API_KEY" ]; then
 fi
 if [ -n "$LITELLM_BASE_URL" ]; then
   export OPENAI_BASE_URL="${LITELLM_BASE_URL}/api/v1"
+  export OPENAI_API_BASE="${LITELLM_BASE_URL}/api/v1"
   export ANTHROPIC_BASE_URL="${LITELLM_BASE_URL}/anthropic"
 fi
 


### PR DESCRIPTION
## Summary

- Add `aider` to INSTALL.md brew packages with `aider --version` verification
- Create `configs/.aider.conf.yml` (model: `anthropic/claude-opus-4-6`, dark mode)
- COPY `.aider.conf.yml` into container alongside other dotfiles
- Add `OPENAI_API_BASE` export in entrypoint.sh (aider reads this, not `OPENAI_BASE_URL`)
- Add `.aider.conf.yml` to dotfiles copy step and verify checklist

**Note**: Aider does not support `ANTHROPIC_OAUTH_TOKEN`. It authenticates via `ANTHROPIC_API_KEY` (set from `LITELLM_API_KEY` by entrypoint) or proxy mode via `OPENAI_API_BASE` + `OPENAI_API_KEY`.

Closes #529

## Test plan

- [ ] macOS: `brew install aider && aider --version` outputs version
- [ ] macOS: `~/.aider.conf.yml` exists after dotfiles step
- [ ] Container: `aider --version` works
- [ ] Container (proxy mode): `echo $OPENAI_API_BASE` shows LiteLLM URL
- [ ] Container: `aider` starts with correct model from config

🤖 Generated with [Claude Code](https://claude.com/claude-code)