### PR TITLE
fix: address container log errors and warnings

### DIFF
--- a/claude-config/chrome-browser.sh
+++ b/claude-config/chrome-browser.sh
@@ -61,6 +61,7 @@ start_chrome_browser() {
     --disable-background-timer-throttling
     --disable-backgrounding-occluded-windows
     --disable-dev-shm-usage
+    --disable-background-networking
   )
 
   # Conditional GPU support

--- a/claude-config/claude.json
+++ b/claude-config/claude.json
@@ -14,7 +14,10 @@
   "mcpServers": {
     "chrome-devtools": {
       "command": "npx",
-      "args": ["-y", "chrome-devtools-mcp@0.20.2", "--browserUrl=http://localhost:9222"]
+      "args": ["-y", "chrome-devtools-mcp@0.20.2", "--browserUrl=http://localhost:9222"],
+      "env": {
+        "NODE_OPTIONS": "--no-warnings"
+      }
     }
   },
   "projects": {

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -41,6 +41,9 @@ if [ -n "$GH_TOKEN" ]; then
   gh auth setup-git 2>/dev/null || true
 fi
 
+# Ensure Homebrew npm global directory exists (issue #677)
+mkdir -p "${HOME}/.npm-global/lib" 2>/dev/null || true
+
 # ============================================================
 # gogcli (gog) — restore OAuth credentials and refresh token
 # ============================================================
@@ -220,6 +223,15 @@ if [ "${ENABLE_VNC:-false}" = "true" ]; then
     fi
 
   ) &
+fi
+
+# ============================================================
+# Clean up stale processes on claude-mem worker port (issue #676)
+# Prevents port 37777 conflict when SessionStart hook triggers
+# the claude-mem worker before a previous instance has released.
+# ============================================================
+if command -v fuser >/dev/null 2>&1; then
+  fuser -k 37777/tcp >/dev/null 2>&1 || true
 fi
 
 # ============================================================


### PR DESCRIPTION
## Summary

- Suppress Chrome GCM deprecated endpoint log noise with `--disable-background-networking` (#678)
- Create `~/.npm-global/lib` directory in entrypoint to fix Homebrew npm global list (#677)
- Kill stale processes on port 37777 before claude-mem worker starts (#676)
- Suppress `--localstorage-file` Node.js warning in chrome-devtools-mcp via `NODE_OPTIONS=--no-warnings` (#675)

Closes #675
Closes #676
Closes #677
Closes #678

## Changes

### `claude-config/chrome-browser.sh`
- Added `--disable-background-networking` flag to prevent Chrome from making background network requests (GCM registration to deprecated endpoints)

### `entrypoint.sh`
- Added `mkdir -p ~/.npm-global/lib` early in startup to ensure Homebrew's npm can list global packages
- Added `fuser -k 37777/tcp` cleanup before plugin/session hooks to prevent claude-mem port conflict

### `claude-config/claude.json`
- Added `"env": {"NODE_OPTIONS": "--no-warnings"}` to chrome-devtools MCP server config to suppress Node.js `--localstorage-file` deprecation warning

## Test plan

- [ ] CI checks pass
- [ ] Chrome log shows no GCM DEPRECATED_ENDPOINT errors after startup
- [ ] `npm list --global` via Homebrew npm succeeds without ENOENT
- [ ] claude-mem worker starts without port conflict error
- [ ] Chrome DevTools MCP log shows no `--localstorage-file` warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)