### PR TITLE
fix: add runtime chmod sweep for plugin scripts in entrypoint.sh

### DIFF
--- a/claude-config/self-test.sh
+++ b/claude-config/self-test.sh
@@ -231,6 +231,15 @@ NON_EXEC_SCRIPTS=$(find "$HOME/.claude/plugins" -name "*.sh" -type f \
   ! -perm -u+x 2>/dev/null | wc -l)
 check "all plugin scripts executable (${NON_EXEC_SCRIPTS} non-executable)" \
   test "$NON_EXEC_SCRIPTS" -eq 0
+# Track upstream workaround — warn when issue #648 is closed so the
+# entrypoint chmod sweep can be reviewed for removal
+ISSUE_STATE=$(gh issue view 648 --repo f5xc-salesdemos/devcontainer \
+  --json state --jq '.state' 2>/dev/null || echo "UNKNOWN")
+if [ "$ISSUE_STATE" = "CLOSED" ]; then
+  warn "workaround for #648 may be removable — issue is closed, review entrypoint.sh" false
+elif [ "$ISSUE_STATE" = "UNKNOWN" ]; then
+  echo "  SKIP: could not check issue #648 status (no GH_TOKEN or network)"
+fi
 
 echo ""
 echo "8. Chrome DevTools MCP"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -219,6 +219,14 @@ if [ "${ENABLE_VNC:-false}" = "true" ]; then
 fi
 
 # ============================================================
+# Fix plugin script permissions (workaround for #648)
+# FORCE_AUTOUPDATE_PLUGINS causes runtime marketplace syncs
+# that overwrite build-time chmod from install-plugins.sh.
+# Remove this block when upstream issue #648 is resolved.
+# ============================================================
+find "${HOME}/.claude/plugins" -name "*.sh" -type f -exec chmod +x {} + 2>/dev/null || true
+
+# ============================================================
 # Shared Chrome browser (remote debugging on port 9222)
 # ============================================================
 start_chrome_browser


### PR DESCRIPTION
## Summary

- Add a `find ... chmod +x` sweep in `entrypoint.sh` to re-apply execute permissions on plugin `.sh` files after runtime marketplace syncs overwrite build-time permissions
- Add a self-test guard in `claude-config/self-test.sh` that warns when tracking issue #648 is closed, signaling the workaround can be reviewed for removal

Closes #648

## Test plan

- [ ] CI checks pass (super-linter, linked-issue check)
- [ ] Container starts and `claude-self-test` reports 0 non-executable plugin scripts
- [ ] With `FORCE_AUTOUPDATE_PLUGINS=true`, runtime sync does not leave non-executable `.sh` files
- [ ] When issue #648 is closed, self-test emits a warning about the removable workaround