### PR TITLE
fix: correct INSTALL.md verify commands and stale version checks

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -277,7 +277,7 @@ eza --version          # VERIFY: output starts with "v"
 fzf --version          # VERIFY: output contains a version number
 lsd --version          # VERIFY: output starts with "lsd"
 yq --version           # VERIFY: output contains "yq" followed by a version number
-python3 --version      # VERIFY: output starts with "Python 3.13"
+python3 --version      # VERIFY: output starts with "Python 3."
 go version             # VERIFY: output contains "go1."
 terraform --version    # VERIFY: output contains "Terraform v1"
 nvim --version         # VERIFY: output contains "NVIM v"
@@ -1552,8 +1552,8 @@ fi
 ### Verify Plugin and Settings Installation
 
 ```bash
-# Check installed_plugins.json has all 19 plugins
-jq 'length' ~/.claude/plugins/installed_plugins.json
+# Check installed_plugins.json has all 19 plugins (v2 format uses .plugins object)
+jq '.plugins | length' ~/.claude/plugins/installed_plugins.json
 # Expected: 19
 
 # Check both marketplace caches exist


### PR DESCRIPTION
## Summary

- Fix `jq` query for v2 plugin format: `jq 'length'` returns `2` (number of top-level keys in the v2 object), not `19`; use `jq '.plugins | length'` to correctly count installed plugins
- Loosen Python version verify from `'Python 3.13'` to `'Python 3.'` so it stays valid as brew ships newer Python releases (currently 3.14+)

## Test plan

- [x] Verified `jq '.plugins | length' ~/.claude/plugins/installed_plugins.json` returns `19` on current workstation
- [x] Verified `python3 --version` outputs `Python 3.14.3` on current workstation (old check would have failed)

Closes #596

🤖 Generated with [Claude Code](https://claude.com/claude-code)