### PR TITLE
feat: add playwright-cli, notebooklm-mcp-cli, signal-cli, grammy, baileys, CLI-Anything

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -791,7 +791,10 @@ RUN npm install -g \
     @devcontainers/cli \
     @googleworkspace/cli \
     html2canvas \
+    @playwright/cli \
     playwright \
+    grammy \
+    @whiskeysockets/baileys \
     puppeteer \
     puppeteer-extra \
     puppeteer-extra-plugin-stealth \
@@ -898,8 +901,18 @@ RUN UV_TOOL_DIR=/opt/uv-tools UV_TOOL_BIN_DIR=/usr/local/bin \
     uv tool install --python python3.12 aider-chat@latest \
       --with aider-chat[browser] \
       --with aider-chat[help] \
-      --with aider-chat[playwright]
+      --with aider-chat[playwright] \
+    && UV_TOOL_DIR=/opt/uv-tools UV_TOOL_BIN_DIR=/usr/local/bin \
+    uv tool install notebooklm-mcp-cli
 
+# signal-cli (Signal messenger CLI — Java application)
+# hadolint ignore=DL3059
+RUN SIGNAL_CLI_VERSION="0.14.1" \
+    && curl -fsSL "https://github.com/AsamK/signal-cli/releases/download/v${SIGNAL_CLI_VERSION}/signal-cli-${SIGNAL_CLI_VERSION}.tar.gz" \
+      -o /tmp/signal-cli.tar.gz \
+    && sudo tar xf /tmp/signal-cli.tar.gz -C /opt \
+    && sudo ln -sf "/opt/signal-cli-${SIGNAL_CLI_VERSION}/bin/signal-cli" /usr/local/bin/signal-cli \
+    && rm /tmp/signal-cli.tar.gz
 
 # ============================================================
 # 12c. Ruby linters (rubocop + extensions)
@@ -1097,7 +1110,8 @@ RUN npx playwright install \
     && CHROME_BIN="$(find ~/.cache/ms-playwright \
         -name chrome -path '*/chromium-*/chrome-linux*/chrome' -print -quit)" \
     && sudo mkdir -p /opt/google/chrome \
-    && sudo ln -sf "$CHROME_BIN" /opt/google/chrome/chrome
+    && sudo ln -sf "$CHROME_BIN" /opt/google/chrome/chrome \
+    && playwright-cli install --skills || true
 
 # Chrome DevTools MCP: pre-cache the package (runs as vscode so npm caches
 # to ~/.npm/_npx; --headless is passed via .mcp.json args in each content repo)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -217,6 +217,7 @@ brew_install terraform         # Infrastructure as Code for cloud resources
 brew_install neovim            # Terminal editor with LSP support
 brew_install uv                # Fast Python package manager (10-100x faster than pip)
 brew_install aider             # AI pair programming in your terminal
+brew_install playwright-cli    # Token-efficient browser automation CLI for AI agents
 brew_install dos2unix          # Convert Windows CRLF line endings to Unix LF
 
 # Cloud CLI
@@ -289,6 +290,7 @@ trufflehog --version   # VERIFY: output contains a version number
 ffmpeg -version        # VERIFY: output starts with "ffmpeg version"
 yt-dlp --version       # VERIFY: output contains a version string
 aider --version        # VERIFY: output contains a version number
+playwright-cli --version  # VERIFY: output contains a version number
 ```
 
 ---
@@ -1331,6 +1333,48 @@ ls -la ~/.claude/settings.json
 ls -la ~/.claude/statusline.sh
 ls -la ~/.claude/plugins/installed_plugins.json
 ```
+
+---
+
+## Step 6b — Install AI Tool Extensions
+
+### 6b.1 — NotebookLM MCP CLI
+
+Install the NotebookLM CLI and MCP server (provides Google NotebookLM access from Claude Code and other AI assistants):
+
+```bash
+uv tool install notebooklm-mcp-cli
+```
+
+Register as a Claude Code MCP server:
+
+```bash
+nlm setup add claude-code
+```
+
+VERIFY:
+
+```bash
+nlm --version              # VERIFY: output contains a version number
+```
+
+### 6b.2 — Playwright CLI Skills
+
+Install AI-discoverable skill definitions for Playwright CLI (already installed via Homebrew in Step 1):
+
+```bash
+playwright-cli install --skills
+```
+
+This copies SKILL.md documentation that Claude Code reads to understand available browser automation commands.
+
+### 6b.3 — CLI-Anything (Claude Code Plugin)
+
+> **INTERACTIVE STEP**: CLI-Anything is a Claude Code plugin marketplace that must be installed from within a Claude Code session:
+>
+> 1. Start Claude Code: `claude`
+> 2. Run: `/plugin marketplace add HKUDS/CLI-Anything`
+> 3. Run: `/plugin install cli-anything`
 
 ---
 


### PR DESCRIPTION
## Summary

Add 6 tools across container (Dockerfile) and macOS (INSTALL.md):

- **@playwright/cli**: Token-efficient browser automation CLI for AI agents (npm global + brew)
- **notebooklm-mcp-cli**: Google NotebookLM CLI + MCP server (uv tool install)
- **signal-cli**: Signal messenger CLI — v0.14.1 release tarball in container (already in INSTALL.md brew)
- **grammy**: Telegram Bot Framework (npm global, container only)
- **@whiskeysockets/baileys**: WhatsApp Web API library (npm global, container only)
- **CLI-Anything**: Claude Code plugin marketplace (interactive install step)

New INSTALL.md Step 6b for AI tool extensions (notebooklm, playwright skills, CLI-Anything).

Closes #539

## Test plan

- [ ] Container: `playwright-cli --version` outputs version
- [ ] Container: `nlm --version` outputs version
- [ ] Container: `signal-cli --version` outputs version
- [ ] Container: `node -e "require('grammy')"` succeeds
- [ ] macOS: `playwright-cli --version` outputs version
- [ ] macOS: `nlm --version` outputs version

🤖 Generated with [Claude Code](https://claude.com/claude-code)