### PR TITLE
feat: add jnettop to Dockerfile apt networking tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -90,7 +90,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     # Media / utilities
     ffmpeg poppler-utils qrencode \
     # Network tools
-    dnsutils net-tools iputils-ping traceroute tcpdump nmap netcat-openbsd \
+    dnsutils net-tools iputils-ping traceroute tcpdump nmap netcat-openbsd jnettop \
     # CLI browsers (xdg-open fallback for gh auth login)
     lynx w3m elinks links2 \
     # Tailscale VPN


### PR DESCRIPTION
## Summary

Adds `jnettop` to the devcontainer Dockerfile — a real-time network traffic visualizer (like top for network traffic).

## Changes

- Added `jnettop` to the Network tools apt install block in the Dockerfile

## Testing

- `apt-get install -y --no-install-recommends jnettop` — standard apt package, no config needed

Closes #630