### PR TITLE
feat: enable f5xc-sales-engineer plugin

### DIFF
--- a/claude-config/settings.json
+++ b/claude-config/settings.json
@@ -26,7 +26,8 @@
     "pr-review-toolkit@claude-plugins-official": true,
     "skill-creator@claude-plugins-official": true,
     "claude-code-setup@claude-plugins-official": true,
-    "hookify@claude-plugins-official": true
+    "hookify@claude-plugins-official": true,
+    "f5xc-sales-engineer@f5xc-salesdemos-marketplace": true
   },
   "env": {
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",


### PR DESCRIPTION
## Summary
- Adds `f5xc-sales-engineer@f5xc-salesdemos-marketplace` to `enabledPlugins` in `claude-config/settings.json`
- Plugin will be pre-installed in the devcontainer image via existing `install-plugins.sh` mechanism

## Test plan
- [ ] `settings.json` is valid JSON
- [ ] Plugin name matches marketplace registry entry
- [ ] Devcontainer image builds successfully with the new plugin enabled

Closes #543

🤖 Generated with [Claude Code](https://claude.com/claude-code)