### PR TITLE
fix: update self-test plugin count to 18 and fix v2 format check

### DIFF
--- a/claude-config/self-test.sh
+++ b/claude-config/self-test.sh
@@ -191,8 +191,8 @@ echo ""
 echo "8. Claude Code Plugins"
 check "enabledPlugins in settings.json" \
   jq -e '.enabledPlugins' "$HOME/.claude/settings.json"
-check "19 plugins configured" \
-  test "$(jq '.enabledPlugins | length' "$HOME/.claude/settings.json")" -eq 19
+check "18 plugins configured" \
+  test "$(jq '.enabledPlugins | length' "$HOME/.claude/settings.json")" -eq 18
 check "FORCE_AUTOUPDATE_PLUGINS set" test "$FORCE_AUTOUPDATE_PLUGINS" = "true"
 check "official marketplace cached" \
   test -d "$HOME/.claude/plugins/marketplaces/claude-plugins-official"
@@ -213,7 +213,7 @@ check "f5xc plugin cache populated" \
 check "superpowers pre-installed" \
   test -d "$HOME/.claude/plugins/cache/claude-plugins-official/superpowers"
 check "all enabled plugins cached" \
-  test "$(jq 'length' "$HOME/.claude/plugins/installed_plugins.json")" -eq 19
+  test "$(jq '.plugins | keys | length' "$HOME/.claude/plugins/installed_plugins.json")" -eq 18
 check "frontend-slides skill installed" \
   test -f "$HOME/.claude/skills/frontend-slides/SKILL.md"
 


### PR DESCRIPTION
## Summary

- Updates expected plugin count from 19 → 18 (commit-commands removed in #585)
- Fixes `jq 'length'` on `installed_plugins.json` v2 format: `jq 'length'` on `{"version":2,"plugins":{...}}` returns 2 (top-level key count), not the plugin count. Fixed to `jq '.plugins | keys | length'` (#583 introduced v2 format)

## Test plan

- [ ] `jq '.enabledPlugins | length' ~/.claude/settings.json` returns 18
- [ ] `jq '.plugins | keys | length' ~/.claude/plugins/installed_plugins.json` returns 18
- [ ] `claude-self-test` passes both plugin checks
- [ ] CI linting passes

Closes #594

🤖 Generated with [Claude Code](https://claude.com/claude-code)