### PR TITLE
fix: remove aider-chat to unblock Docker Publish

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -902,14 +902,9 @@ RUN pip install --no-cache-dir --break-system-packages --ignore-installed \
     && pip install --no-cache-dir --break-system-packages --ignore-installed \
     prowler kube-hunter
 
-# Aider AI chat — requires Python <3.13, so install isolated with uv + Python 3.12
+# uv-isolated tools (notebooklm-mcp-cli, checkov)
 # hadolint ignore=DL3059
 RUN UV_TOOL_DIR=/opt/uv-tools UV_TOOL_BIN_DIR=/usr/local/bin \
-    uv tool install --python python3.12 aider-chat@latest \
-      --with aider-chat[browser] \
-      --with aider-chat[help] \
-      --with aider-chat[playwright] \
-    && UV_TOOL_DIR=/opt/uv-tools UV_TOOL_BIN_DIR=/usr/local/bin \
     uv tool install notebooklm-mcp-cli \
     && UV_TOOL_DIR=/opt/uv-tools UV_TOOL_BIN_DIR=/usr/local/bin \
     uv tool install --python python3.12 checkov


### PR DESCRIPTION
## Summary

- Remove aider-chat from Dockerfile uv tool installs
- aider-chat@latest (v0.86.2) depends on litellm==1.81.10 which does not exist in PyPI, breaking Docker Publish CI on both amd64 and arm64 (runs 23492870884 and 23493638807)
- aider-chat is unused -- removing it unblocks the image build and reduces image size
- Remaining uv-isolated tools (notebooklm-mcp-cli, checkov) are preserved

Closes #616

## Test plan

- [ ] CI checks pass (Check linked issues, Lint Code Base)
- [ ] Docker Publish workflow succeeds on both amd64 and arm64