### PR TITLE
refactor: remove redundant Convention Files section

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -26,18 +26,6 @@ follow its instructions exactly**.
 4. **Read convention files** — skills read product-specific content
    from standardized files in the repository root
 
-## Convention Files
-
-Skills read product-specific content from these repo-local files:
-
-| File | Purpose | Required By |
-| ---- | ------- | ----------- |
-| `PRODUCT_EXPERTISE.md` | Product capabilities, detection signals, threat coverage, compliance alignment, API reference | All skills |
-| `WALKTHROUGH_CONFIG.md` | Demo app URL, walkthrough order, detection timing | presenter |
-| `SOURCE_INDEX.md` | Research source catalog for demo-researcher agent | demo-executor (Q&A), subject-matter-expert |
-| `READINESS_MATRIX.md` | Required/optional variables, readiness checks (T0–T5), API endpoints | demo-executor (Prepare/Teardown) |
-| `docs/api-automation/` | Phase files with cURL commands and evidence gates | demo-executor (Execute) |
-
 ## Ambiguous Intent
 
 If the user's request relates to the demo but does not clearly


### PR DESCRIPTION
## Summary

- Removed the Convention Files table from `.claude/CLAUDE.md` — plugin agents already hardcode their convention file dependencies (READINESS_MATRIX.md, SOURCE_INDEX.md, etc.) directly in their agent definitions
- Keeps CLAUDE.md focused on trigger routing only, reducing redundant context weight

Closes #602

## Test plan

- [x] Pre-commit hooks pass
- [ ] CI checks pass
- [ ] Plugin agent skills still resolve their convention files correctly (no behavioral change expected — the table was informational only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)