### PR TITLE
fix: add --no-quarantine flag for Alacritty cask install

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -492,10 +492,10 @@ zed --version                  # VERIFY: output contains a version number
 
 ## Step 4i — Install Alacritty
 
-Alacritty is a GPU-accelerated terminal emulator. Install via Homebrew Cask:
+Alacritty is a GPU-accelerated terminal emulator. The Homebrew cask is deprecated due to macOS Gatekeeper issues (deadline Sept 2026) and requires `--no-quarantine` to install correctly:
 
 ```bash
-[ -d "/Applications/Alacritty.app" ] || brew install --cask alacritty
+[ -d "/Applications/Alacritty.app" ] || HOMEBREW_CASK_OPTS="--no-quarantine" brew install --cask alacritty
 ```
 
 VERIFY:


### PR DESCRIPTION
## Summary

Closes #557

Testing the INSTALL.md steps locally revealed that Alacritty's Homebrew cask is deprecated due to macOS Gatekeeper issues. Without `--no-quarantine`, the app bundle is quarantined and the CLI symlink at `/opt/homebrew/bin/alacritty` breaks (target doesn't exist in `/Applications`).

Updated Step 4i to use `HOMEBREW_CASK_OPTS="--no-quarantine"`.

## Test plan

- [x] Verified locally: `HOMEBREW_CASK_OPTS="--no-quarantine" brew install --cask alacritty` installs correctly
- [x] `alacritty --version` returns `alacritty 0.16.1`
- [x] App exists at `/Applications/Alacritty.app`

🤖 Generated with [Claude Code](https://claude.com/claude-code)