### PR TITLE
fix: add multi-marketplace support to plugin installer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1049,11 +1049,12 @@ COPY claude-config/settings.json /opt/claude-config/settings.json
 RUN chmod +x /opt/claude-config/install-plugins.sh
 
 # ============================================================
-# 12l. Claude Code plugins (pre-install from marketplace)
-#      Clones the official marketplace, copies each enabled
-#      plugin into the cache, clones superpowers separately,
-#      and generates installed_plugins.json so Claude Code
-#      treats all plugins as fully installed at first launch.
+# 12l. Claude Code plugins (pre-install from marketplaces)
+#      Clones the official and f5xc-salesdemos marketplaces,
+#      copies each enabled plugin into the cache, clones
+#      superpowers separately, and generates
+#      installed_plugins.json so Claude Code treats all
+#      plugins as fully installed at first launch.
 # ============================================================
 # hadolint ignore=DL3059
 RUN PLUGIN_BASE="/home/${USERNAME}/.claude/plugins" \
@@ -1061,12 +1062,15 @@ RUN PLUGIN_BASE="/home/${USERNAME}/.claude/plugins" \
     && git clone --depth=1 --single-branch --branch main \
         https://github.com/anthropics/claude-plugins-official.git \
         "${PLUGIN_BASE}/marketplaces/claude-plugins-official" \
-    && printf '{"claude-plugins-official":{"source":{"source":"github","repo":"anthropics/claude-plugins-official"},"installLocation":"%s","lastUpdated":"%s"}}' \
-        "${PLUGIN_BASE}/marketplaces/claude-plugins-official" \
-        "$(date -u +%Y-%m-%dT%H:%M:%S.000Z)" \
+    && git clone --depth=1 --single-branch --branch main \
+        https://github.com/f5xc-salesdemos/marketplace.git \
+        "${PLUGIN_BASE}/marketplaces/f5xc-salesdemos-marketplace" \
+    && TS="$(date -u +%Y-%m-%dT%H:%M:%S.000Z)" \
+    && printf '{"claude-plugins-official":{"source":{"source":"github","repo":"anthropics/claude-plugins-official"},"installLocation":"%s","lastUpdated":"%s"},"f5xc-salesdemos-marketplace":{"source":{"source":"github","repo":"f5xc-salesdemos/marketplace"},"installLocation":"%s","lastUpdated":"%s"}}' \
+        "${PLUGIN_BASE}/marketplaces/claude-plugins-official" "$TS" \
+        "${PLUGIN_BASE}/marketplaces/f5xc-salesdemos-marketplace" "$TS" \
         > "${PLUGIN_BASE}/known_marketplaces.json" \
-    && printf '{"fetchedAt":"%s","plugins":[]}' \
-        "$(date -u +%Y-%m-%dT%H:%M:%S.000Z)" \
+    && printf '{"fetchedAt":"%s","plugins":[]}' "$TS" \
         > "${PLUGIN_BASE}/blocklist.json" \
     && /opt/claude-config/install-plugins.sh \
         "${PLUGIN_BASE}" /opt/claude-config/settings.json \

--- a/claude-config/install-plugins.sh
+++ b/claude-config/install-plugins.sh
@@ -1,33 +1,43 @@
 #!/usr/bin/env bash
 # Pre-install Claude Code plugins into the cache directory.
-# Called from Dockerfile section 12l after the marketplace clone.
+# Called from Dockerfile section 12l after marketplace clones.
+# Supports multiple marketplaces — reads the @marketplace suffix
+# from each enabledPlugins key in settings.json.
 set -euo pipefail
 
 PLUGIN_BASE="$1" # e.g. /home/vscode/.claude/plugins
 SETTINGS="$2"    # e.g. /opt/claude-config/settings.json
-MARKETPLACE="${PLUGIN_BASE}/marketplaces/claude-plugins-official"
-CACHE="${PLUGIN_BASE}/cache/claude-plugins-official"
 INSTALLED_JSON="${PLUGIN_BASE}/installed_plugins.json"
 TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%S.000Z)
-GIT_SHA=$(cd "$MARKETPLACE" && git rev-parse HEAD)
-
-mkdir -p "$CACHE"
 
 # Start building installed_plugins.json
 echo '[' >"$INSTALLED_JSON"
 FIRST=true
 
-# Read enabled plugin names from settings.json
-# Format: "name@claude-plugins-official" -> extract "name"
-PLUGINS=$(jq -r '.enabledPlugins | keys[] | split("@")[0]' "$SETTINGS")
+# Read enabled plugin keys from settings.json
+# Format: "name@marketplace-name"
+KEYS=$(jq -r '.enabledPlugins | keys[]' "$SETTINGS")
 
-for NAME in $PLUGINS; do
+for KEY in $KEYS; do
+  NAME=$(echo "$KEY" | cut -d@ -f1)
+  MKT=$(echo "$KEY" | cut -d@ -f2)
+  MKT_DIR="${PLUGIN_BASE}/marketplaces/${MKT}"
+  CACHE_DIR="${PLUGIN_BASE}/cache/${MKT}"
+
+  mkdir -p "$CACHE_DIR"
+
+  # Get git SHA for this marketplace (if it exists)
+  GIT_SHA=""
+  if [ -d "$MKT_DIR/.git" ]; then
+    GIT_SHA=$(cd "$MKT_DIR" && git rev-parse HEAD)
+  fi
+
   # Determine source path in marketplace
   SRC=""
-  if [ -d "${MARKETPLACE}/plugins/${NAME}" ]; then
-    SRC="${MARKETPLACE}/plugins/${NAME}"
-  elif [ -d "${MARKETPLACE}/external_plugins/${NAME}" ]; then
-    SRC="${MARKETPLACE}/external_plugins/${NAME}"
+  if [ -d "${MKT_DIR}/plugins/${NAME}" ]; then
+    SRC="${MKT_DIR}/plugins/${NAME}"
+  elif [ -d "${MKT_DIR}/external_plugins/${NAME}" ]; then
+    SRC="${MKT_DIR}/external_plugins/${NAME}"
   fi
 
   # Read version from plugin.json (default 0.0.0)
@@ -41,7 +51,7 @@ for NAME in $PLUGINS; do
     [ -n "$V" ] && VERSION="$V"
   fi
 
-  DEST="${CACHE}/${NAME}/${VERSION}"
+  DEST="${CACHE_DIR}/${NAME}/${VERSION}"
   mkdir -p "$DEST"
 
   if [ -n "$SRC" ]; then
@@ -52,7 +62,7 @@ for NAME in $PLUGINS; do
     git clone --depth=1 --single-branch --branch main \
       https://github.com/obra/superpowers.git "$DEST"
   else
-    echo "WARNING: no source found for plugin '$NAME', skipping"
+    echo "WARNING: no source found for plugin '${NAME}' in marketplace '${MKT}', skipping"
     rm -rf "$DEST"
     continue
   fi
@@ -67,7 +77,7 @@ for NAME in $PLUGINS; do
   cat >>"$INSTALLED_JSON" <<ENTRY
   {
     "name": "${NAME}",
-    "marketplace": "claude-plugins-official",
+    "marketplace": "${MKT}",
     "scope": "user",
     "version": "${VERSION}",
     "installPath": "${DEST}",

--- a/claude-config/self-test.sh
+++ b/claude-config/self-test.sh
@@ -190,23 +190,29 @@ echo ""
 echo "8. Claude Code Plugins"
 check "enabledPlugins in settings.json" \
   jq -e '.enabledPlugins' "$HOME/.claude/settings.json"
-check "14 plugins configured" \
-  test "$(jq '.enabledPlugins | length' "$HOME/.claude/settings.json")" -eq 14
+check "15 plugins configured" \
+  test "$(jq '.enabledPlugins | length' "$HOME/.claude/settings.json")" -eq 15
 check "FORCE_AUTOUPDATE_PLUGINS set" test "$FORCE_AUTOUPDATE_PLUGINS" = "true"
-check "plugin marketplace cached" \
+check "official marketplace cached" \
   test -d "$HOME/.claude/plugins/marketplaces/claude-plugins-official"
-check "marketplace.json in cache" \
+check "official marketplace.json in cache" \
   test -f "$HOME/.claude/plugins/marketplaces/claude-plugins-official/.claude-plugin/marketplace.json"
+check "f5xc marketplace cached" \
+  test -d "$HOME/.claude/plugins/marketplaces/f5xc-salesdemos-marketplace"
+check "f5xc marketplace.json in cache" \
+  test -f "$HOME/.claude/plugins/marketplaces/f5xc-salesdemos-marketplace/.claude-plugin/marketplace.json"
 check "known_marketplaces.json exists" \
   test -f "$HOME/.claude/plugins/known_marketplaces.json"
 check "installed_plugins.json exists" \
   test -f "$HOME/.claude/plugins/installed_plugins.json"
-check "plugin cache populated" \
+check "official plugin cache populated" \
   test -d "$HOME/.claude/plugins/cache/claude-plugins-official"
+check "f5xc plugin cache populated" \
+  test -d "$HOME/.claude/plugins/cache/f5xc-salesdemos-marketplace"
 check "superpowers pre-installed" \
   test -d "$HOME/.claude/plugins/cache/claude-plugins-official/superpowers"
 check "all enabled plugins cached" \
-  test "$(jq 'length' "$HOME/.claude/plugins/installed_plugins.json")" -eq 14
+  test "$(jq 'length' "$HOME/.claude/plugins/installed_plugins.json")" -eq 15
 
 echo ""
 echo "9. Chrome DevTools MCP"


### PR DESCRIPTION
## Summary
- Rewrites `install-plugins.sh` to parse `@marketplace-name` suffix from each plugin key and route to the correct marketplace directory
- Clones both `anthropics/claude-plugins-official` and `f5xc-salesdemos/marketplace` in the Dockerfile
- Registers both marketplaces in `known_marketplaces.json`
- Updates `self-test.sh` to validate both marketplace directories and 15 total plugins

## Test plan
- [ ] `install-plugins.sh` correctly installs plugins from both marketplaces
- [ ] Dockerfile clones both marketplace repos successfully
- [ ] `known_marketplaces.json` contains two marketplace entries
- [ ] `self-test.sh` passes with 15 plugins and both marketplace cache directories
- [ ] Docker image builds successfully

Closes #545

🤖 Generated with [Claude Code](https://claude.com/claude-code)