### PR TITLE
docs: add missing pre-commit linting tools to INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -237,6 +237,11 @@ brew_install gitleaks          # Secret scanner (catches leaked credentials pre-
 brew_install trivy             # Vulnerability scanner for containers and code
 brew_install sslscan           # TLS/SSL configuration scanner
 brew_install trufflehog        # Deep git history secret scanner
+brew_install actionlint        # GitHub Actions workflow linter (syntax + logic)
+brew_install yamllint          # YAML linter (used by pre-commit hooks)
+brew_install codespell         # Source code spell checker
+brew_install checkov           # IaC / GitHub Actions security scanner
+brew_install zizmor            # GitHub Actions supply-chain security scanner
 
 # Media tools
 brew_install ffmpeg            # Video/audio processing (convert, extract, transcode)
@@ -288,6 +293,11 @@ gitleaks version       # VERIFY: output contains a version number
 trivy --version        # VERIFY: output starts with "Version:"
 sslscan --version      # VERIFY: output contains "sslscan version"
 trufflehog --version   # VERIFY: output contains a version number
+actionlint -version    # VERIFY: output contains a version number
+yamllint --version     # VERIFY: output starts with "yamllint"
+codespell --version    # VERIFY: output starts with "codespell"
+checkov --version      # VERIFY: output contains a version number
+zizmor --version       # VERIFY: output contains a version number
 ffmpeg -version        # VERIFY: output starts with "ffmpeg version"
 yt-dlp --version       # VERIFY: output contains a version string
 aider --version        # VERIFY: output contains a version number


### PR DESCRIPTION
## Summary

- Adds 5 missing linting tools to the macOS setup guide (Step 1 brew section)
- Adds verification commands for each tool

These tools are required by the native pre-commit hooks added in [docs-control#238](https://github.com/f5xc-salesdemos/docs-control/pull/238) which replaces the Docker-based Super-Linter hook.

**Tools added:**

| Tool | Purpose |
|------|---------|
| `actionlint` | GitHub Actions workflow linter |
| `yamllint` | YAML linter |
| `codespell` | Source code spell checker |
| `checkov` | IaC / GitHub Actions security scanner |
| `zizmor` | GitHub Actions supply-chain security scanner |

All five are available via `brew install <tool>`. They are already pre-installed in the devcontainer `Dockerfile` (no Dockerfile changes needed).

## Test plan

- [ ] `brew install actionlint yamllint codespell checkov zizmor` succeeds on macOS
- [ ] Each verify command returns a version string

Closes #590

🤖 Generated with [Claude Code](https://claude.com/claude-code)