### PR TITLE
fix: eliminate SessionStart hook errors and inotifywait stdout leak

### DIFF
--- a/claude-config/install-plugins.sh
+++ b/claude-config/install-plugins.sh
@@ -156,5 +156,7 @@ for MKT_DIR in "${PLUGIN_BASE}/marketplaces"/*/; do
       continue
     fi
     echo '{}' >"$HOOKS_FILE"
+    chmod 444 "$HOOKS_FILE"
+    chmod 555 "$(dirname "$HOOKS_FILE")"
   done
 done

--- a/claude-config/settings.json
+++ b/claude-config/settings.json
@@ -1,5 +1,8 @@
 {
-  "statusLine": { "type": "command", "command": "/opt/claude-config/statusline.sh" },
+  "statusLine": {
+    "type": "command",
+    "command": "/opt/claude-config/statusline.sh"
+  },
   "model": "opus",
   "spinnerTipsEnabled": false,
   "terminalProgressBarEnabled": false,
@@ -10,7 +13,12 @@
   "defaultMode": "bypassPermissions",
   "skipDangerousModePermissionPrompt": true,
   "permissions": {
-    "allow": ["Bash", "Edit", "Write", "mcp__*"]
+    "allow": [
+      "Bash",
+      "Edit",
+      "Write",
+      "mcp__*"
+    ]
   },
   "enabledPlugins": {
     "frontend-design@claude-plugins-official": true,
@@ -54,7 +62,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "find ~/.claude/plugins -name '*.sh' -type f ! -perm -u+x -exec chmod +x {} + ; for hf in ~/.claude/plugins/marketplaces/*/plugins/*/hooks/hooks.json; do [ -f \"$hf\" ] || continue; p=$(basename $(dirname $(dirname \"$hf\"))); m=$(basename $(dirname $(dirname $(dirname $(dirname \"$hf\"))))); jq -e --arg k \"${p}@${m}\" '.enabledPlugins[$k]' ~/.claude/settings.json >/dev/null 2>&1 || echo '{}' > \"$hf\"; done",
+            "command": "find ~/.claude/plugins -name '*.sh' -type f ! -perm -u+x -exec chmod +x {} + ; for hf in ~/.claude/plugins/marketplaces/*/plugins/*/hooks/hooks.json; do [ -f \"$hf\" ] || continue; hd=$(dirname \"$hf\"); p=$(basename $(dirname $(dirname \"$hf\"))); m=$(basename $(dirname $(dirname $(dirname $(dirname \"$hf\"))))); if jq -e --arg k \"${p}@${m}\" '.enabledPlugins[$k]' ~/.claude/settings.json >/dev/null 2>&1; then chmod 755 \"$hd\" 2>/dev/null; chmod 644 \"$hf\" 2>/dev/null; else chmod 755 \"$hd\" 2>/dev/null; chmod 644 \"$hf\" 2>/dev/null; echo '{}' > \"$hf\"; chmod 444 \"$hf\"; chmod 555 \"$hd\"; fi; done",
             "timeout": 10
           }
         ]
@@ -66,7 +74,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "find ~/.claude/plugins -name '*.sh' -type f ! -perm -u+x -exec chmod +x {} + ; for hf in ~/.claude/plugins/marketplaces/*/plugins/*/hooks/hooks.json; do [ -f \"$hf\" ] || continue; p=$(basename $(dirname $(dirname \"$hf\"))); m=$(basename $(dirname $(dirname $(dirname $(dirname \"$hf\"))))); jq -e --arg k \"${p}@${m}\" '.enabledPlugins[$k]' ~/.claude/settings.json >/dev/null 2>&1 || echo '{}' > \"$hf\"; done",
+            "command": "find ~/.claude/plugins -name '*.sh' -type f ! -perm -u+x -exec chmod +x {} + ; for hf in ~/.claude/plugins/marketplaces/*/plugins/*/hooks/hooks.json; do [ -f \"$hf\" ] || continue; hd=$(dirname \"$hf\"); p=$(basename $(dirname $(dirname \"$hf\"))); m=$(basename $(dirname $(dirname $(dirname $(dirname \"$hf\"))))); if jq -e --arg k \"${p}@${m}\" '.enabledPlugins[$k]' ~/.claude/settings.json >/dev/null 2>&1; then chmod 755 \"$hd\" 2>/dev/null; chmod 644 \"$hf\" 2>/dev/null; else chmod 755 \"$hd\" 2>/dev/null; chmod 644 \"$hf\" 2>/dev/null; echo '{}' > \"$hf\"; chmod 444 \"$hf\"; chmod 555 \"$hd\"; fi; done",
             "timeout": 10
           }
         ]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -275,13 +275,20 @@ neutralize_non_enabled_hooks() {
       plugin_name=$(basename "$plugin")
       local key="${plugin_name}@${mkt_name}"
       local hooks_file="${plugin}hooks/hooks.json"
+      local hooks_dir="${plugin}hooks"
       [ -f "$hooks_file" ] || continue
-      # Skip if plugin is enabled
       if jq -e --arg k "$key" '.enabledPlugins[$k]' "$settings" >/dev/null 2>&1; then
+        # Enabled plugin: restore normal permissions (handles disable->enable)
+        chmod 755 "$hooks_dir" 2>/dev/null
+        chmod 644 "$hooks_file" 2>/dev/null
         continue
       fi
-      # Neutralize hooks for non-enabled plugin
+      # Non-enabled plugin: neutralize and lock with chmod
+      chmod 755 "$hooks_dir" 2>/dev/null
+      chmod 644 "$hooks_file" 2>/dev/null
       echo '{}' >"$hooks_file"
+      chmod 444 "$hooks_file"
+      chmod 555 "$hooks_dir"
     done
   done
 }
@@ -307,7 +314,7 @@ neutralize_non_enabled_hooks
   # Phase 2: event-driven watch (falls back to polling if inotifywait unavailable)
   if command -v inotifywait >/dev/null 2>&1; then
     while true; do
-      inotifywait -q -r -e modify,create,moved_to \
+      inotifywait -qq -r -e modify,create,moved_to \
         "${HOME}/.claude/plugins/marketplaces" 2>/dev/null
       sleep 1
       find "${HOME}/.claude/plugins" -name "*.sh" -type f \
@@ -322,7 +329,7 @@ neutralize_non_enabled_hooks
       neutralize_non_enabled_hooks
     done
   fi
-) &
+) >/dev/null 2>&1 &
 
 # Inject SessionStart + PostToolUse hooks from template into runtime settings.json
 # The template at /opt/claude-config/settings.json has the canonical hook definitions.


### PR DESCRIPTION
## Summary

Fixes two bugs that appear on every Claude Code session start:

- **inotifywait stdout leak**: `-q` flag still prints file events (e.g., `CREATE,ISDIR`) to stdout, which leaks into the Claude CLI display. Changed to `-qq` and redirected the background subshell to `/dev/null`.
- **SessionStart hook errors**: Race condition where marketplace sync (tarball extraction) restores non-enabled plugin hooks.json files before neutralization can run. Fixed by chmod-locking neutralized files (444 file, 555 directory) so the sync cannot overwrite them.

## Changes

| File | Change |
|---|---|
| `entrypoint.sh` | `-q` to `-qq`, subshell redirect, `neutralize_non_enabled_hooks()` adds chmod 444/555 locking |
| `claude-config/install-plugins.sh` | Build-time neutralization now also chmod-locks |
| `claude-config/settings.json` | SessionStart and PostToolUse hook commands include chmod locking logic |

## Test plan

- [ ] Start Claude Code — zero SessionStart:startup hook error messages
- [ ] No filesystem event text (like CREATE,ISDIR) in CLI output
- [ ] stat -c '%a' on non-enabled plugin hooks.json shows 444
- [ ] echo test > hooks.json for locked file returns Permission denied
- [ ] Enabled plugin hooks (hookify, ralph-loop, security-guidance) still have 644 permissions and function normally
- [ ] Background daemon still auto-fixes .sh file permissions within seconds
- [ ] Docker image rebuild with install-plugins.sh ships with locked hooks

Closes #701