### PR TITLE
fix: add SessionStart hook to fix plugin script permissions after sync

### DIFF
--- a/claude-config/self-test.sh
+++ b/claude-config/self-test.sh
@@ -227,16 +227,22 @@ check "all ${ENABLED_COUNT} enabled plugins cached (${CACHED_COUNT} found)" \
   test "$CACHED_COUNT" -eq "$ENABLED_COUNT"
 check "frontend-slides skill installed" \
   test -f "$HOME/.claude/skills/frontend-slides/SKILL.md"
-NON_EXEC_SCRIPTS=$(find "$HOME/.claude/plugins" -name "*.sh" -type f \
+# Check permissions by marketplace to pinpoint source (issue #648)
+NON_EXEC_OFFICIAL=$(find "$HOME/.claude/plugins" \
+  -path "*/claude-plugins-official/*" -name "*.sh" -type f \
   ! -perm -u+x 2>/dev/null | wc -l)
-check "all plugin scripts executable (${NON_EXEC_SCRIPTS} non-executable)" \
-  test "$NON_EXEC_SCRIPTS" -eq 0
+NON_EXEC_F5XC=$(find "$HOME/.claude/plugins" \
+  -path "*/f5xc-salesdemos-marketplace/*" -name "*.sh" -type f \
+  ! -perm -u+x 2>/dev/null | wc -l)
+NON_EXEC_TOTAL=$((NON_EXEC_OFFICIAL + NON_EXEC_F5XC))
+check "all plugin scripts executable (${NON_EXEC_TOTAL} non-exec: ${NON_EXEC_OFFICIAL} official, ${NON_EXEC_F5XC} f5xc)" \
+  test "$NON_EXEC_TOTAL" -eq 0
 # Track upstream workaround — warn when issue #648 is closed so the
-# entrypoint chmod sweep can be reviewed for removal
+# SessionStart hook and entrypoint chmod sweep can be reviewed for removal
 ISSUE_STATE=$(gh issue view 648 --repo f5xc-salesdemos/devcontainer \
   --json state --jq '.state' 2>/dev/null || echo "UNKNOWN")
 if [ "$ISSUE_STATE" = "CLOSED" ]; then
-  warn "workaround for #648 may be removable — issue is closed, review entrypoint.sh" false
+  warn "workaround for #648 may be removable — issue is closed, review settings.json hook and entrypoint.sh" false
 elif [ "$ISSUE_STATE" = "UNKNOWN" ]; then
   echo "  SKIP: could not check issue #648 status (no GH_TOKEN or network)"
 fi

--- a/claude-config/settings.json
+++ b/claude-config/settings.json
@@ -45,5 +45,19 @@
   "preferences": {
     "tmuxSplitPanes": true
   },
-  "autoUpdatesChannel": "latest"
+  "autoUpdatesChannel": "latest",
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "find ~/.claude/plugins -name '*.sh' -type f ! -perm -u+x -exec chmod +x {} +",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -219,12 +219,29 @@ if [ "${ENABLE_VNC:-false}" = "true" ]; then
 fi
 
 # ============================================================
-# Fix plugin script permissions (workaround for #648)
-# FORCE_AUTOUPDATE_PLUGINS causes runtime marketplace syncs
-# that overwrite build-time chmod from install-plugins.sh.
-# Remove this block when upstream issue #648 is resolved.
+# Fix plugin script permissions (issue #648)
+# Two-layer fix:
+#   1. Immediate chmod sweep for non-session contexts (self-test)
+#   2. SessionStart hook injected into settings.json so Claude
+#      Code re-applies chmod AFTER its plugin sync overwrites
+#      build-time permissions.
+# Remove both when upstream issue #648 is resolved.
 # ============================================================
 find "${HOME}/.claude/plugins" -name "*.sh" -type f -exec chmod +x {} + 2>/dev/null || true
+
+# Inject SessionStart hook into runtime settings.json if missing
+SETTINGS="${HOME}/.claude/settings.json"
+if [ -f "$SETTINGS" ] && command -v python3 >/dev/null 2>&1; then
+  python3 -c "
+import json, sys
+p = '${SETTINGS}'
+with open(p) as f: s = json.load(f)
+hook = [{'matcher':'','hooks':[{'type':'command','command':\"find ~/.claude/plugins -name '*.sh' -type f ! -perm -u+x -exec chmod +x {} +\",'timeout':10}]}]
+if s.get('hooks',{}).get('SessionStart') == hook: sys.exit(0)
+s.setdefault('hooks',{})['SessionStart'] = hook
+with open(p,'w') as f: json.dump(s, f, indent=2)
+" 2>/dev/null || true
+fi
 
 # ============================================================
 # Shared Chrome browser (remote debugging on port 9222)


### PR DESCRIPTION
## Summary

- Adds a `SessionStart` hook in `settings.json` that runs `chmod +x` on plugin scripts AFTER Claude Code's plugin sync completes, fixing the race condition where PR #649's entrypoint.sh chmod sweep was overwritten by later marketplace re-syncs
- Adds an `entrypoint.sh` Python snippet that injects the hook into the runtime `~/.claude/settings.json` at container startup, ensuring persistence even if Claude Code rewrites settings
- Enhances `self-test.sh` diagnostics to break down non-executable script counts by marketplace (official vs f5xc)

Closes #648

## Test plan

- [ ] CI checks pass
- [ ] Container builds successfully with updated entrypoint
- [ ] After Claude Code session start, all plugin scripts in `~/.claude/marketplace/` are executable
- [ ] `self-test.sh` reports 0 non-executable files and shows per-marketplace breakdown
- [ ] No "Permission denied" errors on stop hooks during session lifecycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)