### PR TITLE
feat: enable new marketplace plugins in managed Claude config

### DIFF
--- a/claude-config/settings.json
+++ b/claude-config/settings.json
@@ -27,7 +27,10 @@
     "skill-creator@claude-plugins-official": true,
     "claude-code-setup@claude-plugins-official": true,
     "hookify@claude-plugins-official": true,
-    "f5xc-sales-engineer@f5xc-salesdemos-marketplace": true
+    "f5xc-sales-engineer@f5xc-salesdemos-marketplace": true,
+    "f5xc-docs-tools@f5xc-salesdemos-marketplace": true,
+    "f5xc-repo-governance@f5xc-salesdemos-marketplace": true,
+    "f5xc-docs-pipeline@f5xc-salesdemos-marketplace": true
   },
   "env": {
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",


### PR DESCRIPTION
## Summary

- Add `f5xc-docs-tools` to enabledPlugins (was in marketplace but not enabled)
- Add `f5xc-repo-governance` to enabledPlugins (new plugin)
- Add `f5xc-docs-pipeline` to enabledPlugins (new plugin)

## Motivation

These plugins absorb detailed instructions from CLAUDE.md, enabling it to be reduced from ~550 lines to ~80 lines across all repos.

## Test plan

- [ ] Verify settings.json is valid JSON
- [ ] Verify all 3 new plugin entries use `@f5xc-salesdemos-marketplace` suffix
- [ ] Verify no existing plugins were removed or modified

Closes #561

🤖 Generated with [Claude Code](https://claude.com/claude-code)