### PR TITLE
refactor: rename f5xc-repo-governance references to f5xc-github-ops

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ Invoke the relevant skill **before** starting work.
 
 | Skill | Activates when... |
 | ----- | ----------------- |
-| `f5xc-repo-governance:workflow-lifecycle` | Starting any development task |
+| `f5xc-github-ops:workflow-lifecycle` | Starting any development task |
 | `f5xc-docs-pipeline:pipeline-navigator` | Changing docs infrastructure config |
 | `f5xc-docs-pipeline:content-author` | Editing docs content (MDX/Markdown) |
 | `f5xc-brand:brand-guardian` | Creating any visual content or assets |
@@ -58,7 +58,7 @@ Invoke the relevant skill **before** starting work.
 ## GitHub Operations Routing
 
 ALL Git and GitHub operations are handled exclusively by the
-`f5xc-repo-governance:github-ops` agent. This supersedes the
+`f5xc-github-ops:github-ops` agent. This supersedes the
 `commit-commands` official plugin for all f5xc-salesdemos repos.
 
 **Never** run these directly in the main session:
@@ -79,7 +79,7 @@ complete. The agent will:
 
 ```
 Agent(
-  subagent_type="f5xc-repo-governance:github-ops",
+  subagent_type="f5xc-github-ops:github-ops",
   prompt="<type>: <description>\n\nFiles to stage:\n- <file-list>\n\nWhy: <motivation>"
 )
 ```

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1283,7 +1283,7 @@ for KEY in \
   hookify@claude-plugins-official \
   f5xc-sales-engineer@f5xc-salesdemos-marketplace \
   f5xc-docs-tools@f5xc-salesdemos-marketplace \
-  f5xc-repo-governance@f5xc-salesdemos-marketplace \
+  f5xc-github-ops@f5xc-salesdemos-marketplace \
   f5xc-docs-pipeline@f5xc-salesdemos-marketplace \
   f5xc-brand@f5xc-salesdemos-marketplace \
 ; do
@@ -1447,7 +1447,7 @@ CONTAINER_SETTINGS="$(cat <<SETTINGS
     "hookify@claude-plugins-official": true,
     "f5xc-sales-engineer@f5xc-salesdemos-marketplace": true,
     "f5xc-docs-tools@f5xc-salesdemos-marketplace": true,
-    "f5xc-repo-governance@f5xc-salesdemos-marketplace": true,
+    "f5xc-github-ops@f5xc-salesdemos-marketplace": true,
     "f5xc-docs-pipeline@f5xc-salesdemos-marketplace": true,
     "f5xc-brand@f5xc-salesdemos-marketplace": true
   },
@@ -1555,7 +1555,7 @@ jq '.plugins | length' ~/.claude/plugins/installed_plugins.json
 
 # Check both marketplace caches exist
 ls ~/.claude/plugins/cache/claude-plugins-official/       # Expected: plugin directories
-ls ~/.claude/plugins/cache/f5xc-salesdemos-marketplace/   # Expected: f5xc-sales-engineer, f5xc-docs-tools, f5xc-repo-governance, f5xc-docs-pipeline, f5xc-brand
+ls ~/.claude/plugins/cache/f5xc-salesdemos-marketplace/   # Expected: f5xc-sales-engineer, f5xc-docs-tools, f5xc-github-ops, f5xc-docs-pipeline, f5xc-brand
 
 # Check SKILL.md files were loaded (plugins)
 find ~/.claude/plugins/cache -name "SKILL.md" -type f | wc -l

--- a/claude-config/settings.json
+++ b/claude-config/settings.json
@@ -28,7 +28,7 @@
     "hookify@claude-plugins-official": true,
     "f5xc-sales-engineer@f5xc-salesdemos-marketplace": true,
     "f5xc-docs-tools@f5xc-salesdemos-marketplace": true,
-    "f5xc-repo-governance@f5xc-salesdemos-marketplace": true,
+    "f5xc-github-ops@f5xc-salesdemos-marketplace": true,
     "f5xc-docs-pipeline@f5xc-salesdemos-marketplace": true,
     "f5xc-brand@f5xc-salesdemos-marketplace": true
   },


### PR DESCRIPTION
## Summary

- Rename all `f5xc-repo-governance` plugin references to `f5xc-github-ops` across devcontainer configuration
- Updates `claude-config/settings.json` plugin enable key
- Updates `CLAUDE.md` skill references and delegation pattern
- Updates `INSTALL.md` install loop, settings block, and verification comment

Closes #600

## Test plan

- [ ] CI checks pass
- [ ] Plugin references resolve correctly in Claude Code sessions using the updated settings