### PR TITLE
fix: move checkov to uv tool install with Python 3.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -861,8 +861,6 @@ RUN pip install --no-cache-dir --break-system-packages --ignore-installed \
     "markitdown[all]" \
     python-pptx \
     progressbar2 \
-    "pydantic>=2.0" \
-    checkov \
     ansible-lint \
     cfn-lint \
     cpplint \
@@ -910,7 +908,10 @@ RUN UV_TOOL_DIR=/opt/uv-tools UV_TOOL_BIN_DIR=/usr/local/bin \
       --with aider-chat[help] \
       --with aider-chat[playwright] \
     && UV_TOOL_DIR=/opt/uv-tools UV_TOOL_BIN_DIR=/usr/local/bin \
-    uv tool install notebooklm-mcp-cli
+    uv tool install notebooklm-mcp-cli \
+    && UV_TOOL_DIR=/opt/uv-tools UV_TOOL_BIN_DIR=/usr/local/bin \
+    uv tool install --python python3.12 checkov \
+    # checkov requires Python <3.13 (FileType.JSON AttributeError on 3.13)
 
 # signal-cli (Signal messenger CLI — Java application)
 # hadolint ignore=DL3059


### PR DESCRIPTION
## Summary

- Move checkov from system pip install to `uv tool install` with `--python python3.12` to avoid Python 3.13 AttributeError (`FileType.JSON` not found in `bc_check_type` enum)
- Remove the now-unnecessary `pydantic>=2.0` pin from the pip block since checkov runs in its own isolated venv
- Follows the same isolation pattern already used for `aider-chat`

Closes #608

## Test plan

- [ ] CI checks pass
- [ ] Docker build completes successfully
- [ ] `checkov --version` works in the built container
- [ ] checkov can scan a file without the `FileType.JSON` AttributeError

🤖 Generated with [Claude Code](https://claude.com/claude-code)