### PR TITLE
fix: place ZSH_DOTENV_PROMPT before oh-my-zsh source and fix cp -a overwrite prompt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1218,7 +1218,7 @@ RUN ZSH_CUSTOM="${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}" \
     && echo 'export MANPAGER="sh -c '\''col -bx | bat -l man -p'\''"' >> "$HOME/.zshrc" \
     && echo 'export BAT_THEME="Coldark-Dark"' >> "$HOME/.zshrc" \
     && echo 'export BROWSER="browsh"' >> "$HOME/.zshrc" \
-    && echo 'export ZSH_DOTENV_PROMPT=false' >> "$HOME/.zshrc"
+    && sed -i '/^source \$ZSH\/oh-my-zsh.sh/i export ZSH_DOTENV_PROMPT=false' "$HOME/.zshrc"
 
 # ============================================================
 # 16. User shell bootstrap (baked in — eliminates runtime setup)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1002,11 +1002,21 @@ sed -i '' 's/^plugins=(.*/plugins=(zsh-syntax-highlighting zsh-autosuggestions z
 
 <!-- markdownlint-enable MD013 -->
 
-VERIFY both changes applied:
+**dotenv plugin config** — the `dotenv` plugin prompts before sourcing `.env` files. Disable the prompt by inserting `ZSH_DOTENV_PROMPT=false` **before** `source $ZSH/oh-my-zsh.sh` (the plugin reads this variable at load time, so appending to the end of `.zshrc` is too late):
+
+```bash
+grep -q 'ZSH_DOTENV_PROMPT' ~/.zshrc || \
+  sed -i '' '/^source \$ZSH\/oh-my-zsh.sh/i\
+export ZSH_DOTENV_PROMPT=false
+' ~/.zshrc
+```
+
+VERIFY all changes applied:
 
 ```bash
 grep '^ZSH_THEME=' ~/.zshrc    # VERIFY: output is ZSH_THEME="powerlevel10k/powerlevel10k"
 grep '^plugins=' ~/.zshrc       # VERIFY: output includes zsh-claudecode-completion
+grep 'ZSH_DOTENV_PROMPT' ~/.zshrc  # VERIFY: output is export ZSH_DOTENV_PROMPT=false (before source line)
 ```
 
 #### Common plugins (both macOS and devcontainer)
@@ -1261,6 +1271,7 @@ for KEY in \
   mkdir -p "$DEST"
 
   if [ -n "$SRC" ]; then
+    rm -rf "$DEST" && mkdir -p "$DEST"
     cp -a "${SRC}/." "$DEST/"
   elif [ "$NAME" = "superpowers" ]; then
     EXISTING="$(ls -d "${CACHE_DIR}/${NAME}"/*/. 2>/dev/null | head -1)"
@@ -2590,8 +2601,11 @@ grep -q 'VSCODE=cursor' ~/.zshrc || \
   echo 'export VSCODE=cursor' >> ~/.zshrc
 
 # dotenv plugin: auto-source .env files without prompting
+# Must appear BEFORE `source $ZSH/oh-my-zsh.sh` so the dotenv plugin sees it at load time
 grep -q 'ZSH_DOTENV_PROMPT' ~/.zshrc || \
-  echo 'export ZSH_DOTENV_PROMPT=false' >> ~/.zshrc
+  sed -i '' '/^source \$ZSH\/oh-my-zsh.sh/i\
+export ZSH_DOTENV_PROMPT=false
+' ~/.zshrc
 
 # Claude Code plugin autoupdate
 grep -q 'FORCE_AUTOUPDATE_PLUGINS' ~/.zshrc || \


### PR DESCRIPTION
## Summary
- Move `ZSH_DOTENV_PROMPT=false` to insert before `source $ZSH/oh-my-zsh.sh` instead of appending to end of `.zshrc` — the dotenv plugin reads this at load time, so appending is too late
- Add `rm -rf "$DEST" && mkdir -p "$DEST"` before `cp -a` in the plugin installer to prevent interactive overwrite prompts on macOS re-runs
- Add dotenv config step and verification in INSTALL.md Step 5.5

Closes #565

## Test plan
- [x] Verified `ZSH_DOTENV_PROMPT` appears before `source $ZSH/oh-my-zsh.sh` in `~/.zshrc`
- [x] Verified `source ~/.zshrc` no longer triggers dotenv interactive prompt
- [x] Verified plugin installer runs cleanly without overwrite prompts on macOS
- [x] Verified all 18 plugins install and cache correctly
- [x] Verified settings.json has 18 enabledPlugins

🤖 Generated with [Claude Code](https://claude.com/claude-code)