### PR TITLE
feat: add f5xc-brand plugin and frontend-slides skill

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -861,6 +861,7 @@ RUN pip install --no-cache-dir --break-system-packages --ignore-installed \
     nodriver \
     browserforge \
     "markitdown[all]" \
+    python-pptx \
     progressbar2 \
     checkov \
     ansible-lint \
@@ -1078,6 +1079,13 @@ RUN PLUGIN_BASE="/home/${USERNAME}/.claude/plugins" \
     && /opt/claude-config/install-plugins.sh \
         "${PLUGIN_BASE}" /opt/claude-config/settings.json \
     && chown -R ${USERNAME}:${USERNAME} "${PLUGIN_BASE}"
+
+# 12m. Claude Code skills (git-cloned external skills)
+# hadolint ignore=DL3059
+RUN git clone --depth=1 --single-branch --branch main \
+      https://github.com/zarazhangrui/frontend-slides.git \
+      "/home/${USERNAME}/.claude/skills/frontend-slides" \
+    && chown -R ${USERNAME}:${USERNAME} "/home/${USERNAME}/.claude/skills"
 
 # ============================================================
 # 13. Playwright system dependencies (requires root for apt)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1243,6 +1243,7 @@ for KEY in \
   f5xc-docs-tools@f5xc-salesdemos-marketplace \
   f5xc-repo-governance@f5xc-salesdemos-marketplace \
   f5xc-docs-pipeline@f5xc-salesdemos-marketplace \
+  f5xc-brand@f5xc-salesdemos-marketplace \
 ; do
   NAME="$(echo "$KEY" | cut -d@ -f1)"
   MKT="$(echo "$KEY" | cut -d@ -f2)"
@@ -1335,7 +1336,26 @@ printf '{"claude-plugins-official":{"source":{"source":"github","repo":"anthropi
 printf '{"fetchedAt":"%s","plugins":[]}' "$TIMESTAMP" > "${PLUGIN_BASE}/blocklist.json"
 ```
 
-### 6.4 — Merge Container Settings into `~/.claude/settings.json`
+### 6.4 — Install External Skills
+
+Some tools are installed as Claude Code skills (not marketplace
+plugins). These are git-cloned into `~/.claude/skills/`.
+
+```bash
+# frontend-slides — HTML presentation generator with visual styles
+git clone --depth=1 --single-branch --branch main \
+  https://github.com/zarazhangrui/frontend-slides.git \
+  ~/.claude/skills/frontend-slides
+```
+
+Invoke with `/frontend-slides` in Claude Code. For PowerPoint
+conversion, install the optional Python dependency:
+
+```bash
+pip install python-pptx
+```
+
+### 6.5 — Merge Container Settings into `~/.claude/settings.json`
 
 This step idempotently merges the container's Claude Code settings (model, status line, permissions, env vars, plugins, accessibility) into the local `~/.claude/settings.json`. If the file already exists, **local values win on conflict** — any user-specific settings (like `voiceEnabled`) are preserved.
 
@@ -1381,7 +1401,8 @@ CONTAINER_SETTINGS="$(cat <<SETTINGS
     "f5xc-sales-engineer@f5xc-salesdemos-marketplace": true,
     "f5xc-docs-tools@f5xc-salesdemos-marketplace": true,
     "f5xc-repo-governance@f5xc-salesdemos-marketplace": true,
-    "f5xc-docs-pipeline@f5xc-salesdemos-marketplace": true
+    "f5xc-docs-pipeline@f5xc-salesdemos-marketplace": true,
+    "f5xc-brand@f5xc-salesdemos-marketplace": true
   },
   "env": {
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
@@ -1481,19 +1502,19 @@ fi
 ### Verify Plugin and Settings Installation
 
 ```bash
-# Check installed_plugins.json has all 18 plugins
+# Check installed_plugins.json has all 19 plugins
 jq 'length' ~/.claude/plugins/installed_plugins.json
-# Expected: 18
+# Expected: 19
 
 # Check both marketplace caches exist
 ls ~/.claude/plugins/cache/claude-plugins-official/       # Expected: plugin directories
-ls ~/.claude/plugins/cache/f5xc-salesdemos-marketplace/   # Expected: f5xc-sales-engineer, f5xc-docs-tools, f5xc-repo-governance, f5xc-docs-pipeline
+ls ~/.claude/plugins/cache/f5xc-salesdemos-marketplace/   # Expected: f5xc-sales-engineer, f5xc-docs-tools, f5xc-repo-governance, f5xc-docs-pipeline, f5xc-brand
 
 # Check SKILL.md files were loaded
 find ~/.claude/plugins/cache -name "SKILL.md" -type f | wc -l
 
 # Check settings.json has full container settings merged
-jq '.enabledPlugins | keys | length' ~/.claude/settings.json  # Expected: 18
+jq '.enabledPlugins | keys | length' ~/.claude/settings.json  # Expected: 19
 jq '.model' ~/.claude/settings.json                            # Expected: "opus"
 jq '.statusLine.type' ~/.claude/settings.json                  # Expected: "command"
 jq '.env.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS' ~/.claude/settings.json  # Expected: "1"
@@ -2803,14 +2824,14 @@ echo $LITELLM_API_KEY        # VERIFY: output is your API key (not empty, not a 
 ```bash
 # Verify plugin count
 jq 'length' ~/.claude/plugins/installed_plugins.json
-# Expected: 18
+# Expected: 19
 
 # Verify SKILL.md files
 find ~/.claude/plugins/cache -name "SKILL.md" -type f | wc -l
 # Expected: 19
 
 # Verify settings.json has full container settings
-jq '.enabledPlugins | keys | length' ~/.claude/settings.json    # Expected: 18
+jq '.enabledPlugins | keys | length' ~/.claude/settings.json    # Expected: 19
 jq '.model' ~/.claude/settings.json                              # Expected: "opus"
 jq '.statusLine.type' ~/.claude/settings.json                    # Expected: "command"
 jq '.env.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS' ~/.claude/settings.json  # Expected: "1"

--- a/claude-config/self-test.sh
+++ b/claude-config/self-test.sh
@@ -191,8 +191,8 @@ echo ""
 echo "8. Claude Code Plugins"
 check "enabledPlugins in settings.json" \
   jq -e '.enabledPlugins' "$HOME/.claude/settings.json"
-check "18 plugins configured" \
-  test "$(jq '.enabledPlugins | length' "$HOME/.claude/settings.json")" -eq 18
+check "19 plugins configured" \
+  test "$(jq '.enabledPlugins | length' "$HOME/.claude/settings.json")" -eq 19
 check "FORCE_AUTOUPDATE_PLUGINS set" test "$FORCE_AUTOUPDATE_PLUGINS" = "true"
 check "official marketplace cached" \
   test -d "$HOME/.claude/plugins/marketplaces/claude-plugins-official"
@@ -213,7 +213,9 @@ check "f5xc plugin cache populated" \
 check "superpowers pre-installed" \
   test -d "$HOME/.claude/plugins/cache/claude-plugins-official/superpowers"
 check "all enabled plugins cached" \
-  test "$(jq 'length' "$HOME/.claude/plugins/installed_plugins.json")" -eq 18
+  test "$(jq 'length' "$HOME/.claude/plugins/installed_plugins.json")" -eq 19
+check "frontend-slides skill installed" \
+  test -f "$HOME/.claude/skills/frontend-slides/SKILL.md"
 
 echo ""
 echo "9. Chrome DevTools MCP"

--- a/claude-config/settings.json
+++ b/claude-config/settings.json
@@ -30,7 +30,8 @@
     "f5xc-sales-engineer@f5xc-salesdemos-marketplace": true,
     "f5xc-docs-tools@f5xc-salesdemos-marketplace": true,
     "f5xc-repo-governance@f5xc-salesdemos-marketplace": true,
-    "f5xc-docs-pipeline@f5xc-salesdemos-marketplace": true
+    "f5xc-docs-pipeline@f5xc-salesdemos-marketplace": true,
+    "f5xc-brand@f5xc-salesdemos-marketplace": true
   },
   "env": {
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",


### PR DESCRIPTION
## Summary

- Add `f5xc-brand` marketplace plugin to settings.json, INSTALL.md install loop, and settings example (3 skills: brand-guardian, visual-content, brand-reviewer + /review-brand command)
- Update plugin counts from 18 → 19 across self-test.sh and all INSTALL.md verification sections
- Add `frontend-slides` as a git-cloned skill to `~/.claude/skills/` (HTML presentation generator — installed per README, not as a marketplace plugin)
- Add `python-pptx` pip dependency for PowerPoint conversion support
- Add self-test check for frontend-slides SKILL.md

## Test plan

- [ ] `jq '.enabledPlugins | length' claude-config/settings.json` returns 19
- [ ] `grep 'f5xc-brand' claude-config/settings.json` shows the new plugin
- [ ] `grep 'frontend-slides' Dockerfile` shows git clone to skills dir
- [ ] `grep 'python-pptx' Dockerfile` shows pip dependency
- [ ] `hadolint Dockerfile` passes
- [ ] CI super-linter passes

Closes #572

🤖 Generated with [Claude Code](https://claude.com/claude-code)