### PR TITLE
chore: bump oh-my-opencode plugin to 3.11.0-fork.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1161,7 +1161,7 @@ RUN OPENCODE_CACHE="$HOME/.cache/opencode" \
     && printf '21' > "$OPENCODE_CACHE/version" \
     && printf '{"dependencies":{}}\n' > "$OPENCODE_CACHE/package.json" \
     && bun add --cwd "$OPENCODE_CACHE" --force --exact \
-        @robinmordasiewicz/oh-my-opencode@3.11.0-fork.2 \
+        @robinmordasiewicz/oh-my-opencode@3.11.0-fork.3 \
         @ai-sdk/anthropic \
         @ai-sdk/openai-compatible \
         opencode-anthropic-auth@0.0.13

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1552,7 +1552,7 @@ Write the file `~/.cache/opencode/package.json` with the following content (vers
 ```json
 {
   "dependencies": {
-    "@robinmordasiewicz/oh-my-opencode": "3.11.0-fork.2",
+    "@robinmordasiewicz/oh-my-opencode": "3.11.0-fork.3",
     "@ai-sdk/anthropic": "^3.0.64",
     "@ai-sdk/openai-compatible": "^2.0.37",
     "opencode-anthropic-auth": "0.0.13"
@@ -2101,7 +2101,7 @@ if [ -n "$LITELLM_API_KEY" ] && [ -n "$LITELLM_BASE_URL" ]; then
   "small_model": "anthropic-proxy/claude-sonnet-4-6",
   "permission": "allow",
   "plugin": [
-    "@robinmordasiewicz/oh-my-opencode@3.11.0-fork.2"
+    "@robinmordasiewicz/oh-my-opencode@3.11.0-fork.3"
   ],
   "lsp": {
     "marksman": { "command": ["marksman", "server"], "extensions": [".md", ".mdx"] },
@@ -2151,7 +2151,7 @@ elif [ -n "$CLAUDE_CODE_OAUTH_TOKEN" ]; then
       }
     }
   },
-  "plugin": ["opencode-claude-auth", "@robinmordasiewicz/oh-my-opencode@3.11.0-fork.2"],
+  "plugin": ["opencode-claude-auth", "@robinmordasiewicz/oh-my-opencode@3.11.0-fork.3"],
   "mcp": {
     "chrome-devtools": {
       "type": "local",

--- a/opencode-config/opencode-anthropic.json
+++ b/opencode-config/opencode-anthropic.json
@@ -3,7 +3,7 @@
   "permission": "allow",
   "model": "anthropic/claude-opus-4-6",
   "small_model": "anthropic/claude-sonnet-4-6",
-  "plugin": ["opencode-claude-auth", "@robinmordasiewicz/oh-my-opencode@3.11.0-fork.1"],
+  "plugin": ["opencode-claude-auth", "@robinmordasiewicz/oh-my-opencode@3.11.0-fork.3"],
   "mcp": {},
   "lsp": {
     "marksman": {

--- a/opencode-config/opencode.json
+++ b/opencode-config/opencode.json
@@ -71,7 +71,7 @@
   },
   "model": "anthropic-proxy/claude-opus-4-6",
   "small_model": "anthropic-proxy/claude-sonnet-4-6",
-  "plugin": ["@robinmordasiewicz/oh-my-opencode@3.11.0-fork.1"],
+  "plugin": ["@robinmordasiewicz/oh-my-opencode@3.11.0-fork.3"],
   "mcp": {},
   "lsp": {
     "marksman": {


### PR DESCRIPTION
## Summary

- Bump @robinmordasiewicz/oh-my-opencode from fork.1/fork.2 to 3.11.0-fork.3 across all version pins
- Published with parseToolsConfig array fix built from upstream dev

Closes #711

## Files Changed

- `Dockerfile` — npm install version pin
- `INSTALL.md` — documented install commands
- `opencode-config/opencode.json` — plugin version field
- `opencode-config/opencode-anthropic.json` — plugin version field

## Test plan

- [ ] CI checks pass
- [ ] Container builds with new plugin version