### PR TITLE
fix: gog completions missing from container (COPY path error)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1239,10 +1239,11 @@ RUN mkdir -p "$HOME/.npm-global" \
     && "$HOME/.tfenv/bin/tfenv" use latest \
     && git clone --depth=1 https://github.com/tmux-plugins/tpm "$HOME/.tmux/plugins/tpm" \
     && SHELL=/bin/zsh opencode completion >> "$HOME/.zshrc" \
-    && cp /opt/devcontainer/configs/_gog /usr/local/share/zsh/site-functions/_gog \
-    && mkdir -p "${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/completions" \
-    && cp /opt/devcontainer/configs/_gog "${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/completions/_gog" \
     && zsh -c "autoload -U compinit && compinit" 2>/dev/null || true
+
+# gogcli (gog) native zsh completions (generated from gog help-json schema)
+COPY configs/_gog /usr/local/share/zsh/site-functions/_gog
+COPY --chown=${USERNAME}:${USERNAME} configs/_gog /home/${USERNAME}/.oh-my-zsh/custom/completions/_gog
 
 COPY --chown=${USERNAME}:${USERNAME} configs/.p10k.zsh /home/${USERNAME}/.p10k.zsh
 COPY --chown=${USERNAME}:${USERNAME} \


### PR DESCRIPTION
## Summary

- Root cause: `RUN cp /opt/devcontainer/configs/_gog ...` referenced a path that never existed in the container — config files are individually `COPY`'d, not mounted from a shared directory
- Replace with proper `COPY` directives to both `/usr/local/share/zsh/site-functions/_gog` and `~/.oh-my-zsh/custom/completions/_gog`
- Completions verified working on macOS after the same fix in PR #579

## Test plan

- [ ] `docker run --rm <image> ls /usr/local/share/zsh/site-functions/_gog` — file exists
- [ ] `docker run --rm <image> ls /home/vscode/.oh-my-zsh/custom/completions/_gog` — file exists
- [ ] `docker run --rm <image> zsh -i -c 'echo ${_comps[gog]}'` — shows `_gog`
- [ ] `hadolint Dockerfile` passes

Closes #580

🤖 Generated with [Claude Code](https://claude.com/claude-code)