### PR TITLE
feat: disable commit-commands plugin in favor of github-ops agent

### DIFF
--- a/claude-config/settings.json
+++ b/claude-config/settings.json
@@ -20,7 +20,6 @@
     "feature-dev@claude-plugins-official": true,
     "ralph-loop@claude-plugins-official": true,
     "typescript-lsp@claude-plugins-official": true,
-    "commit-commands@claude-plugins-official": true,
     "security-guidance@claude-plugins-official": true,
     "claude-md-management@claude-plugins-official": true,
     "pr-review-toolkit@claude-plugins-official": true,


### PR DESCRIPTION
## Summary

- Remove `commit-commands@claude-plugins-official` from `enabledPlugins` in `settings.json`
- Prevents `/commit` and `/commit-push-pr` from bypassing governance workflow
- All git operations now route through `f5xc-repo-governance:github-ops` agent

Closes #584

## Test plan

- [ ] CI checks pass
- [ ] `settings.json` is valid JSON
- [ ] Plugin list no longer includes `commit-commands`