### PR TITLE
fix: remove chmod 555 directory locking that blocks marketplace sync

### DIFF
--- a/claude-config/install-plugins.sh
+++ b/claude-config/install-plugins.sh
@@ -182,15 +182,14 @@ for MKT_DIR in "${PLUGIN_BASE}/marketplaces"/*/; do
     # Skip if already neutralized (idempotent)
     CURRENT=$(cat "$HOOKS_FILE" 2>/dev/null || true)
     if [ "$CURRENT" = "{}" ]; then
+      chmod 755 "$(dirname "$HOOKS_FILE")" 2>/dev/null || true
       chmod 444 "$HOOKS_FILE" 2>/dev/null || true
-      chmod 555 "$(dirname "$HOOKS_FILE")" 2>/dev/null || true
       continue
     fi
     chmod 755 "$(dirname "$HOOKS_FILE")" 2>/dev/null || true
     chmod 644 "$HOOKS_FILE" 2>/dev/null || true
     echo '{}' >"$HOOKS_FILE"
     chmod 444 "$HOOKS_FILE"
-    chmod 555 "$(dirname "$HOOKS_FILE")"
   done
 done
 
@@ -222,13 +221,12 @@ while IFS= read -r HF; do
   fi
   CURRENT=$(cat "$HF" 2>/dev/null || true)
   if [ "$CURRENT" = "{}" ]; then
+    chmod 755 "$HD" 2>/dev/null || true
     chmod 444 "$HF" 2>/dev/null || true
-    chmod 555 "$HD" 2>/dev/null || true
     continue
   fi
   chmod 755 "$HD" 2>/dev/null || true
   chmod 644 "$HF" 2>/dev/null || true
   echo '{}' >"$HF" 2>/dev/null || true
   chmod 444 "$HF" 2>/dev/null || true
-  chmod 555 "$HD" 2>/dev/null || true
 done < <(find "${PLUGIN_BASE}/marketplaces" -name "hooks.json" 2>/dev/null)

--- a/claude-config/neutralize-hooks.sh
+++ b/claude-config/neutralize-hooks.sh
@@ -57,8 +57,8 @@ for hf in "$PLUGIN_BASE"/marketplaces/*/plugins/*/hooks/hooks.json; do
   # Skip if already neutralized (idempotent)
   current=$(cat "$hf" 2>/dev/null || true)
   if [ "$current" = "{}" ]; then
+    chmod 755 "$hd" 2>/dev/null || true
     chmod 444 "$hf" 2>/dev/null || true
-    chmod 555 "$hd" 2>/dev/null || true
     continue
   fi
 
@@ -67,7 +67,6 @@ for hf in "$PLUGIN_BASE"/marketplaces/*/plugins/*/hooks/hooks.json; do
   chmod 644 "$hf" 2>/dev/null || true
   echo '{}' >"$hf" 2>/dev/null || true
   chmod 444 "$hf" 2>/dev/null || true
-  chmod 555 "$hd" 2>/dev/null || true
 done
 
 # ── 4. Neutralize non-standard-path hooks.json (monorepo marketplaces) ────
@@ -108,8 +107,8 @@ while IFS= read -r hf; do
   # Skip if already neutralized
   current=$(cat "$hf" 2>/dev/null || true)
   if [ "$current" = "{}" ]; then
+    chmod 755 "$hd" 2>/dev/null || true
     chmod 444 "$hf" 2>/dev/null || true
-    chmod 555 "$hd" 2>/dev/null || true
     continue
   fi
 
@@ -118,7 +117,6 @@ while IFS= read -r hf; do
   chmod 644 "$hf" 2>/dev/null || true
   echo '{}' >"$hf" 2>/dev/null || true
   chmod 444 "$hf" 2>/dev/null || true
-  chmod 555 "$hd" 2>/dev/null || true
 done < <(find "$PLUGIN_BASE/marketplaces" -name "hooks.json" 2>/dev/null)
 
 # ALWAYS exit 0 — never cause "hook error" display

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -317,8 +317,8 @@ neutralize_non_enabled_hooks() {
       local current
       current=$(cat "$hooks_file" 2>/dev/null || true)
       if [ "$current" = "{}" ]; then
+        chmod 755 "$hooks_dir" 2>/dev/null || true
         chmod 444 "$hooks_file" 2>/dev/null || true
-        chmod 555 "$hooks_dir" 2>/dev/null || true
         continue
       fi
       # Non-enabled plugin: neutralize and lock with chmod
@@ -326,7 +326,6 @@ neutralize_non_enabled_hooks() {
       chmod 644 "$hooks_file" 2>/dev/null || true
       echo '{}' >"$hooks_file"
       chmod 444 "$hooks_file"
-      chmod 555 "$hooks_dir"
     done
   done
 
@@ -359,15 +358,14 @@ neutralize_non_enabled_hooks() {
     fi
     current=$(cat "$hf" 2>/dev/null || true)
     if [ "$current" = "{}" ]; then
+      chmod 755 "$hd" 2>/dev/null || true
       chmod 444 "$hf" 2>/dev/null || true
-      chmod 555 "$hd" 2>/dev/null || true
       continue
     fi
     chmod 755 "$hd" 2>/dev/null || true
     chmod 644 "$hf" 2>/dev/null || true
     echo '{}' >"$hf" 2>/dev/null || true
     chmod 444 "$hf" 2>/dev/null || true
-    chmod 555 "$hd" 2>/dev/null || true
   done < <(find "$plugin_base/marketplaces" -name "hooks.json" 2>/dev/null)
 }
 

--- a/tests/test-hook-neutralization.sh
+++ b/tests/test-hook-neutralization.sh
@@ -52,7 +52,6 @@ SETTINGS
 teardown_mock_env() {
   if [ -n "$MOCK_HOME" ]; then
     # Unlock any chmod-locked files before removal
-    find "$MOCK_HOME" -type d -perm 555 -exec chmod 755 {} + 2>/dev/null || true
     find "$MOCK_HOME" -type f -perm 444 -exec chmod 644 {} + 2>/dev/null || true
     rm -rf "$MOCK_HOME"
   fi
@@ -169,8 +168,8 @@ check "non-enabled plugin hooks.json neutralized to {}" \
   test "$CONTENT" = "{}"
 check "non-enabled plugin hooks.json perms 444" \
   test "$FPERMS" = "444"
-check "non-enabled plugin hooks dir perms 555" \
-  test "$DPERMS" = "555"
+check "non-enabled plugin hooks dir perms 755" \
+  test "$DPERMS" = "755"
 teardown_mock_env
 
 # Test 6: enabled plugin hooks.json preserved with 644/755 perms
@@ -191,7 +190,7 @@ teardown_mock_env
 setup_mock_env
 create_mock_mkt_plugin "test-mkt" "gamma" '{}'
 chmod 444 "${MOCK_HOME}/.claude/plugins/marketplaces/test-mkt/plugins/gamma/hooks/hooks.json"
-chmod 555 "${MOCK_HOME}/.claude/plugins/marketplaces/test-mkt/plugins/gamma/hooks"
+chmod 755 "${MOCK_HOME}/.claude/plugins/marketplaces/test-mkt/plugins/gamma/hooks"
 source_neutralize_fn
 STDERR_OUTPUT=$(HOME="$MOCK_HOME" neutralize_non_enabled_hooks 2>&1 || true)
 CONTENT=$(cat "${MOCK_HOME}/.claude/plugins/marketplaces/test-mkt/plugins/gamma/hooks/hooks.json")
@@ -256,7 +255,7 @@ echo "4. Settings.json Hook Command"
 setup_mock_env
 create_mock_mkt_plugin "test-mkt" "gamma" '{}'
 chmod 444 "${MOCK_HOME}/.claude/plugins/marketplaces/test-mkt/plugins/gamma/hooks/hooks.json"
-chmod 555 "${MOCK_HOME}/.claude/plugins/marketplaces/test-mkt/plugins/gamma/hooks"
+chmod 755 "${MOCK_HOME}/.claude/plugins/marketplaces/test-mkt/plugins/gamma/hooks"
 SCRIPT="$(dirname "$0")/../claude-config/neutralize-hooks.sh"
 if [ -f "$SCRIPT" ]; then
   HOME="$MOCK_HOME" bash "$SCRIPT" 2>/dev/null
@@ -378,6 +377,67 @@ if [ -f "$SCRIPT" ]; then
 else
   echo "  FAIL: neutralize-hooks.sh not found"
   FAIL=$((FAIL + 2))
+fi
+teardown_mock_env
+
+echo ""
+echo "8. Marketplace Sync Compatibility"
+
+# Test 23: rm -rf succeeds on marketplace with neutralized plugins
+setup_mock_env
+create_mock_mkt_plugin "test-mkt" "gamma" '{"hooks":{"SessionStart":[{"hooks":[{"type":"command","command":"echo bad"}]}]}}'
+create_mock_mkt_plugin "test-mkt" "delta" '{"hooks":{"PreToolUse":[]}}'
+SCRIPT="$(dirname "$0")/../claude-config/neutralize-hooks.sh"
+if [ -f "$SCRIPT" ]; then
+  HOME="$MOCK_HOME" bash "$SCRIPT" 2>/dev/null
+  rm -rf "${MOCK_HOME}/.claude/plugins/marketplaces/test-mkt" 2>/dev/null
+  check "rm -rf succeeds on marketplace with neutralized plugins" \
+    test -z "$(ls -d "${MOCK_HOME}/.claude/plugins/marketplaces/test-mkt" 2>/dev/null)"
+else
+  echo "  FAIL: neutralize-hooks.sh not found"
+  FAIL=$((FAIL + 1))
+fi
+teardown_mock_env
+
+# Test 24: neutralized hooks directory has 755 not 555
+setup_mock_env
+create_mock_mkt_plugin "test-mkt" "gamma" '{"hooks":{"SessionStart":[]}}'
+if [ -f "$SCRIPT" ]; then
+  HOME="$MOCK_HOME" bash "$SCRIPT" 2>/dev/null
+  DPERMS=$(stat -c '%a' "${MOCK_HOME}/.claude/plugins/marketplaces/test-mkt/plugins/gamma/hooks" 2>/dev/null)
+  check "neutralized hooks dir has 755 (not 555)" test "$DPERMS" = "755"
+else
+  echo "  FAIL: neutralize-hooks.sh not found"
+  FAIL=$((FAIL + 1))
+fi
+teardown_mock_env
+
+# Test 25: hooks.json still protected at 444 after neutralization
+setup_mock_env
+create_mock_mkt_plugin "test-mkt" "gamma" '{"hooks":{"SessionStart":[]}}'
+if [ -f "$SCRIPT" ]; then
+  HOME="$MOCK_HOME" bash "$SCRIPT" 2>/dev/null
+  FPERMS=$(stat -c '%a' "${MOCK_HOME}/.claude/plugins/marketplaces/test-mkt/plugins/gamma/hooks/hooks.json" 2>/dev/null)
+  check "hooks.json still protected at 444" test "$FPERMS" = "444"
+else
+  echo "  FAIL: neutralize-hooks.sh not found"
+  FAIL=$((FAIL + 1))
+fi
+teardown_mock_env
+
+# Test 26: staging marketplace removable after neutralization
+setup_mock_env
+mkdir -p "${MOCK_HOME}/.claude/plugins/marketplaces/test-mkt.staging/plugins"
+create_mock_mkt_plugin "test-mkt.staging" "gamma" '{"hooks":{"SessionStart":[]}}'
+create_mock_mkt_plugin "test-mkt.staging" "delta" '{"hooks":{"PreToolUse":[]}}'
+if [ -f "$SCRIPT" ]; then
+  HOME="$MOCK_HOME" bash "$SCRIPT" 2>/dev/null
+  rm -rf "${MOCK_HOME}/.claude/plugins/marketplaces/test-mkt.staging" 2>/dev/null
+  check "staging marketplace removable after neutralization" \
+    test -z "$(ls -d "${MOCK_HOME}/.claude/plugins/marketplaces/test-mkt.staging" 2>/dev/null)"
+else
+  echo "  FAIL: neutralize-hooks.sh not found"
+  FAIL=$((FAIL + 1))
 fi
 teardown_mock_env
 


### PR DESCRIPTION
## Summary

- Remove all `chmod 555` directory locking from hook neutralization (neutralize-hooks.sh, entrypoint.sh, install-plugins.sh)
- Add `chmod 755` to reset previously-locked directories so marketplace sync can operate
- Add 4 new marketplace sync compatibility tests and update existing test expectations from 555 to 755

Closes #717

## Test plan

- [ ] CI checks pass (lint, shell script lint, spelling)
- [ ] `test-hook-neutralization.sh` passes all assertions including new marketplace sync tests
- [ ] Verify marketplace directories are writable (755) after container start
- [ ] Confirm hooks.json remains read-only (444) with empty `{}` content

:robot: Generated with [Claude Code](https://claude.com/claude-code)