### PR TITLE
fix: replace bun install with npm install for claude-mem dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1083,7 +1083,7 @@ RUN PLUGIN_BASE="/home/${USERNAME}/.claude/plugins" \
 RUN CMEM_PKG=$(find /home/${USERNAME}/.claude/plugins/cache/thedotmack/claude-mem \
       -name "package.json" -not -path "*/node_modules/*" -maxdepth 3 -print -quit 2>/dev/null) \
     && if [ -n "$CMEM_PKG" ]; then \
-        cd "$(dirname "$CMEM_PKG")" && bun install; \
+        cd "$(dirname "$CMEM_PKG")" && npm install; \
     fi
 
 # 12m. Claude Code skills (git-cloned external skills)


### PR DESCRIPTION
## Summary

- Replace `bun install` with `npm install` at line 1086 in Dockerfile
- bun is installed later (line 1114) under `USER vscode`, so unavailable in root context
- npm is already on PATH (used at line 1033 for Caldera frontend build)

Closes #667

## Test plan

- [ ] CI checks pass (Lint Code Base)
- [ ] Docker Publish workflow succeeds on both amd64 and arm64
- [ ] claude-mem tree-sitter dependencies are installed correctly

---
Generated with Claude Code