### PR TITLE
fix: remove trailing backslash on checkov install line

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -912,7 +912,7 @@ RUN UV_TOOL_DIR=/opt/uv-tools UV_TOOL_BIN_DIR=/usr/local/bin \
     && UV_TOOL_DIR=/opt/uv-tools UV_TOOL_BIN_DIR=/usr/local/bin \
     uv tool install notebooklm-mcp-cli \
     && UV_TOOL_DIR=/opt/uv-tools UV_TOOL_BIN_DIR=/usr/local/bin \
-    uv tool install --python python3.12 checkov \
+    uv tool install --python python3.12 checkov
     # checkov requires Python <3.13 (FileType.JSON AttributeError on 3.13)
 
 # signal-cli (Signal messenger CLI — Java application)


### PR DESCRIPTION
## Summary

- Remove trailing `\` (line continuation) from the checkov `uv tool install` line in the Dockerfile
- This backslash caused Docker to concatenate the checkov RUN block with the next signal-cli RUN instruction, breaking the Docker Publish CI on both amd64 and arm64 (run 23492870884)
- Introduced in PR #609 (commit c3d1ca1), now blocking Docker Publish triggered by the self-awareness merge (#613)

Closes #614

## Test plan

- [ ] CI checks pass (Check linked issues, Lint Code Base)
- [ ] Docker Publish workflow succeeds on main after merge
- [ ] Both amd64 and arm64 builds complete successfully

## Checklist

- [x] Branch name follows convention: `fix/614-remove-checkov-trailing-backslash`
- [x] Conventional commit message: `fix: ...`
- [x] PR linked to issue: Closes #614
- [x] Pre-commit hooks pass (checkov skipped — pre-existing pydantic breakage in container)