### PR TITLE
fix: ensure plugin hook scripts are executable and add f5xc-console plugin

### DIFF
--- a/claude-config/install-plugins.sh
+++ b/claude-config/install-plugins.sh
@@ -89,6 +89,10 @@ for KEY in $KEYS; do
     continue
   fi
 
+  # Fix script permissions — cp -a preserves source perms which
+  # may lack execute bits on .sh files from marketplace repos
+  find "$DEST" -name "*.sh" -type f -exec chmod +x {} +
+
   # Add entry to collection
   ENTRIES=$(echo "$ENTRIES" | jq \
     --arg key "$KEY" \
@@ -105,3 +109,8 @@ echo "$ENTRIES" | jq '{
   version: 2,
   plugins: (reduce .[] as $e ({}; .[$e.key] = [($e | del(.key))]))
 }' >"$INSTALLED_JSON"
+
+# Final sweep: ensure all .sh files across marketplaces and cache
+# are executable — catches any scripts missed by per-plugin fixups
+find "${PLUGIN_BASE}/marketplaces" "${PLUGIN_BASE}/cache" \
+  -name "*.sh" -type f -exec chmod +x {} + 2>/dev/null || true

--- a/claude-config/self-test.sh
+++ b/claude-config/self-test.sh
@@ -227,6 +227,10 @@ check "all ${ENABLED_COUNT} enabled plugins cached (${CACHED_COUNT} found)" \
   test "$CACHED_COUNT" -eq "$ENABLED_COUNT"
 check "frontend-slides skill installed" \
   test -f "$HOME/.claude/skills/frontend-slides/SKILL.md"
+NON_EXEC_SCRIPTS=$(find "$HOME/.claude/plugins" -name "*.sh" -type f \
+  ! -perm -u+x 2>/dev/null | wc -l)
+check "all plugin scripts executable (${NON_EXEC_SCRIPTS} non-executable)" \
+  test "$NON_EXEC_SCRIPTS" -eq 0
 
 echo ""
 echo "8. Chrome DevTools MCP"

--- a/claude-config/settings.json
+++ b/claude-config/settings.json
@@ -31,7 +31,8 @@
     "f5xc-github-ops@f5xc-salesdemos-marketplace": true,
     "f5xc-docs-pipeline@f5xc-salesdemos-marketplace": true,
     "f5xc-brand@f5xc-salesdemos-marketplace": true,
-    "f5xc-devcontainer@f5xc-salesdemos-marketplace": true
+    "f5xc-devcontainer@f5xc-salesdemos-marketplace": true,
+    "f5xc-console@f5xc-salesdemos-marketplace": true
   },
   "env": {
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",


### PR DESCRIPTION
## Summary

- Add `chmod +x` after every `cp -a` in `install-plugins.sh` plus a final sweep, preventing runtime "Permission denied" errors on plugin hook scripts
- Add self-test validation that detects non-executable `.sh` files in plugin directories at build verification time
- Add `f5xc-console` plugin to `enabledPlugins` in `settings.json` so it gets installed during Docker build

Closes #646

## Test plan

- [ ] CI checks pass
- [ ] Docker build succeeds with the updated install-plugins.sh
- [ ] `claude-self-test` detects non-executable .sh files when intentionally introduced
- [ ] f5xc-console plugin is installed during build

Generated with [Claude Code](https://claude.com/claude-code)