### PR TITLE
fix: move GIT_COMMITTER derivation from docker-compose.yml to entrypoint.sh

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -82,6 +82,9 @@ LITELLM_BASE_URL=https://proxy.example.com
 # =============================================================================
 # Git Config
 # =============================================================================
+# The entrypoint derives GIT_COMMITTER_NAME and GIT_COMMITTER_EMAIL from these
+# automatically, so you only need to set the AUTHOR variables.
+#
 # @auto-detect: git config user.email
 # @requires: git with user.email configured
 # @check: git config user.email

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,6 @@ services:
       - path: .env
         required: false
     environment:
-      - GIT_COMMITTER_NAME=${GIT_AUTHOR_NAME:-}
-      - GIT_COMMITTER_EMAIL=${GIT_AUTHOR_EMAIL:-}
       - TERM=xterm-256color
       - COLORTERM=truecolor
       - LANG=en_US.UTF-8

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,9 +5,11 @@
 
 if [ -n "$GIT_AUTHOR_NAME" ]; then
   git config --global user.name "$GIT_AUTHOR_NAME"
+  export GIT_COMMITTER_NAME="${GIT_COMMITTER_NAME:-$GIT_AUTHOR_NAME}"
 fi
 if [ -n "$GIT_AUTHOR_EMAIL" ]; then
   git config --global user.email "$GIT_AUTHOR_EMAIL"
+  export GIT_COMMITTER_EMAIL="${GIT_COMMITTER_EMAIL:-$GIT_AUTHOR_EMAIL}"
 fi
 
 git config --global --add safe.directory /workspace


### PR DESCRIPTION
## Summary

- Move `GIT_COMMITTER_NAME` and `GIT_COMMITTER_EMAIL` derivation from `docker-compose.yml` to `entrypoint.sh` so all launch methods (docker-compose, podman, devcontainer CLI) get committer vars set automatically
- Use `${VAR:-default}` pattern so explicit overrides still win
- Add clarifying comment in `.env.example` about auto-derivation

Closes #636

## Test plan

- [ ] CI checks pass
- [ ] Launch via `docker-compose up` and verify `git var GIT_COMMITTER_IDENT` matches author
- [ ] Launch via `podman run --env-file .env` and verify committer vars are set
- [ ] Set explicit `GIT_COMMITTER_NAME` in `.env` and verify override wins