### PR TITLE
fix: add missing npm SDK fields to INSTALL.md opencode.json heredoc

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -2033,6 +2033,7 @@ if [ -n "$LITELLM_API_KEY" ] && [ -n "$LITELLM_BASE_URL" ]; then
   "provider": {
     "openai-proxy": {
       "name": "OpenAI Proxy",
+      "npm": "@ai-sdk/openai-compatible",
       "options": {
         "baseURL": "${LITELLM_BASE_URL}/api/v1",
         "apiKey": "${LITELLM_API_KEY}"
@@ -2067,6 +2068,7 @@ if [ -n "$LITELLM_API_KEY" ] && [ -n "$LITELLM_BASE_URL" ]; then
     },
     "anthropic-proxy": {
       "name": "Anthropic Proxy",
+      "npm": "@ai-sdk/anthropic",
       "options": {
         "baseURL": "${LITELLM_BASE_URL}/anthropic/v1",
         "apiKey": "${LITELLM_API_KEY}"


### PR DESCRIPTION
Closes #726

## Summary

- Add `"npm": "@ai-sdk/anthropic"` to the `anthropic-proxy` provider in INSTALL.md Step 9 heredoc
- Add `"npm": "@ai-sdk/openai-compatible"` to the `openai-proxy` provider in INSTALL.md Step 9 heredoc

Without the `"npm"` key, OpenCode cannot resolve which AI SDK package to load at runtime. The Dockerfile's baked config (`opencode-config/opencode.json`) already had these fields — only the laptop installer template was missing them.