### PR TITLE
fix: self-awareness pass 2 — fix inaccuracies and add self-diagnosis

### DIFF
--- a/claude-config/CLAUDE.md
+++ b/claude-config/CLAUDE.md
@@ -17,14 +17,13 @@ All Claude Code tools use PascalCase. NEVER use snake_case.
 | `Bash` | `bash`, `run_command`, `shell`, `execute` | Run shell commands |
 | `Glob` | `glob`, `find_files`, `list_files` | Find files by pattern |
 | `Grep` | `grep`, `search`, `search_files` | Search file contents |
-| `Task` | `task`, `run_task`, `agent` | Launch subagent tasks |
+| `Agent` | `agent`, `task`, `run_task` | Launch subagent tasks |
 
-
-## Task Tool Requirements
+## Agent Tool Requirements
 
 - Always include `description` (string) — it is REQUIRED
-- Subagent types are PascalCase: `Explore`, `Plan`
 - Both `description` and `prompt` are required
+- Use `subagent_type` to select specialized agents (e.g., `Explore`, `Plan`)
 
 ## Parameter Types
 
@@ -42,32 +41,19 @@ If a tool call returns "No such tool available":
 4. NEVER conclude tools are unavailable — they are always present
 5. NEVER build workarounds for "missing" tools — fix the tool call
 
-## Subagent (Task Tool) Limitations
+## Agent Subagent Capabilities
 
-When launched via the `Task` tool, subagents (Explore and Plan types)
-have a **restricted tool set**. They can NOT use filesystem or shell tools.
+The `Agent` tool spawns subagents whose available tools depend on
+the `subagent_type` parameter:
 
-### Tools available to subagents
+- **general-purpose**: Full tool access — `Bash`, `Read`, `Write`,
+  `Edit`, `Glob`, `Grep`, and can launch further agents
+- **Explore**: Read-only — `Glob`, `Grep`, `Read`, `LS`, `Bash`
+  (output only). Cannot edit, write, or launch nested agents
+- **Plan**: Read-only — same as Explore. Cannot edit or write
 
-Subagents can only use knowledge-base and utility tools:
-
-- `list_knowledge_bases`, `search_knowledge_bases`, `query_knowledge_bases`
-- `search_knowledge_files`, `query_knowledge_files`, `view_knowledge_file`
-- `search_chats`, `view_chat`
-- `generate_image`
-- `get_current_timestamp`, `calculate_timestamp`
-
-### Tools NOT available to subagents
-
-- `Bash`, `Read`, `Write`, `Edit`, `Glob`, `Grep`
-- `Task` (subagents cannot launch further subagents)
-
-### Implication for the main session
-
-Do NOT delegate filesystem exploration, shell commands, or file reading
-to subagents. Perform those operations directly in the main session.
-Use subagents only for knowledge-base search, chat history search,
-and planning/reasoning tasks that don't require filesystem access.
+Subagents inherit the session's permissions and working directory.
+They are full Claude Code instances with their own context window.
 
 ## Bash Tool Escaping
 

--- a/claude-config/self-test.sh
+++ b/claude-config/self-test.sh
@@ -44,7 +44,7 @@ MANAGED_CLAUDE="/etc/claude-code/CLAUDE.md"
 check "$MANAGED_CLAUDE exists" test -f "$MANAGED_CLAUDE"
 check "Managed policy contains PascalCase reference" grep -q "PascalCase" "$MANAGED_CLAUDE"
 check "Managed policy contains tool table" grep -q "Read file contents" "$MANAGED_CLAUDE"
-check "Managed policy contains subagent docs" grep -q "Subagent" "$MANAGED_CLAUDE"
+check "Managed policy contains Agent tool docs" grep -q "Agent" "$MANAGED_CLAUDE"
 
 echo ""
 echo "4. Container Environment"
@@ -53,7 +53,7 @@ check "home directory writable" test -w "$HOME"
 check "TERM is set" test -n "${TERM:-}"
 
 echo ""
-echo "6. Super-Linter Tools"
+echo "5. Super-Linter Tools"
 # Binary tools
 check "shfmt installed" command -v shfmt
 check "gitleaks installed" command -v gitleaks
@@ -121,7 +121,7 @@ check "arm-ttk installed" test -f /usr/lib/microsoft/arm-ttk/arm-ttk/arm-ttk.psd
 check "Rscript installed" command -v Rscript
 
 echo ""
-echo "7. Security & Pentest Tools"
+echo "6. Security & Pentest Tools"
 DPKG_ARCH=$(dpkg --print-architecture)
 # Network tools
 check "tshark installed" command -v tshark
@@ -185,11 +185,12 @@ if [ "$DPKG_ARCH" = "amd64" ]; then
 fi
 
 echo ""
-echo "8. Claude Code Plugins"
+echo "7. Claude Code Plugins"
 check "enabledPlugins in settings.json" \
   jq -e '.enabledPlugins' "$HOME/.claude/settings.json"
-check "18 plugins configured" \
-  test "$(jq '.enabledPlugins | length' "$HOME/.claude/settings.json")" -eq 18
+ENABLED_COUNT=$(jq '.enabledPlugins | length' "$HOME/.claude/settings.json")
+check "${ENABLED_COUNT} plugins configured (at least 1)" \
+  test "$ENABLED_COUNT" -ge 1
 check "FORCE_AUTOUPDATE_PLUGINS set" test "$FORCE_AUTOUPDATE_PLUGINS" = "true"
 check "official marketplace cached" \
   test -d "$HOME/.claude/plugins/marketplaces/claude-plugins-official"
@@ -209,13 +210,14 @@ check "f5xc plugin cache populated" \
   test -d "$HOME/.claude/plugins/cache/f5xc-salesdemos-marketplace"
 check "superpowers pre-installed" \
   test -d "$HOME/.claude/plugins/cache/claude-plugins-official/superpowers"
-check "all enabled plugins cached" \
-  test "$(jq '.plugins | keys | length' "$HOME/.claude/plugins/installed_plugins.json")" -eq 18
+CACHED_COUNT=$(jq '.plugins | keys | length' "$HOME/.claude/plugins/installed_plugins.json")
+check "all ${ENABLED_COUNT} enabled plugins cached (${CACHED_COUNT} found)" \
+  test "$CACHED_COUNT" -eq "$ENABLED_COUNT"
 check "frontend-slides skill installed" \
   test -f "$HOME/.claude/skills/frontend-slides/SKILL.md"
 
 echo ""
-echo "9. Chrome DevTools MCP"
+echo "8. Chrome DevTools MCP"
 check "Chrome symlink exists" test -L /opt/google/chrome/chrome
 check "Chrome symlink target exists" test -e /opt/google/chrome/chrome
 check "Chrome binary responds" /opt/google/chrome/chrome --version
@@ -231,7 +233,7 @@ else
 fi
 
 echo ""
-echo "10. iTerm2 Utilities"
+echo "9. iTerm2 Utilities"
 check "imgcat installed" command -v imgcat
 check "imgls installed" command -v imgls
 check "it2dl installed" command -v it2dl
@@ -240,7 +242,7 @@ check "it2copy installed" command -v it2copy
 check "it2check installed" command -v it2check
 
 echo ""
-echo "11. Anti-Bot Detection Tools"
+echo "10. Anti-Bot Detection Tools"
 check "puppeteer installed (npm)" node -e "require('puppeteer')"
 check "puppeteer-extra installed (npm)" node -e "require('puppeteer-extra')"
 check "puppeteer-extra-plugin-stealth installed (npm)" node -e "require('puppeteer-extra-plugin-stealth')"

--- a/claude-config/statusline.sh
+++ b/claude-config/statusline.sh
@@ -5,6 +5,12 @@ CTX_USED=$(echo "$input" | jq -r '.context_window.used_percentage // 0')
 DIR=$(echo "$input" | jq -r '.workspace.current_dir // empty')
 [ -z "$DIR" ] && DIR=$(pwd)
 
+# Build SHA (read once from fingerprint file)
+BUILD_SHA=""
+if [ -f /etc/devcontainer-version ]; then
+  BUILD_SHA=$(grep '^BUILD_COMMIT=' /etc/devcontainer-version | cut -c15-21)
+fi
+
 # Colors (matching p10k theme)
 GREEN='\033[32m'
 YELLOW='\033[33m'
@@ -53,7 +59,11 @@ if git -C "$DIR" rev-parse --git-dir >/dev/null 2>&1; then
   [ "$UNTRACKED" -gt 0 ] && DETAILS="${DETAILS} ${CYAN}?${UNTRACKED}${RESET}"
   [ "$CONFLICTED" -gt 0 ] && DETAILS="${DETAILS} ${RED}!${CONFLICTED}${RESET}"
 
-  echo -e "${CTX_COLOR}${CTX_USED}%${RESET} ${DIR} ${DIM}|${RESET} ${BRANCH_COLOR}${BRANCH}${RESET} ${STATE}${DETAILS}"
+  BUILD_TAG=""
+  [ -n "$BUILD_SHA" ] && BUILD_TAG=" ${DIM}[${BUILD_SHA}]${RESET}"
+  echo -e "${CTX_COLOR}${CTX_USED}%${RESET} ${DIR} ${DIM}|${RESET} ${BRANCH_COLOR}${BRANCH}${RESET} ${STATE}${DETAILS}${BUILD_TAG}"
 else
-  echo -e "${CTX_COLOR}${CTX_USED}%${RESET} ${DIR}"
+  BUILD_TAG=""
+  [ -n "$BUILD_SHA" ] && BUILD_TAG=" ${DIM}[${BUILD_SHA}]${RESET}"
+  echo -e "${CTX_COLOR}${CTX_USED}%${RESET} ${DIR}${BUILD_TAG}"
 fi

--- a/claude-config/user-CLAUDE.md
+++ b/claude-config/user-CLAUDE.md
@@ -134,6 +134,34 @@ Dockerfile change, every claude-config/ update, every entrypoint.sh
 tweak will be reflected in the next container that runs you. This is
 your self-improvement mechanism.
 
+## Self-Diagnosis
+
+When asked to self-analyze, or when encountering unexpected behavior,
+run a structured self-diagnosis:
+
+1. **Baseline health** — run `claude-self-test` and check for failures
+2. **Source drift** — clone the source repo and diff runtime config
+   against source to detect divergence:
+
+   ```text
+   gh repo clone f5xc-salesdemos/devcontainer /tmp/devcontainer-audit
+   diff /etc/claude-code/CLAUDE.md /tmp/devcontainer-audit/claude-config/CLAUDE.md
+   diff ~/.claude/CLAUDE.md /tmp/devcontainer-audit/claude-config/user-CLAUDE.md
+   diff ~/.claude/settings.json /tmp/devcontainer-audit/claude-config/settings.json
+   ```
+
+3. **Tool accuracy** — verify that tool names and capabilities
+   documented in the managed CLAUDE.md match the tools actually
+   available in your current session
+4. **Test coverage** — check self-test section numbering for gaps,
+   validate that checks match actual installed tools
+5. **Resource health** — check disk usage (`df -h /`), memory
+   (`free -h`), and running processes (`ps aux --sort=-rss`)
+
+**Acting on findings:** Follow the Ephemeral Filesystem Rule —
+fix issues in the running container immediately, then persist
+changes to the source repo and commit via the github-ops agent.
+
 ## Self-Test
 
 Run `claude-self-test` to verify container configuration is correct.


### PR DESCRIPTION
## Summary

- Fixed managed CLAUDE.md: renamed Task to Agent tool, replaced incorrect subagent capability docs
- Fixed self-test.sh: sequential section numbering (was 1-4,6-11, now 1-10), dynamic plugin count check
- Added Self-Diagnosis section to user-CLAUDE.md with structured self-analysis procedure
- Added build SHA to statusline output for container identity visibility

Closes #622

## Test plan

- [ ] CI checks pass (lint, governance, secrets detection)
- [ ] `claude-self-test` passes with corrected sequential numbering
- [ ] Statusline displays build SHA correctly
- [ ] Managed CLAUDE.md reflects accurate Agent tool naming and subagent capabilities