### PR TITLE
fix: resolve persistent hook errors from stale plugin name and non-standard paths

### DIFF
--- a/claude-config/install-plugins.sh
+++ b/claude-config/install-plugins.sh
@@ -193,3 +193,42 @@ for MKT_DIR in "${PLUGIN_BASE}/marketplaces"/*/; do
     chmod 555 "$(dirname "$HOOKS_FILE")"
   done
 done
+
+# Second pass: neutralize hooks.json at non-standard paths (monorepo marketplaces)
+# e.g. thedotmack/cursor-hooks/hooks.json (not under plugins/)
+while IFS= read -r HF; do
+  [ -f "$HF" ] || continue
+  # Skip files already handled by the standard loop above
+  echo "$HF" | grep -q '/marketplaces/[^/]*/plugins/[^/]*/hooks/hooks.json$' && continue
+  HD=$(dirname "$HF")
+  HF_PARENT=$(dirname "$HD")
+  HF_PARENT_REAL=$(readlink -f "$HF_PARENT" 2>/dev/null || echo "$HF_PARENT")
+  SKIP=false
+  for LINK in "${PLUGIN_BASE}/marketplaces"/*/plugins/*/; do
+    [ -L "${LINK%/}" ] || continue
+    LINK_TARGET=$(readlink -f "${LINK%/}" 2>/dev/null || true)
+    [ -n "$LINK_TARGET" ] || continue
+    if [ "$HF_PARENT_REAL" = "$LINK_TARGET" ]; then
+      LINK_NAME=$(basename "${LINK%/}")
+      LINK_MKT=$(basename "$(dirname "$(dirname "${LINK%/}")")")
+      if jq -e --arg k "${LINK_NAME}@${LINK_MKT}" '.enabledPlugins[$k]' "$SETTINGS" >/dev/null 2>&1; then
+        SKIP=true
+        break
+      fi
+    fi
+  done
+  if [ "$SKIP" = true ]; then
+    continue
+  fi
+  CURRENT=$(cat "$HF" 2>/dev/null || true)
+  if [ "$CURRENT" = "{}" ]; then
+    chmod 444 "$HF" 2>/dev/null || true
+    chmod 555 "$HD" 2>/dev/null || true
+    continue
+  fi
+  chmod 755 "$HD" 2>/dev/null || true
+  chmod 644 "$HF" 2>/dev/null || true
+  echo '{}' >"$HF" 2>/dev/null || true
+  chmod 444 "$HF" 2>/dev/null || true
+  chmod 555 "$HD" 2>/dev/null || true
+done < <(find "${PLUGIN_BASE}/marketplaces" -name "hooks.json" 2>/dev/null)

--- a/claude-config/neutralize-hooks.sh
+++ b/claude-config/neutralize-hooks.sh
@@ -70,5 +70,56 @@ for hf in "$PLUGIN_BASE"/marketplaces/*/plugins/*/hooks/hooks.json; do
   chmod 555 "$hd" 2>/dev/null || true
 done
 
+# ── 4. Neutralize non-standard-path hooks.json (monorepo marketplaces) ────
+# Some marketplaces (e.g. thedotmack) have hooks.json at non-standard paths
+# like <mkt>/cursor-hooks/hooks.json instead of <mkt>/plugins/<name>/hooks/.
+# These are missed by the glob in step 3. Find them and neutralize unless
+# they are part of an enabled plugin's standard directory.
+while IFS= read -r hf; do
+  [ -f "$hf" ] || continue
+  # Skip files already handled by the standard glob in step 3
+  echo "$hf" | grep -q '/marketplaces/[^/]*/plugins/[^/]*/hooks/hooks.json$' && continue
+  hd=$(dirname "$hf")
+
+  # Check if this hooks.json is inside a directory that an enabled plugin
+  # symlinks to (e.g. thedotmack/plugin/ -> cache/thedotmack/claude-mem/)
+  hf_parent=$(dirname "$hd")
+  hf_parent_real=$(readlink -f "$hf_parent" 2>/dev/null || echo "$hf_parent")
+  skip=false
+  for link in "$PLUGIN_BASE"/marketplaces/*/plugins/*/; do
+    [ -L "${link%/}" ] || continue
+    link_target=$(readlink -f "${link%/}" 2>/dev/null || true)
+    [ -n "$link_target" ] || continue
+    # Check if enabled plugin symlink target matches this hooks.json location
+    if [ "$hf_parent_real" = "$link_target" ]; then
+      # Verify the symlinked plugin is actually enabled
+      link_name=$(basename "${link%/}")
+      link_mkt=$(basename "$(dirname "$(dirname "${link%/}")")")
+      if jq -e --arg k "${link_name}@${link_mkt}" '.enabledPlugins[$k]' "$SETTINGS" >/dev/null 2>&1; then
+        skip=true
+        break
+      fi
+    fi
+  done
+  if [ "$skip" = true ]; then
+    continue
+  fi
+
+  # Skip if already neutralized
+  current=$(cat "$hf" 2>/dev/null || true)
+  if [ "$current" = "{}" ]; then
+    chmod 444 "$hf" 2>/dev/null || true
+    chmod 555 "$hd" 2>/dev/null || true
+    continue
+  fi
+
+  # Neutralize and lock
+  chmod 755 "$hd" 2>/dev/null || true
+  chmod 644 "$hf" 2>/dev/null || true
+  echo '{}' >"$hf" 2>/dev/null || true
+  chmod 444 "$hf" 2>/dev/null || true
+  chmod 555 "$hd" 2>/dev/null || true
+done < <(find "$PLUGIN_BASE/marketplaces" -name "hooks.json" 2>/dev/null)
+
 # ALWAYS exit 0 — never cause "hook error" display
 exit 0

--- a/claude-config/settings.json
+++ b/claude-config/settings.json
@@ -35,7 +35,7 @@
     "f5xc-docs-pipeline@f5xc-salesdemos-marketplace": true,
     "f5xc-brand@f5xc-salesdemos-marketplace": true,
     "f5xc-devcontainer@f5xc-salesdemos-marketplace": true,
-    "f5xc-console@f5xc-salesdemos-marketplace": true,
+    "f5xc-platform@f5xc-salesdemos-marketplace": true,
     "claude-mem@thedotmack": true
   },
   "env": {

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -329,6 +329,46 @@ neutralize_non_enabled_hooks() {
       chmod 555 "$hooks_dir"
     done
   done
+
+  # Second pass: neutralize hooks.json at non-standard paths (monorepo marketplaces)
+  # e.g. thedotmack/cursor-hooks/hooks.json (not under plugins/)
+  local plugin_base="${HOME}/.claude/plugins"
+  local hf hd hf_parent hf_parent_real skip link link_target link_name link_mkt current
+  while IFS= read -r hf; do
+    [ -f "$hf" ] || continue
+    echo "$hf" | grep -q '/marketplaces/[^/]*/plugins/[^/]*/hooks/hooks.json$' && continue
+    hd=$(dirname "$hf")
+    hf_parent=$(dirname "$hd")
+    hf_parent_real=$(readlink -f "$hf_parent" 2>/dev/null || echo "$hf_parent")
+    skip=false
+    for link in "$plugin_base"/marketplaces/*/plugins/*/; do
+      [ -L "${link%/}" ] || continue
+      link_target=$(readlink -f "${link%/}" 2>/dev/null || true)
+      [ -n "$link_target" ] || continue
+      if [ "$hf_parent_real" = "$link_target" ]; then
+        link_name=$(basename "${link%/}")
+        link_mkt=$(basename "$(dirname "$(dirname "${link%/}")")")
+        if jq -e --arg k "${link_name}@${link_mkt}" '.enabledPlugins[$k]' "$settings" >/dev/null 2>&1; then
+          skip=true
+          break
+        fi
+      fi
+    done
+    if [ "$skip" = true ]; then
+      continue
+    fi
+    current=$(cat "$hf" 2>/dev/null || true)
+    if [ "$current" = "{}" ]; then
+      chmod 444 "$hf" 2>/dev/null || true
+      chmod 555 "$hd" 2>/dev/null || true
+      continue
+    fi
+    chmod 755 "$hd" 2>/dev/null || true
+    chmod 644 "$hf" 2>/dev/null || true
+    echo '{}' >"$hf" 2>/dev/null || true
+    chmod 444 "$hf" 2>/dev/null || true
+    chmod 555 "$hd" 2>/dev/null || true
+  done < <(find "$plugin_base/marketplaces" -name "hooks.json" 2>/dev/null)
 }
 
 ensure_marketplace_dirs

--- a/tests/test-hook-neutralization.sh
+++ b/tests/test-hook-neutralization.sh
@@ -323,12 +323,70 @@ else
   FAIL=$((FAIL + 1))
 fi
 
+echo ""
+echo "6. Non-Standard Plugin Paths"
+
+# Test 20: hooks.json at non-standard path (not under plugins/) gets neutralized
+setup_mock_env
+# Create a monorepo-style marketplace with hooks NOT under plugins/
+mkdir -p "${MOCK_HOME}/.claude/plugins/marketplaces/test-mkt/cursor-hooks"
+echo '{"hooks":{"beforeSubmitPrompt":[{"command":"./session-init.sh"}]}}' \
+  >"${MOCK_HOME}/.claude/plugins/marketplaces/test-mkt/cursor-hooks/hooks.json"
+# Run the standalone script (which has the broader scan)
+SCRIPT="$(dirname "$0")/../claude-config/neutralize-hooks.sh"
+if [ -f "$SCRIPT" ]; then
+  HOME="$MOCK_HOME" bash "$SCRIPT" 2>/dev/null
+  CONTENT=$(cat "${MOCK_HOME}/.claude/plugins/marketplaces/test-mkt/cursor-hooks/hooks.json" 2>/dev/null)
+  check "non-standard path hooks.json neutralized" test "$CONTENT" = "{}"
+else
+  echo "  FAIL: neutralize-hooks.sh not found"
+  FAIL=$((FAIL + 1))
+fi
+teardown_mock_env
+
+# Test 21: hooks.json at non-standard path that is a symlink target of enabled plugin is preserved
+setup_mock_env
+create_mock_cache_plugin "test-mkt" "alpha" "1.0.0" '{"hooks":{"SessionStart":[{"hooks":[{"type":"command","command":"echo ok"}]}]}}'
+# Create symlink: plugins/alpha -> cache entry (simulates ensure_marketplace_dirs)
+source_ensure_dirs_fn || true
+HOME="$MOCK_HOME" ensure_marketplace_dirs 2>/dev/null || true
+# Now the non-standard path (cache target) has hooks.json — should be preserved via the standard path check
+ORIG_HOOKS='{"hooks":{"SessionStart":[{"hooks":[{"type":"command","command":"echo ok"}]}]}}'
+if [ -f "$SCRIPT" ]; then
+  HOME="$MOCK_HOME" bash "$SCRIPT" 2>/dev/null
+  # The standard plugins/alpha/hooks/hooks.json (symlink to cache) should be preserved
+  CONTENT=$(cat "${MOCK_HOME}/.claude/plugins/marketplaces/test-mkt/plugins/alpha/hooks/hooks.json" 2>/dev/null)
+  check "enabled plugin hooks preserved through symlink" test "$CONTENT" = "$ORIG_HOOKS"
+else
+  echo "  FAIL: neutralize-hooks.sh not found"
+  FAIL=$((FAIL + 1))
+fi
+teardown_mock_env
+
+# Test 22: multiple non-standard paths in same marketplace all neutralized
+setup_mock_env
+mkdir -p "${MOCK_HOME}/.claude/plugins/marketplaces/test-mkt/subdir-a/hooks"
+mkdir -p "${MOCK_HOME}/.claude/plugins/marketplaces/test-mkt/subdir-b/hooks"
+echo '{"hooks":{"Stop":[]}}' >"${MOCK_HOME}/.claude/plugins/marketplaces/test-mkt/subdir-a/hooks/hooks.json"
+echo '{"hooks":{"Stop":[]}}' >"${MOCK_HOME}/.claude/plugins/marketplaces/test-mkt/subdir-b/hooks/hooks.json"
+if [ -f "$SCRIPT" ]; then
+  HOME="$MOCK_HOME" bash "$SCRIPT" 2>/dev/null
+  CONTENT_A=$(cat "${MOCK_HOME}/.claude/plugins/marketplaces/test-mkt/subdir-a/hooks/hooks.json" 2>/dev/null)
+  CONTENT_B=$(cat "${MOCK_HOME}/.claude/plugins/marketplaces/test-mkt/subdir-b/hooks/hooks.json" 2>/dev/null)
+  check "non-standard path A neutralized" test "$CONTENT_A" = "{}"
+  check "non-standard path B neutralized" test "$CONTENT_B" = "{}"
+else
+  echo "  FAIL: neutralize-hooks.sh not found"
+  FAIL=$((FAIL + 2))
+fi
+teardown_mock_env
+
 if [ "$UNIT_ONLY" = true ]; then
   echo ""
   echo "── Skipping E2E tests (--unit-only) ──"
 else
   echo ""
-  echo "6. End-to-End (Container)"
+  echo "7. End-to-End (Container)"
 
   # Test 17: every enabled plugin has a marketplace directory
   PLUGIN_BASE="$HOME/.claude/plugins"
@@ -372,7 +430,53 @@ else
   check "no active hooks from non-enabled plugins (${NON_ENABLED_HOOKS} found)" \
     test "$NON_ENABLED_HOOKS" -eq 0
 
-  # Test 19: self-test hook checks pass
+  # Test 19: all enabled plugins have cache entries
+  MISSING_CACHE=0
+  while IFS= read -r key; do
+    name="${key%%@*}"
+    mkt="${key#*@}"
+    cache_dir="${PLUGIN_BASE}/cache/${mkt}/${name}"
+    if [ -d "$cache_dir" ] || [ -L "$cache_dir" ]; then
+      : # ok
+    else
+      echo "    MISSING CACHE: $cache_dir (for $key)"
+      MISSING_CACHE=$((MISSING_CACHE + 1))
+    fi
+  done < <(jq -r '.enabledPlugins | keys[]' "$SETTINGS" 2>/dev/null)
+  check "all enabled plugins have cache entries (${MISSING_CACHE} missing)" \
+    test "$MISSING_CACHE" -eq 0
+
+  # Test 20e: non-standard path hooks.json files are neutralized unless they
+  # belong to an enabled plugin's directory (e.g., thedotmack/plugin/ is claude-mem)
+  NON_STD_ACTIVE=0
+  while IFS= read -r hf; do
+    [ -f "$hf" ] || continue
+    # Skip standard paths (already tested above)
+    echo "$hf" | grep -q '/plugins/[^/]*/hooks/hooks.json$' && continue
+    # Skip if the hooks.json's parent structure is a symlink target for an enabled plugin
+    hf_real=$(readlink -f "$(dirname "$(dirname "$hf")")")
+    is_enabled_target=false
+    for link in "$PLUGIN_BASE/marketplaces"/*/plugins/*/; do
+      [ -L "${link%/}" ] || continue
+      link_target=$(readlink -f "${link%/}")
+      if [ "$hf_real" = "$link_target" ] || echo "$hf_real" | grep -q "^${link_target}"; then
+        is_enabled_target=true
+        break
+      fi
+    done
+    if [ "$is_enabled_target" = true ]; then
+      continue
+    fi
+    CONTENT=$(cat "$hf" 2>/dev/null)
+    if [ "$CONTENT" != "{}" ]; then
+      echo "    ACTIVE NON-STD: $hf"
+      NON_STD_ACTIVE=$((NON_STD_ACTIVE + 1))
+    fi
+  done < <(find "$PLUGIN_BASE/marketplaces" -name "hooks.json" 2>/dev/null)
+  check "no active hooks from non-standard unlinked paths (${NON_STD_ACTIVE} found)" \
+    test "$NON_STD_ACTIVE" -eq 0
+
+  # Test: self-test hook checks pass
   if command -v claude-self-test >/dev/null 2>&1; then
     SELF_TEST_OUTPUT=$(claude-self-test 2>&1 || true)
     HOOK_FAILS=$(echo "$SELF_TEST_OUTPUT" | grep -c "FAIL:.*hook\|FAIL:.*plugin\|FAIL:.*chmod" || true)


### PR DESCRIPTION
## Summary

- Replace `f5xc-console` with `f5xc-platform` in `claude-config/settings.json` enabledPlugins (phantom plugin causing load failures)
- Add recursive `hooks.json` scan to all three neutralization code paths (`neutralize-hooks.sh`, `entrypoint.sh`, `install-plugins.sh`) to catch monorepo-style hook locations missed by the previous glob pattern
- Add 6 new TDD tests verifying both root causes are fixed

Closes #713
Closes #706
Closes #701

## Test plan

- [ ] CI checks pass (Lint Code Base, Check linked issues)
- [ ] New tests in `tests/test-hook-neutralization.sh` pass (non-standard path detection, cache completeness)
- [ ] No SessionStart or UserPromptSubmit hook errors on container start

🤖 Generated with [Claude Code](https://claude.com/claude-code)