### PR TITLE
feat: add f5xc-meddpicc plugin to INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1235,6 +1235,7 @@ for KEY in \
   f5xc-brand@f5xc-salesdemos-marketplace \
   f5xc-devcontainer@f5xc-salesdemos-marketplace \
   f5xc-platform@f5xc-salesdemos-marketplace \
+  f5xc-meddpicc@f5xc-salesdemos-marketplace \
   claude-mem@thedotmack \
 ; do
   NAME="$(echo "$KEY" | cut -d@ -f1)"
@@ -1424,6 +1425,7 @@ CONTAINER_SETTINGS="$(cat <<SETTINGS
     "f5xc-brand@f5xc-salesdemos-marketplace": true,
     "f5xc-devcontainer@f5xc-salesdemos-marketplace": true,
     "f5xc-platform@f5xc-salesdemos-marketplace": true,
+    "f5xc-meddpicc@f5xc-salesdemos-marketplace": true,
     "claude-mem@thedotmack": true
   },
   "env": {


### PR DESCRIPTION
## Summary

- Adds `f5xc-meddpicc@f5xc-salesdemos-marketplace` to Step 6.2 plugin install loop
- Adds `f5xc-meddpicc@f5xc-salesdemos-marketplace: true` to Step 6.5 `enabledPlugins`

Plugin discovered during local end-to-end test run of INSTALL.md — it was already in the marketplace but not yet referenced in the installer.

## Test plan

- [x] `f5xc-meddpicc` exists in marketplace at `plugins/f5xc-meddpicc/`
- [x] Installs locally at v1.0.2 with valid `plugin.json`
- [ ] CI super-linter passes

Closes #693

🤖 Generated with [Claude Code](https://claude.com/claude-code)