### PR TITLE
fix: remove trivy — flagged as risk by IT

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -532,8 +532,6 @@ RUN ghlatest() { curl -fsSL -o /dev/null -w '%{url_effective}' "https://github.c
     && curl ${CURL_RETRY} -fsSL "https://github.com/editorconfig-checker/editorconfig-checker/releases/latest/download/ec-linux-${DPKG_ARCH}.tar.gz" \
       | tar -xz --strip-components=1 -C /usr/local/bin "bin/ec-linux-${DPKG_ARCH}" \
     && mv /usr/local/bin/ec-linux-${DPKG_ARCH} /usr/local/bin/editorconfig-checker \
-    # trivy (install script auto-detects arch)
-    && curl ${CURL_RETRY} -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin \
     # clj-kondo
     && CLJ_KONDO_VERSION=$(ghlatest clj-kondo/clj-kondo) \
     && if [ "$DPKG_ARCH" = "amd64" ]; then CK_ARCH="amd64"; else CK_ARCH="aarch64"; fi \

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -133,7 +133,7 @@ OpenCode will read this document and execute Steps 1–16 sequentially. The `"pe
 
 These are the brew packages required by OpenCode and its LSP/tooling ecosystem. Homebrew is idempotent — running `brew install` on an already-installed package prints a warning and exits with code 0. No pre-checks are needed.
 
-**Known issue — stale Cellar directories**: Some packages (notably `trivy`) can leave behind
+**Known issue — stale Cellar directories**: Some packages can leave behind
 a Cellar directory from a previous version after an upgrade or partial uninstall. When
 Homebrew tries to pour a newer bottle, it fails with
 `Error: /opt/homebrew/Cellar/<pkg>/<version> is not a directory` because a directory for a
@@ -143,8 +143,7 @@ re-link. A helper function below handles this automatically for all packages.
 ```bash
 # Helper function: install a brew package with stale-Cellar recovery.
 # On re-runs, Homebrew may fail to pour a new bottle version if an old
-# Cellar directory from a previous version still exists (commonly seen
-# with trivy, but can affect any package). This function:
+# Cellar directory from a previous version still exists. This function:
 #   1. Attempts a normal `brew install`.
 #   2. If that fails, removes the stale Cellar directory and retries.
 #   3. If the retry also fails, forces a re-link of whatever version
@@ -234,7 +233,6 @@ brew_install terraform-docs    # Auto-generate Terraform module documentation
 # Linting and security scanning
 brew_install hadolint          # Dockerfile linter (best practices enforcement)
 brew_install gitleaks          # Secret scanner (catches leaked credentials pre-commit)
-brew_install trivy             # Vulnerability scanner for containers and code
 brew_install sslscan           # TLS/SSL configuration scanner
 brew_install trufflehog        # Deep git history secret scanner
 brew_install actionlint        # GitHub Actions workflow linter (syntax + logic)
@@ -290,7 +288,6 @@ tflint --version       # VERIFY: output starts with "TFLint version"
 terraform-docs --version # VERIFY: output contains a version number
 hadolint --version     # VERIFY: output contains "Haskell Dockerfile Linter"
 gitleaks version       # VERIFY: output contains a version number
-trivy --version        # VERIFY: output starts with "Version:"
 sslscan --version      # VERIFY: output contains "sslscan version"
 trufflehog --version   # VERIFY: output contains a version number
 actionlint -version    # VERIFY: output contains a version number
@@ -3094,7 +3091,7 @@ echo "==========================================================="
 Error: /opt/homebrew/Cellar/<pkg>/<version> is not a directory
 ```
 
-**Cause**: A previous version's Cellar directory survived an upgrade or partial uninstall. Homebrew refuses to pour a new bottle version when an old version directory already exists. This is commonly seen with `trivy` but can affect any package. Running `brew uninstall --force` does not always remove the stale directory.
+**Cause**: A previous version's Cellar directory survived an upgrade or partial uninstall. Homebrew refuses to pour a new bottle version when an old version directory already exists. Running `brew uninstall --force` does not always remove the stale directory.
 
 **Fix**:
 

--- a/claude-config/self-test.sh
+++ b/claude-config/self-test.sh
@@ -59,7 +59,6 @@ echo "6. Super-Linter Tools"
 # Binary tools
 check "shfmt installed" command -v shfmt
 check "gitleaks installed" command -v gitleaks
-check "trivy installed" command -v trivy
 check "editorconfig-checker installed" command -v editorconfig-checker
 check "golangci-lint installed" command -v golangci-lint
 check "kubeconform installed" command -v kubeconform

--- a/docs/local-development.mdx
+++ b/docs/local-development.mdx
@@ -120,7 +120,7 @@ These layers change more frequently (npm/pip updates, config changes) but rebuil
 | 9. AWS CLI v2 | Official installer |
 | 10. Binary tools | kubectl, helm, tflint, terraform-docs, act, actionlint, yt-dlp, uv, opencode |
 | 10b. Additional binaries | VS Code CLI, oc, yq, terragrunt, ibmcloud, fzf, hadolint, codex |
-| 10c. Super-linter binaries | shfmt, gitleaks, editorconfig-checker, trivy, clj-kondo, dotenv-linter, golangci-lint, goreleaser, kubeconform, protolint, scalafmt, ktlint |
+| 10c. Super-linter binaries | shfmt, gitleaks, editorconfig-checker, clj-kondo, dotenv-linter, golangci-lint, goreleaser, kubeconform, protolint, scalafmt, ktlint |
 | 10d. Java JAR tools | checkstyle, google-java-format (wrapper scripts) |
 | 10e. PHP linters | phpcs, phpstan, psalm (PHAR downloads) |
 | 10f. PowerShell modules | PSScriptAnalyzer, arm-ttk |

--- a/docs/security.mdx
+++ b/docs/security.mdx
@@ -115,7 +115,7 @@ The container includes approximately 80 pre-installed security and penetration t
 | Reverse engineering | radare2, Ghidra, gdb, binwalk, strace, ltrace |
 | Reconnaissance | subfinder, amass, httpx, nuclei, gau, waybackurls, recon-ng, spiderfoot |
 | Fuzzing and enumeration | ffuf, gobuster, SecLists |
-| Supply chain and secrets | trufflehog, grype, syft, gitleaks, trivy |
+| Supply chain and secrets | trufflehog, grype, syft, gitleaks |
 | Exploitation frameworks | Metasploit (amd64), searchsploit (ExploitDB) |
 
 Some tools (bettercap, Metasploit) are only available on amd64 due to upstream packaging constraints. Packet capture tools (tshark, bettercap) require the `NET_ADMIN` capability, which is included in the default `docker-compose.yml`.


### PR DESCRIPTION
## Summary

IT has flagged trivy as a security risk. Removed from all locations:

- **Dockerfile**: removed `curl` install step
- **INSTALL.md**: removed `brew_install trivy` and verify command; scrubbed trivy mentions from stale Cellar note
- **claude-config/self-test.sh**: removed `check "trivy installed"` line
- **docs/local-development.mdx**: removed from super-linter binaries table
- **docs/security.mdx**: removed from supply chain and secrets tools table

## Test plan

- [x] Verified `grep -r trivy .` returns no matches after changes
- [x] No hardcoded tool counts in self-test.sh affected

Closes #598

🤖 Generated with [Claude Code](https://claude.com/claude-code)