### PR TITLE
fix: resolve checkov pydantic dependency and self-test chrome-devtools check

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -861,6 +861,7 @@ RUN pip install --no-cache-dir --break-system-packages --ignore-installed \
     "markitdown[all]" \
     python-pptx \
     progressbar2 \
+    "pydantic>=2.0" \
     checkov \
     ansible-lint \
     cfn-lint \

--- a/claude-config/self-test.sh
+++ b/claude-config/self-test.sh
@@ -223,7 +223,7 @@ check "Chrome symlink target exists" test -e /opt/google/chrome/chrome
 check "Chrome binary responds" /opt/google/chrome/chrome --version
 check "chrome-browser.sh installed" test -f /usr/local/lib/chrome-browser.sh
 check "Chrome remote debugging active" curl -sf --connect-timeout 2 http://localhost:9222/json/version
-check "chrome-devtools in settings" grep -q '"chrome-devtools"' "$HOME/.claude/settings.json"
+check "chrome-devtools in settings" grep -q '"chrome-devtools"' "$HOME/.claude.json"
 MCP_MAIN_FILE=$(find /home/vscode/.npm/_npx -name 'chrome-devtools-mcp-main.js' \
   -path '*/bin/*' 2>/dev/null | head -1)
 if [ -n "$MCP_MAIN_FILE" ]; then


### PR DESCRIPTION
## Summary

- Add explicit `pydantic>=2.0` to pip install block before checkov to resolve `ImportError: cannot import name 'model_serializer' from 'pydantic'`
- Fix self-test chrome-devtools config check to grep `$HOME/.claude.json` instead of `$HOME/.claude/settings.json` (MCP servers are configured in the former)

Closes #604

## Test plan

- [ ] CI checks pass
- [ ] Rebuild devcontainer image and verify `checkov --version` succeeds
- [ ] Run `claude-self-test` and verify chrome-devtools check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)