### PR TITLE
feat: update installers for new marketplace plugins

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1228,6 +1228,9 @@ for KEY in \
   claude-code-setup@claude-plugins-official \
   hookify@claude-plugins-official \
   f5xc-sales-engineer@f5xc-salesdemos-marketplace \
+  f5xc-docs-tools@f5xc-salesdemos-marketplace \
+  f5xc-repo-governance@f5xc-salesdemos-marketplace \
+  f5xc-docs-pipeline@f5xc-salesdemos-marketplace \
 ; do
   NAME="$(echo "$KEY" | cut -d@ -f1)"
   MKT="$(echo "$KEY" | cut -d@ -f2)"
@@ -1362,7 +1365,10 @@ CONTAINER_SETTINGS="$(cat <<SETTINGS
     "skill-creator@claude-plugins-official": true,
     "claude-code-setup@claude-plugins-official": true,
     "hookify@claude-plugins-official": true,
-    "f5xc-sales-engineer@f5xc-salesdemos-marketplace": true
+    "f5xc-sales-engineer@f5xc-salesdemos-marketplace": true,
+    "f5xc-docs-tools@f5xc-salesdemos-marketplace": true,
+    "f5xc-repo-governance@f5xc-salesdemos-marketplace": true,
+    "f5xc-docs-pipeline@f5xc-salesdemos-marketplace": true
   },
   "env": {
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
@@ -1462,19 +1468,19 @@ fi
 ### Verify Plugin and Settings Installation
 
 ```bash
-# Check installed_plugins.json has all 15 plugins
+# Check installed_plugins.json has all 18 plugins
 jq 'length' ~/.claude/plugins/installed_plugins.json
-# Expected: 15
+# Expected: 18
 
 # Check both marketplace caches exist
 ls ~/.claude/plugins/cache/claude-plugins-official/       # Expected: plugin directories
-ls ~/.claude/plugins/cache/f5xc-salesdemos-marketplace/   # Expected: f5xc-sales-engineer directory
+ls ~/.claude/plugins/cache/f5xc-salesdemos-marketplace/   # Expected: f5xc-sales-engineer, f5xc-docs-tools, f5xc-repo-governance, f5xc-docs-pipeline
 
 # Check SKILL.md files were loaded
 find ~/.claude/plugins/cache -name "SKILL.md" -type f | wc -l
 
 # Check settings.json has full container settings merged
-jq '.enabledPlugins | keys | length' ~/.claude/settings.json  # Expected: 15
+jq '.enabledPlugins | keys | length' ~/.claude/settings.json  # Expected: 18
 jq '.model' ~/.claude/settings.json                            # Expected: "opus"
 jq '.statusLine.type' ~/.claude/settings.json                  # Expected: "command"
 jq '.env.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS' ~/.claude/settings.json  # Expected: "1"
@@ -2780,14 +2786,14 @@ echo $LITELLM_API_KEY        # VERIFY: output is your API key (not empty, not a 
 ```bash
 # Verify plugin count
 jq 'length' ~/.claude/plugins/installed_plugins.json
-# Expected: 14
+# Expected: 18
 
 # Verify SKILL.md files
 find ~/.claude/plugins/cache -name "SKILL.md" -type f | wc -l
 # Expected: 19
 
 # Verify settings.json has full container settings
-jq '.enabledPlugins | keys | length' ~/.claude/settings.json    # Expected: 14
+jq '.enabledPlugins | keys | length' ~/.claude/settings.json    # Expected: 18
 jq '.model' ~/.claude/settings.json                              # Expected: "opus"
 jq '.statusLine.type' ~/.claude/settings.json                    # Expected: "command"
 jq '.env.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS' ~/.claude/settings.json  # Expected: "1"

--- a/claude-config/self-test.sh
+++ b/claude-config/self-test.sh
@@ -191,8 +191,8 @@ echo ""
 echo "8. Claude Code Plugins"
 check "enabledPlugins in settings.json" \
   jq -e '.enabledPlugins' "$HOME/.claude/settings.json"
-check "15 plugins configured" \
-  test "$(jq '.enabledPlugins | length' "$HOME/.claude/settings.json")" -eq 15
+check "18 plugins configured" \
+  test "$(jq '.enabledPlugins | length' "$HOME/.claude/settings.json")" -eq 18
 check "FORCE_AUTOUPDATE_PLUGINS set" test "$FORCE_AUTOUPDATE_PLUGINS" = "true"
 check "official marketplace cached" \
   test -d "$HOME/.claude/plugins/marketplaces/claude-plugins-official"
@@ -213,7 +213,7 @@ check "f5xc plugin cache populated" \
 check "superpowers pre-installed" \
   test -d "$HOME/.claude/plugins/cache/claude-plugins-official/superpowers"
 check "all enabled plugins cached" \
-  test "$(jq 'length' "$HOME/.claude/plugins/installed_plugins.json")" -eq 15
+  test "$(jq 'length' "$HOME/.claude/plugins/installed_plugins.json")" -eq 18
 
 echo ""
 echo "9. Chrome DevTools MCP"


### PR DESCRIPTION
## Summary

- Add `f5xc-docs-tools`, `f5xc-repo-governance`, and `f5xc-docs-pipeline` to the INSTALL.md plugin install loop and settings.json example
- Update plugin counts from 15 to 18 across `self-test.sh` and all INSTALL.md verification sections
- Update f5xc marketplace cache expected output to list all 4 plugins

## Test plan

- [ ] `grep -c 'f5xc-.*@f5xc-salesdemos-marketplace' INSTALL.md` returns 8 (4 in loop + 4 in settings example)
- [ ] `grep '18' claude-config/self-test.sh` shows updated counts in both checks
- [ ] `jq '.enabledPlugins | length' claude-config/settings.json` returns 18
- [ ] Markdownlint passes
- [ ] Hadolint passes (no Dockerfile changes)

Closes #563

🤖 Generated with [Claude Code](https://claude.com/claude-code)