### PR TITLE
fix: update Step 16 verification expected values

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -2840,26 +2840,22 @@ All four runtime packages should be pre-installed. If any are missing, re-run `(
 ### 16.9 — Environment Variables
 
 ```bash
-which bun                    # VERIFY: output is /opt/homebrew/bin/bun
+which bun                    # VERIFY: /opt/homebrew/bin/bun or ~/.bun/bin/bun
 echo $LITELLM_API_KEY        # VERIFY: output is your API key (not empty, not a placeholder)
 ```
 
 ### 16.10 — Claude Code Plugins and Settings
 
 ```bash
-# Verify plugin count
-jq 'length' ~/.claude/plugins/installed_plugins.json
-# Expected: 19
-
-# Verify SKILL.md files (plugins)
-find ~/.claude/plugins/cache -name "SKILL.md" -type f | wc -l
-# Expected: 19
+# Verify plugin count (v2 format: query .plugins not top-level length)
+jq '.plugins | length' ~/.claude/plugins/installed_plugins.json
+# Expected: 23
 
 # Verify external skills
 test -f ~/.claude/skills/frontend-slides/SKILL.md && echo "OK" || echo "MISSING"  # Expected: OK
 
 # Verify settings.json has full container settings
-jq '.enabledPlugins | keys | length' ~/.claude/settings.json    # Expected: 19
+jq '.enabledPlugins | keys | length' ~/.claude/settings.json    # Expected: 23
 jq '.model' ~/.claude/settings.json                              # Expected: "opus"
 jq '.statusLine.type' ~/.claude/settings.json                    # Expected: "command"
 jq '.env.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS' ~/.claude/settings.json  # Expected: "1"


### PR DESCRIPTION
## Summary

- Fix `jq` query: `'length'` → `'.plugins | length'` — v2 `installed_plugins.json` structure has two top-level keys (`version` + `plugins`), so `length` was returning `2` instead of the actual plugin count
- Update expected plugin count: 19 → 23 (added `claude-mem@thedotmack`, `f5xc-devcontainer`, `f5xc-platform`, `f5xc-meddpicc`)
- Update expected `enabledPlugins` count: 19 → 23
- Remove stale SKILL.md count check — superpowers sub-skills inflate the count to 95+; `installed_plugins.json` is the authoritative source
- Update bun path comment to accept `~/.bun/bin/bun` (standalone install) alongside `/opt/homebrew/bin/bun`

All checks verified locally before pushing.

## Test plan

- [x] `jq '.plugins | length' ~/.claude/plugins/installed_plugins.json` → `23`
- [x] `jq '.enabledPlugins | keys | length' ~/.claude/settings.json` → `23`
- [x] `which bun` → `/Users/robin/.bun/bin/bun` (accepted)

Closes #697

🤖 Generated with [Claude Code](https://claude.com/claude-code)