### PR TITLE
feat: add OpenClaw dependency packages for channel and PDF support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -795,6 +795,10 @@ RUN npm install -g \
     playwright \
     grammy \
     @whiskeysockets/baileys \
+    discord.js \
+    pdfjs-dist \
+    @napi-rs/canvas \
+    matrix-js-sdk \
     puppeteer \
     puppeteer-extra \
     puppeteer-extra-plugin-stealth \

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -209,6 +209,7 @@ brew_install eza               # Modern ls replacement with icons and git status
 brew_install fzf               # Fuzzy finder for files, history, and command output
 brew_install lsd               # ls replacement with color and icons (Nerd Font aware)
 brew_install yq                # YAML/JSON/XML processor (like jq for YAML)
+brew_install poppler           # PDF utilities (pdftotext, pdfinfo — used by AI tools for PDF processing)
 
 # Development runtimes and tools (mirrors devcontainer toolset)
 brew_install python            # Python 3.13 runtime (macOS ships an older system Python)
@@ -291,6 +292,7 @@ ffmpeg -version        # VERIFY: output starts with "ffmpeg version"
 yt-dlp --version       # VERIFY: output contains a version string
 aider --version        # VERIFY: output contains a version number
 playwright-cli --version  # VERIFY: output contains a version number
+pdftotext -v 2>&1 | head -1  # VERIFY: output contains "pdftotext version"
 ```
 
 ---


### PR DESCRIPTION
## Summary

Prepare environment for OpenClaw dependencies (not installing OpenClaw itself):

**Container (Dockerfile npm globals):**
- `discord.js` — Discord channel support
- `pdfjs-dist` — PDF text extraction
- `@napi-rs/canvas` — Image rendering fallback
- `matrix-js-sdk` — Matrix protocol support

**macOS (INSTALL.md brew):**
- `poppler` — `pdftotext` CLI for PDF processing

Already present from earlier PRs: grammY, Baileys, signal-cli, Playwright, bubblewrap, socat.

Closes #541

## Test plan

- [ ] Container: `node -e "require('discord.js')"` succeeds
- [ ] Container: `node -e "require('pdfjs-dist')"` succeeds
- [ ] macOS: `pdftotext -v` shows version

🤖 Generated with [Claude Code](https://claude.com/claude-code)