### PR TITLE
fix: revert TERM passthrough, hardcode xterm-256color

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -43,8 +43,7 @@
 
   "containerEnv": {
     "EDITOR": "nvim",
-    "TERM": "${localEnv:TERM:xterm-256color}",
-    "TERM_PROGRAM": "${localEnv:TERM_PROGRAM}",
+    "TERM": "xterm-256color",
     "COLORTERM": "truecolor",
     "LANG": "en_US.UTF-8",
     "LC_ALL": "en_US.UTF-8",

--- a/Dockerfile
+++ b/Dockerfile
@@ -247,6 +247,7 @@ RUN ln -sf /usr/bin/fdfind /usr/local/bin/fd \
 
 ENV LANG=en_US.UTF-8
 ENV LC_ALL=en_US.UTF-8
+ENV TERM=xterm-256color
 ENV COLORTERM=truecolor
 
 # PowerShell — Microsoft only publishes amd64 .deb packages;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,8 +10,7 @@ services:
     environment:
       - GIT_COMMITTER_NAME=${GIT_AUTHOR_NAME:-}
       - GIT_COMMITTER_EMAIL=${GIT_AUTHOR_EMAIL:-}
-      - TERM=${TERM:-xterm-256color}
-      - TERM_PROGRAM=${TERM_PROGRAM:-}
+      - TERM=xterm-256color
       - COLORTERM=truecolor
       - LANG=en_US.UTF-8
       - LC_ALL=en_US.UTF-8

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,9 +3,6 @@
 # Configure user environment (env-var-dependent only)
 # ============================================================
 
-# Fall back to xterm-256color if no TERM inherited from host
-export TERM="${TERM:-xterm-256color}"
-
 if [ -n "$GIT_AUTHOR_NAME" ]; then
   git config --global user.name "$GIT_AUTHOR_NAME"
 fi


### PR DESCRIPTION
## Summary

Reverts PR #524's TERM passthrough approach which made things worse (TERM became `xterm` instead of `xterm-256color`, TERM_PROGRAM doesn't propagate through podman/docker).

- Restore `TERM=xterm-256color` in Dockerfile, docker-compose.yml, devcontainer.json
- Remove `TERM_PROGRAM` passthrough (doesn't work through container runtimes)
- Remove entrypoint.sh TERM fallback (redundant with Dockerfile ENV)

**Shift+Enter in container**: Works via tmux (`.tmux.conf` has `bind-key -n S-Enter send-keys Escape "[13;2u"`). Claude Code `/terminal-setup` cannot configure xterm-based terminals — tmux is the correct approach.

Closes #531

## Test plan

- [ ] `podman run --rm -it ... zsh` → `echo $TERM` shows `xterm-256color`
- [ ] Start tmux, run `claude` → Shift+Enter works
- [ ] Colors and 24-bit RGB still work (COLORTERM=truecolor unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)