### PR TITLE
fix: conditional GPU support and segfault suppression for Chrome startup

### DIFF
--- a/claude-config/chrome-browser.sh
+++ b/claude-config/chrome-browser.sh
@@ -14,7 +14,17 @@
 # on port 9222. All Claude Code sessions connect to this shared
 # instance via --browserUrl, eliminating profile lock conflicts
 # and sharing cookies/auth across projects.
+#
+# GPU support is conditional — when /dev/dri or /dev/nvidia*
+# devices are present (Linux with GPU passthrough), Chrome uses
+# hardware acceleration. Otherwise (Podman/Docker VM on macOS),
+# GPU and Vulkan probing are disabled to avoid segfaults.
 # ============================================================
+
+# Detect GPU hardware availability
+_chrome_has_gpu() {
+  [ -d /dev/dri ] || compgen -G '/dev/nvidia*' >/dev/null 2>&1
+}
 
 start_chrome_browser() {
   local chrome_bin="/opt/google/chrome/chrome"
@@ -22,6 +32,7 @@ start_chrome_browser() {
   local debug_url="http://localhost:${debug_port}"
   local log_dir="${HOME}/.local/share/chrome-browser"
   local log_file="${log_dir}/chrome.log"
+  local profile_dir="${HOME}/.cache/chrome-devtools-mcp/chrome-profile"
 
   # Chrome binary must exist
   if [ -e "$chrome_bin" ] || [ -L "$chrome_bin" ]; then
@@ -35,22 +46,37 @@ start_chrome_browser() {
     return 0
   fi
 
-  mkdir -p "$log_dir"
+  mkdir -p "$log_dir" "$profile_dir"
 
   # Build Chrome flags
+  local disabled_features="HttpsFirstBalancedModeAutoEnable,HttpsUpgrades,HttpsFirstModeV2"
   local chrome_flags=(
     --no-sandbox
-    --disable-gpu
     --remote-debugging-port="${debug_port}"
     --remote-debugging-address=127.0.0.1
-    --user-data-dir="${HOME}/.cache/chrome-devtools-mcp/chrome-profile"
+    --user-data-dir="${profile_dir}"
     --no-first-run
     --no-default-browser-check
     --disable-extensions
     --disable-background-timer-throttling
     --disable-backgrounding-occluded-windows
-    "--disable-features=HttpsFirstBalancedModeAutoEnable,HttpsUpgrades,HttpsFirstModeV2"
+    --disable-dev-shm-usage
   )
+
+  # Conditional GPU support
+  if _chrome_has_gpu; then
+    : # GPU available — let Chrome use hardware acceleration
+  else
+    # No GPU — disable all graphics probing to prevent segfaults
+    chrome_flags+=(
+      --disable-gpu
+      --disable-vulkan
+      --use-angle=swiftshader-webgl
+    )
+    disabled_features="${disabled_features},OnDeviceModel,Vulkan"
+  fi
+
+  chrome_flags+=("--disable-features=${disabled_features}")
 
   # If DISPLAY is set and working, run headed (VNC visibility)
   # Otherwise run headless
@@ -70,12 +96,13 @@ start_chrome_browser() {
   $quiet || echo "Starting shared Chrome browser on port ${debug_port}..."
 
   # Launch in background with restart loop
+  # Redirect subshell stderr to log file to suppress kernel segfault messages
   (
     while true; do
       "$chrome_bin" "${chrome_flags[@]}" >>"$log_file" 2>&1
       sleep 1
     done
-  ) &
+  ) >>"$log_file" 2>&1 &
 
   # Poll readiness up to ~10s
   local retries=0


### PR DESCRIPTION
## Summary

- Detect GPU hardware at runtime (`/dev/dri`, `/dev/nvidia*`) and conditionally disable GPU/Vulkan probing
- Suppress kernel segfault messages from leaking to the user's terminal
- Add `--disable-dev-shm-usage` and pre-warm Chrome profile directory

Closes #669

## Problem

Chrome segfaults on first startup because it probes for Vulkan/EGL drivers that don't exist in GPU-less containers (ARM64 macOS running Podman/Docker). The `--disable-gpu` flag alone doesn't prevent Vulkan probing. Additionally, the segfault message leaks to the terminal because the restart loop's subshell stderr isn't redirected.

## Approach

**Runtime GPU detection** rather than unconditionally disabling GPU:

```bash
_chrome_has_gpu() {
  [ -d /dev/dri ] || compgen -G '/dev/nvidia*' >/dev/null 2>&1
}
```

| Environment | GPU detected? | Chrome behavior |
|-------------|--------------|-----------------|
| ARM64 macOS (Podman/Docker VM) | No | GPU, Vulkan, OnDeviceModel disabled; SwiftShader fallback |
| Linux with GPU passthrough | Yes (`/dev/dri`) | Hardware acceleration enabled |
| Linux with NVIDIA GPU | Yes (`/dev/nvidia*`) | Hardware acceleration enabled |

### Flags added in no-GPU path
- `--disable-gpu` — disable GPU compositing
- `--disable-vulkan` — skip Vulkan driver probing (prevents segfault)
- `--use-angle=swiftshader-webgl` — force SwiftShader renderer
- `--disable-features=OnDeviceModel,Vulkan` — disable unavailable services

### Other fixes
- Subshell stderr redirected to log file: `(...) >>"$log_file" 2>&1 &`
- `--disable-dev-shm-usage` added unconditionally (containers often have small `/dev/shm`)
- Profile directory pre-created with `mkdir -p` before first launch

## Test plan

- [ ] CI checks pass (shellcheck, lint)
- [ ] In GPU-less container: Chrome starts without segfault, no error in terminal
- [ ] `curl -s http://localhost:9222/json/version` responds after startup
- [ ] On GPU-enabled Linux: `/dev/dri` exists, GPU flags are NOT added
- [ ] `claude-self-test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)