### PR TITLE
fix: remove non-OpenCode AI tools from INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -13,7 +13,7 @@
 > permission errors because the default policy prompts for confirmation — which is impossible in
 > non-interactive mode.
 >
-> **Execution notes**: This document is long (~1200 lines). Execute steps sequentially — do not
+> **Execution notes**: This document is long (~3000 lines). Execute steps sequentially — do not
 > skip ahead. Each step includes inline VERIFY comments that must pass before proceeding.
 > Steps marked **MANUAL STEP** require human interaction and should be skipped during automated runs.
 
@@ -404,72 +404,6 @@ OpenCode Desktop is the GUI companion for OpenCode. Install via Homebrew Cask:
 
 ```bash
 brew install --cask opencode-desktop
-```
-
----
-
-## Step 4c — Install Google Antigravity
-
-Google Antigravity is a UI-based AI Coding Agent IDE. It runs only on macOS (not in the Linux container). Install via Homebrew Cask:
-
-```bash
-brew install --cask antigravity
-```
-
-VERIFY:
-
-```bash
-agy --version              # VERIFY: output contains a version number
-```
-
----
-
-## Step 4e — Install Visual Studio Code
-
-Visual Studio Code is a general-purpose code editor with extensive extension support. Install via Homebrew Cask:
-
-**Idempotency**: Guard with an existence check — `brew install --cask` can fail if the app already exists:
-
-```bash
-[ -d "/Applications/Visual Studio Code.app" ] || brew install --cask visual-studio-code
-```
-
-VERIFY:
-
-```bash
-code --version                 # VERIFY: output contains a version number
-```
-
----
-
-## Step 4f — Install Cursor
-
-Cursor is an AI-native code editor built on the Visual Studio Code platform. Install via Homebrew Cask:
-
-```bash
-[ -d "/Applications/Cursor.app" ] || brew install --cask cursor
-```
-
-VERIFY:
-
-```bash
-cursor --version               # VERIFY: output contains a version number
-```
-
----
-
-## Step 4h — Install Zed
-
-Zed is a GPU-accelerated code editor with built-in AI assistant support. Install via Homebrew Cask:
-
-```bash
-[ -d "/Applications/Zed.app" ] || brew install --cask zed
-```
-
-VERIFY:
-
-```bash
-zed --version                  # VERIFY: output contains a version number
 ```
 
 ---
@@ -971,7 +905,7 @@ sed -i '' 's/^ZSH_THEME=.*/ZSH_THEME="powerlevel10k\/powerlevel10k"/' ~/.zshrc
 <!-- markdownlint-disable MD013 -->
 
 ```bash
-sed -i '' 's/^plugins=(.*/plugins=(zsh-syntax-highlighting zsh-autosuggestions zsh-interactive-cd jsontools gh gh-clone-complete common-aliases zsh-aliases-lsd zsh-eza zsh-tfenv conda-zsh-completion z pip terraform fluxcd azure git-auto-fetch helm istioctl kube-ps1 kubectl sudo vscode aws fzf docker history colored-man-pages command-not-found tmux dotenv emoji gcloud git pre-commit iterm2 macos podman)/' ~/.zshrc
+sed -i '' 's/^plugins=(.*/plugins=(zsh-syntax-highlighting zsh-autosuggestions zsh-interactive-cd jsontools gh gh-clone-complete common-aliases zsh-aliases-lsd zsh-eza zsh-tfenv conda-zsh-completion z pip terraform fluxcd azure git-auto-fetch helm istioctl kube-ps1 kubectl sudo aws fzf docker history colored-man-pages command-not-found tmux dotenv emoji gcloud git pre-commit iterm2 macos podman)/' ~/.zshrc
 ```
 
 <!-- markdownlint-enable MD013 -->
@@ -1019,7 +953,6 @@ grep 'ZSH_DOTENV_PROMPT' ~/.zshrc  # VERIFY: output is export ZSH_DOTENV_PROMPT=
 | `kube-ps1` | OMZ built-in | Kubernetes context/namespace in prompt |
 | `kubectl` | OMZ built-in | kubectl completions and aliases |
 | `sudo` | OMZ built-in | Press Escape twice to prepend `sudo` to current command |
-| `vscode` | OMZ built-in | Visual Studio Code aliases (`code .`, etc.) |
 | `aws` | OMZ built-in | AWS CLI completions |
 | `fzf` | OMZ built-in | Fuzzy finder integration (Ctrl+R history, Ctrl+T files) |
 | `docker` | OMZ built-in | Docker completions |
@@ -1116,33 +1049,6 @@ ls ~/Library/Fonts/MesloLGSNerdFont-Regular.ttf 2>/dev/null \
   ~/Library/Preferences/com.googlecode.iterm2.plist                    # Expected: 2
 defaults read com.googlecode.iterm2 TabStyleWithAutomaticOption        # Expected: 1 (Dark)
 ```
-
----
-
-### 5.9 — Install Codex CLI
-
-Codex is OpenAI's coding agent CLI. Install via Homebrew Cask (checksummed, IT-controlled installer — preferred over npm or GitHub binary downloads).
-
-```bash
-brew install --cask codex
-```
-
-Write the Codex config (selects the model):
-
-```bash
-mkdir -p ~/.codex
-cat > ~/.codex/config.toml <<'EOF'
-model = "gpt-5.2-codex"
-EOF
-```
-
-VERIFY:
-
-```bash
-codex --version            # VERIFY: output contains a version number
-```
-
-First-time users should run `codex` interactively to complete the OAuth login with an OpenAI account.
 
 ---
 
@@ -2650,10 +2556,6 @@ grep -q '\.local/bin' ~/.zshrc || \
 grep -q 'iTerm.app' ~/.zshrc || \
   echo 'export PATH="/Applications/iTerm.app/Contents/Resources/utilities:$PATH"' >> ~/.zshrc
 
-# Oh My Zsh vscode plugin: use Cursor as default editor
-grep -q 'VSCODE=cursor' ~/.zshrc || \
-  echo 'export VSCODE=cursor' >> ~/.zshrc
-
 # dotenv plugin: auto-source .env files without prompting
 # Must appear BEFORE `source $ZSH/oh-my-zsh.sh` so the dotenv plugin sees it at load time
 grep -q 'ZSH_DOTENV_PROMPT' ~/.zshrc || \
@@ -2794,18 +2696,7 @@ VERIFY: all five packages appear in the output (exact versions may vary).
 
 VERIFY: output contains `Google Chrome` followed by a version number.
 
-### 16.5 — IDEs and Terminal
-
-```bash
-ls "/Applications/Visual Studio Code.app"   # VERIFY: directory exists
-code --version                               # VERIFY: output contains a version number
-ls "/Applications/Cursor.app"                # VERIFY: directory exists
-cursor --version                             # VERIFY: output contains a version number
-ls "/Applications/Zed.app"                   # VERIFY: directory exists
-zed --version                                # VERIFY: output contains a version number
-```
-
-### 16.6 — chrome-devtools-mcp
+### 16.5 — chrome-devtools-mcp
 
 ```bash
 npx -y chrome-devtools-mcp@latest --help

--- a/docs/superpowers/plans/2026-03-28-remove-non-opencode-ai-tools.md
+++ b/docs/superpowers/plans/2026-03-28-remove-non-opencode-ai-tools.md
@@ -1,0 +1,120 @@
+# Remove Non-OpenCode AI Tools from INSTALL.md Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove Google Antigravity, VS Code, Cursor, Zed, and Codex from INSTALL.md, leaving OpenCode as the sole AI assistant frontend.
+
+**Architecture:** Nine discrete string-replacement edits to INSTALL.md executed bottom-up (highest line number first) so earlier edits don't shift line numbers for later ones. One GitHub issue and one PR wrap the change.
+
+**Tech Stack:** bash, gh CLI, Edit tool on INSTALL.md
+
+---
+
+### Task 1: Governance — GitHub Issue + Branch
+
+- [ ] Create GitHub issue and capture issue number
+- [ ] Checkout branch `fix/<N>-remove-non-opencode-ai-tools`
+
+---
+
+### Task 2: Edit 9 — Remove Step 16.5 (VS Code / Cursor / Zed verify)
+
+**Files:** Modify `INSTALL.md` (~lines 2797–2807)
+
+Remove the entire `### 16.5 — IDEs and Terminal` section.
+
+---
+
+### Task 3: Edit 8 — Remove `export VSCODE=cursor` block (Step 14.4)
+
+**Files:** Modify `INSTALL.md` (~lines 2652–2655)
+
+Remove the 3-line block setting `VSCODE=cursor` and its preceding comment.
+
+---
+
+### Task 4: Edit 7 — Remove `vscode` row from Oh My Zsh plugins table (Step 5.5)
+
+**Files:** Modify `INSTALL.md` (~line 1022)
+
+Remove the `| \`vscode\` | OMZ built-in | Visual Studio Code aliases |` table row.
+
+---
+
+### Task 5: Edit 6 — Remove `vscode` from Oh My Zsh plugins sed command (Step 5.5)
+
+**Files:** Modify `INSTALL.md` (~line 974)
+
+Remove ` vscode` from the plugins=(...) substitution string.
+
+---
+
+### Task 6: Edit 5 — Remove Step 5.9 (Codex CLI)
+
+**Files:** Modify `INSTALL.md` (~lines 1122–1147)
+
+Remove the entire `### 5.9 — Install Codex CLI` section (~26 lines).
+
+---
+
+### Task 7: Edit 4 — Remove Step 4h (Zed)
+
+**Files:** Modify `INSTALL.md` (~lines 461–475)
+
+Remove the entire `## Step 4h — Install Zed` section.
+
+---
+
+### Task 8: Edit 3 — Remove Step 4f (Cursor)
+
+**Files:** Modify `INSTALL.md` (~lines 445–459)
+
+Remove the entire `## Step 4f — Install Cursor` section.
+
+---
+
+### Task 9: Edit 2 — Remove Step 4e (Visual Studio Code)
+
+**Files:** Modify `INSTALL.md` (~lines 427–442)
+
+Remove the entire `## Step 4e — Install Visual Studio Code` section.
+
+---
+
+### Task 10: Edit 1 — Remove Step 4c (Google Antigravity)
+
+**Files:** Modify `INSTALL.md` (~lines 411–425)
+
+Remove the entire `## Step 4c — Install Google Antigravity` section.
+
+---
+
+### Task 11: Edit 10 — Update preamble line count
+
+**Files:** Modify `INSTALL.md` (line ~16)
+
+Update `~1200 lines` → `~3200 lines`.
+
+---
+
+### Task 12: Verify
+
+```bash
+grep -n 'cursor\|codex\|antigravity\|agy\|zed\b\|vscode\|VSCODE\|VS Code\|Visual Studio\|Cursor\|Zed\b' INSTALL.md
+```
+
+Surviving matches must only be LSP binary names:
+- `vscode-langservers-extracted` (npm package)
+- `vscode-json/css/html-language-server` (LSP binary names in opencode.json)
+
+---
+
+### Task 13: Commit + PR
+
+```bash
+git add INSTALL.md
+git commit -m "fix: remove non-OpenCode AI tools from INSTALL.md (#N)"
+git push -u origin fix/<N>-remove-non-opencode-ai-tools
+gh pr create --title "fix: remove non-OpenCode AI tools from INSTALL.md" --body "Closes #N"
+gh pr merge --squash --delete-branch
+```


### PR DESCRIPTION
## Summary

Removes all AI coding tools that are not OpenCode or Claude Code from INSTALL.md:

- **Step 4c** Google Antigravity (agy) — AI IDE
- **Step 4e** Visual Studio Code
- **Step 4f** Cursor — AI-native editor
- **Step 4h** Zed — editor with built-in AI
- **Step 5.9** Codex CLI (OpenAI coding agent)
- **Step 14.4** `export VSCODE=cursor` and Oh My Zsh `vscode` plugin — exclusively used to configure Cursor
- **Step 16.5** VS Code / Cursor / Zed version checks (renumbered to 16.5 → chrome-devtools-mcp)

**Preserved:** OpenCode, Claude Code plugins, Chrome (required for chrome-devtools-mcp), all LSP servers, linters, formatters, and terminal environment.

## Test plan

- [x] `grep -n 'cursor --\|brew.*cursor\|brew.*codex\|codex\b\|antigravity\|brew.*zed\|zed --\|Visual Studio Code\|VSCODE=' INSTALL.md` → no matches
- [x] `vscode-langservers` and `vscode-json/css/html-language-server` LSP binary names preserved
- [ ] Re-run INSTALL.md Steps 1 and 16 to verify clean install without removed tools

Closes #699

🤖 Generated with [Claude Code](https://claude.com/claude-code)