### PR TITLE
fix: remove stale self-test checks and broken cursor installer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -449,9 +449,6 @@ RUN ghlatest() { curl -fsSL -o /dev/null -w '%{url_effective}' "https://github.c
       -o /tmp/vscode_cli.tar.gz \
     && tar -xzf /tmp/vscode_cli.tar.gz -C /usr/local/bin \
     && rm /tmp/vscode_cli.tar.gz \
-    # Cursor CLI (agent) — official installer detects arch automatically
-    && curl -fsSL https://cursor.com/install | bash \
-    && ln -sf /home/${USERNAME}/.local/bin/agent /usr/local/bin/agent \
     # oc (OpenShift CLI) — stable channel uses version-free filenames
     && if [ "$DPKG_ARCH" = "amd64" ]; then OC_ARCHIVE="openshift-client-linux.tar.gz"; else OC_ARCHIVE="openshift-client-linux-arm64.tar.gz"; fi \
     && curl ${CURL_RETRY} -fsSL \

--- a/claude-config/self-test.sh
+++ b/claude-config/self-test.sh
@@ -27,8 +27,6 @@ check "browsh installed" command -v browsh
 check "firefox-esr installed" command -v firefox-esr
 check "claude CLI installed" command -v claude
 check "pi CLI installed" command -v pi
-check "aider CLI installed" command -v aider
-check "cursor agent CLI installed" command -v agent
 check "node installed" command -v node
 check "python installed" command -v python3
 check "git installed" command -v git


### PR DESCRIPTION
## Summary

- Remove stale self-test checks for aider and cursor agent from `claude-config/self-test.sh`
- Remove broken cursor agent installer from `Dockerfile` (leaves dangling symlink in Docker build context)
- After this change, self-test reports 154 passed, 0 failed

Closes #620

## Test plan

- [x] `claude-self-test` reports 154 passed, 0 failed
- [ ] CI checks pass
- [ ] Container builds successfully without cursor installer

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>