### PR TITLE
feat: add iTerm2 Shift+Enter key binding for Claude Code in containers

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -821,8 +821,8 @@ fi
 > 5. **Esc+ value**: type `[13;2u`
 >
 > This sends `ESC[13;2u` (CSI u encoded Shift+Enter) which Claude Code recognizes regardless of TERM type. The sequence passes through podman/docker and tmux to reach Claude Code.
-
-> **MANUAL STEP — Notifications**: iTerm2 requires additional settings for Claude Code notifications:
+>
+> **Notifications**: iTerm2 also requires settings for Claude Code notifications:
 >
 > 1. Open **iTerm2 Settings** → **Profiles** → **Terminal**
 > 2. Enable **"Notification Center Alerts"**


### PR DESCRIPTION
## Summary

- Add manual step to INSTALL.md for configuring iTerm2 Shift+Enter → `ESC[13;2u`
- This CSI u escape sequence is what Claude Code recognizes for "insert newline"
- Works through podman/docker/SSH/tmux regardless of TERM type
- Also reorganized the notification manual step for clarity

Closes #535

## How it works

```
Keyboard → iTerm2 (sends ESC[13;2u) → podman/docker → container → Claude Code
```

The tmux config already handles forwarding via `extended-keys always` and `bind-key -n S-Enter`.

## Test plan

- [ ] Configure iTerm2 key binding per instructions
- [ ] Run `claude` in container (no tmux) → Shift+Enter inserts newline
- [ ] Run `claude` in container with tmux → Shift+Enter inserts newline
- [ ] Run `claude` on macOS directly → Shift+Enter still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)