### PR TITLE
feat: enable autoupdate for all plugin marketplaces

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1066,7 +1066,7 @@ RUN PLUGIN_BASE="/home/${USERNAME}/.claude/plugins" \
         https://github.com/f5xc-salesdemos/marketplace.git \
         "${PLUGIN_BASE}/marketplaces/f5xc-salesdemos-marketplace" \
     && TS="$(date -u +%Y-%m-%dT%H:%M:%S.000Z)" \
-    && printf '{"claude-plugins-official":{"source":{"source":"github","repo":"anthropics/claude-plugins-official"},"installLocation":"%s","lastUpdated":"%s"},"f5xc-salesdemos-marketplace":{"source":{"source":"github","repo":"f5xc-salesdemos/marketplace"},"installLocation":"%s","lastUpdated":"%s"}}' \
+    && printf '{"claude-plugins-official":{"source":{"source":"github","repo":"anthropics/claude-plugins-official"},"installLocation":"%s","lastUpdated":"%s","autoUpdate":true},"f5xc-salesdemos-marketplace":{"source":{"source":"github","repo":"f5xc-salesdemos/marketplace"},"installLocation":"%s","lastUpdated":"%s","autoUpdate":true}}' \
         "${PLUGIN_BASE}/marketplaces/claude-plugins-official" "$TS" \
         "${PLUGIN_BASE}/marketplaces/f5xc-salesdemos-marketplace" "$TS" \
         > "${PLUGIN_BASE}/known_marketplaces.json" \
@@ -1162,6 +1162,7 @@ RUN if [ -f ~/.config/opencode/oh-my-opencode.json ]; then \
 RUN NONINTERACTIVE=1 /bin/bash -c "$(curl ${CURL_RETRY} -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 
 ENV HOMEBREW_NO_AUTO_UPDATE=1
+ENV FORCE_AUTOUPDATE_PLUGINS=true
 ENV PATH="/home/vscode/.local/bin:/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:${PATH}"
 
 # AI assistant deps + formatters (no APT packages available)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1192,7 +1192,7 @@ PLUGIN_BASE="$HOME/.claude/plugins"
 TIMESTAMP="$(date -u +%Y-%m-%dT%H:%M:%S.000Z)"
 
 # Marketplace registry (both marketplaces)
-printf '{"claude-plugins-official":{"source":{"source":"github","repo":"anthropics/claude-plugins-official"},"installLocation":"%s","lastUpdated":"%s"},"f5xc-salesdemos-marketplace":{"source":{"source":"github","repo":"f5xc-salesdemos/marketplace"},"installLocation":"%s","lastUpdated":"%s"}}' \
+printf '{"claude-plugins-official":{"source":{"source":"github","repo":"anthropics/claude-plugins-official"},"installLocation":"%s","lastUpdated":"%s","autoUpdate":true},"f5xc-salesdemos-marketplace":{"source":{"source":"github","repo":"f5xc-salesdemos/marketplace"},"installLocation":"%s","lastUpdated":"%s","autoUpdate":true}}' \
   "${PLUGIN_BASE}/marketplaces/claude-plugins-official" \
   "$TIMESTAMP" \
   "${PLUGIN_BASE}/marketplaces/f5xc-salesdemos-marketplace" \
@@ -2463,6 +2463,10 @@ grep -q '\.local/bin' ~/.zshrc || \
 grep -q 'iTerm.app' ~/.zshrc || \
   echo 'export PATH="/Applications/iTerm.app/Contents/Resources/utilities:$PATH"' >> ~/.zshrc
 
+# Claude Code plugin autoupdate
+grep -q 'FORCE_AUTOUPDATE_PLUGINS' ~/.zshrc || \
+  echo 'export FORCE_AUTOUPDATE_PLUGINS=true' >> ~/.zshrc
+
 # API key for AI proxy (sourced from .env in Step 8.5)
 # Only write if LITELLM_API_KEY is actually set — in OAuth mode it's empty
 if [ -n "$LITELLM_API_KEY" ]; then
@@ -2479,6 +2483,7 @@ Do **not** run `source ~/.zshrc` — it will fail in a non-interactive shell con
 ```bash
 export BUN_INSTALL="$HOME/.bun"
 export PATH="$BUN_INSTALL/bin:$HOME/.local/bin:/Applications/iTerm.app/Contents/Resources/utilities:$PATH"
+export FORCE_AUTOUPDATE_PLUGINS=true
 eval $(/opt/homebrew/bin/brew shellenv)
 ```
 

--- a/claude-config/claude.json
+++ b/claude-config/claude.json
@@ -9,6 +9,7 @@
   },
   "officialMarketplaceAutoInstallAttempted": true,
   "officialMarketplaceAutoInstalled": true,
+  "autoUpdates": true,
   "cachedChromeExtensionInstalled": false,
   "mcpServers": {
     "chrome-devtools": {


### PR DESCRIPTION
## Summary

Closes #551

- Adds `FORCE_AUTOUPDATE_PLUGINS=true` ENV to Dockerfile (self-test expected it but it was never set)
- Adds `"autoUpdates": true` to `claude-config/claude.json` (INSTALL.md set it via jq merge but the source file was missing it)
- Adds `"autoUpdate": true` per marketplace entry in `known_marketplaces.json` generation (both Dockerfile and INSTALL.md) so third-party marketplaces auto-update
- Adds `FORCE_AUTOUPDATE_PLUGINS` export to INSTALL.md shell profile and activate-environment blocks

## Test plan

- [ ] Container self-test (`claude-self-test`) passes — check at `self-test.sh:195` should be green
- [ ] `echo $FORCE_AUTOUPDATE_PLUGINS` returns `true` in container
- [ ] `jq '.autoUpdates' ~/.claude.json` returns `true` in container
- [ ] `jq '.[].autoUpdate' ~/.claude/plugins/known_marketplaces.json` returns `true` for both entries
- [ ] INSTALL.md local install: same three checks pass after following updated steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)