### PR TITLE
feat: sync thedotmack/claude-mem marketplace and plugin updates into INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1325,14 +1325,24 @@ PLUGIN_BASE="$HOME/.claude/plugins"
 TIMESTAMP="$(date -u +%Y-%m-%dT%H:%M:%S.000Z)"
 
 # Marketplace registry (all three marketplaces)
-printf '{"claude-plugins-official":{"source":{"source":"github","repo":"anthropics/claude-plugins-official"},"installLocation":"%s","lastUpdated":"%s","autoUpdate":true},"f5xc-salesdemos-marketplace":{"source":{"source":"github","repo":"f5xc-salesdemos/marketplace"},"installLocation":"%s","lastUpdated":"%s","autoUpdate":true},"thedotmack":{"source":{"source":"github","repo":"thedotmack/claude-mem"},"installLocation":"%s","lastUpdated":"%s","autoUpdate":false}}' \
-  "${PLUGIN_BASE}/marketplaces/claude-plugins-official" \
-  "$TIMESTAMP" \
-  "${PLUGIN_BASE}/marketplaces/f5xc-salesdemos-marketplace" \
-  "$TIMESTAMP" \
-  "${PLUGIN_BASE}/marketplaces/thedotmack" \
-  "$TIMESTAMP" \
-  > "${PLUGIN_BASE}/known_marketplaces.json"
+jq -n \
+  --arg cl "${PLUGIN_BASE}/marketplaces/claude-plugins-official" \
+  --arg f5 "${PLUGIN_BASE}/marketplaces/f5xc-salesdemos-marketplace" \
+  --arg td "${PLUGIN_BASE}/marketplaces/thedotmack" \
+  --arg ts "$TIMESTAMP" '{
+  "claude-plugins-official": {
+    "source": {"source":"github","repo":"anthropics/claude-plugins-official"},
+    "installLocation": $cl, "lastUpdated": $ts, "autoUpdate": true
+  },
+  "f5xc-salesdemos-marketplace": {
+    "source": {"source":"github","repo":"f5xc-salesdemos/marketplace"},
+    "installLocation": $f5, "lastUpdated": $ts, "autoUpdate": true
+  },
+  "thedotmack": {
+    "source": {"source":"github","repo":"thedotmack/claude-mem"},
+    "installLocation": $td, "lastUpdated": $ts, "autoUpdate": false
+  }
+}' > "${PLUGIN_BASE}/known_marketplaces.json"
 
 # Empty blocklist
 printf '{"fetchedAt":"%s","plugins":[]}' "$TIMESTAMP" > "${PLUGIN_BASE}/blocklist.json"


### PR DESCRIPTION
## Summary

- Adds `thedotmack/claude-mem` as a third plugin marketplace (no auto-update)
- Adds `claude-mem@thedotmack`, `f5xc-devcontainer`, and `f5xc-platform` to the plugin install loop and `enabledPlugins`
- Fixes the plugin loop script to handle `claude-mem`'s non-standard repo structure (plugin lives in `plugin/` subdir, not `plugins/<name>/`)
- Adds `npm install` step for claude-mem's tree-sitter runtime dependencies
- Updates `known_marketplaces.json` generation to include all 3 marketplaces
- Adds `printf '21' > ~/.cache/opencode/version` cache version marker so OpenCode's BunProc doesn't re-download packages on every launch
- Renames `f5xc-console` → `f5xc-platform` throughout

## Test plan

- [x] `git clone thedotmack/claude-mem` succeeds
- [x] `claude-mem` installed to cache at version `10.6.2`
- [x] `npm install` for claude-mem deps succeeds
- [x] `known_marketplaces.json` contains all 3 marketplace keys
- [x] `~/.cache/opencode/version` contains `21`
- [ ] CI super-linter passes

Closes #685

🤖 Generated with [Claude Code](https://claude.com/claude-code)