### PR TITLE
fix: add PostToolUse hook to close mid-session plugin permission gap

### DIFF
--- a/claude-config/self-test.sh
+++ b/claude-config/self-test.sh
@@ -237,12 +237,16 @@ NON_EXEC_F5XC=$(find "$HOME/.claude/plugins" \
 NON_EXEC_TOTAL=$((NON_EXEC_OFFICIAL + NON_EXEC_F5XC))
 check "all plugin scripts executable (${NON_EXEC_TOTAL} non-exec: ${NON_EXEC_OFFICIAL} official, ${NON_EXEC_F5XC} f5xc)" \
   test "$NON_EXEC_TOTAL" -eq 0
+check "SessionStart chmod hook present" \
+  jq -e '.hooks.SessionStart[0].hooks[0].command | test("chmod.*\\+x")' "$HOME/.claude/settings.json"
+check "PostToolUse Skill chmod hook present" \
+  jq -e '.hooks.PostToolUse[0].matcher == "Skill" and (.hooks.PostToolUse[0].hooks[0].command | test("chmod.*\\+x"))' "$HOME/.claude/settings.json"
 # Track upstream workaround — warn when issue #648 is closed so the
-# SessionStart hook and entrypoint chmod sweep can be reviewed for removal
+# SessionStart hook, PostToolUse hook, and entrypoint chmod sweep can be reviewed for removal
 ISSUE_STATE=$(gh issue view 648 --repo f5xc-salesdemos/devcontainer \
   --json state --jq '.state' 2>/dev/null || echo "UNKNOWN")
 if [ "$ISSUE_STATE" = "CLOSED" ]; then
-  warn "workaround for #648 may be removable — issue is closed, review settings.json hook and entrypoint.sh" false
+  warn "workaround for #648 may be removable — issue is closed, review settings.json hooks and entrypoint.sh" false
 elif [ "$ISSUE_STATE" = "UNKNOWN" ]; then
   echo "  SKIP: could not check issue #648 status (no GH_TOKEN or network)"
 fi

--- a/claude-config/settings.json
+++ b/claude-config/settings.json
@@ -58,6 +58,18 @@
           }
         ]
       }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Skill",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "find ~/.claude/plugins -name '*.sh' -type f ! -perm -u+x -exec chmod +x {} +",
+            "timeout": 10
+          }
+        ]
+      }
     ]
   }
 }

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -220,25 +220,32 @@ fi
 
 # ============================================================
 # Fix plugin script permissions (issue #648)
-# Two-layer fix:
+# Three-layer fix:
 #   1. Immediate chmod sweep for non-session contexts (self-test)
 #   2. SessionStart hook injected into settings.json so Claude
 #      Code re-applies chmod AFTER its plugin sync overwrites
 #      build-time permissions.
-# Remove both when upstream issue #648 is resolved.
+#   3. PostToolUse hook (matcher: Skill) catches mid-session
+#      plugin reloads via /reload-plugins that arrive after
+#      SessionStart has already fired.
+# Remove all three when upstream issue #648 is resolved.
 # ============================================================
 find "${HOME}/.claude/plugins" -name "*.sh" -type f -exec chmod +x {} + 2>/dev/null || true
 
-# Inject SessionStart hook into runtime settings.json if missing
+# Inject SessionStart + PostToolUse hooks into runtime settings.json if missing
 SETTINGS="${HOME}/.claude/settings.json"
 if [ -f "$SETTINGS" ] && command -v python3 >/dev/null 2>&1; then
   python3 -c "
 import json, sys
 p = '${SETTINGS}'
 with open(p) as f: s = json.load(f)
-hook = [{'matcher':'','hooks':[{'type':'command','command':\"find ~/.claude/plugins -name '*.sh' -type f ! -perm -u+x -exec chmod +x {} +\",'timeout':10}]}]
-if s.get('hooks',{}).get('SessionStart') == hook: sys.exit(0)
-s.setdefault('hooks',{})['SessionStart'] = hook
+cmd = \"find ~/.claude/plugins -name '*.sh' -type f ! -perm -u+x -exec chmod +x {} +\"
+session_hook = [{'matcher':'','hooks':[{'type':'command','command':cmd,'timeout':10}]}]
+skill_hook = [{'matcher':'Skill','hooks':[{'type':'command','command':cmd,'timeout':10}]}]
+h = s.get('hooks',{})
+if h.get('SessionStart') == session_hook and h.get('PostToolUse') == skill_hook: sys.exit(0)
+s.setdefault('hooks',{})['SessionStart'] = session_hook
+s['hooks']['PostToolUse'] = skill_hook
 with open(p,'w') as f: json.dump(s, f, indent=2)
 " 2>/dev/null || true
 fi


### PR DESCRIPTION
## Summary

- Add PostToolUse hook scoped to the Skill tool that runs chmod on plugin .sh files after any skill invocation, closing the mid-session permission gap when `/reload-plugins` installs new scripts
- Update entrypoint.sh Python injection to handle both SessionStart and PostToolUse hooks idempotently
- Add self-test checks validating both hooks are present in settings.json

Closes #653

## Test plan

- [ ] CI checks pass (lint, shellcheck, biome)
- [ ] Container builds successfully with updated entrypoint
- [ ] Self-test validates both SessionStart and PostToolUse hooks are present
- [ ] Mid-session `/reload-plugins` results in executable .sh files

## Checklist

- [x] I have linked this PR to an issue
- [x] I have followed the conventional commit format
- [x] I have run pre-commit checks locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)