### PR TITLE
fix: switch oh-my-opencode plugin to @f5xc-salesdemos/oh-my-openagent fork

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -431,8 +431,8 @@ RUN ghlatest() { curl -fsSL -o /dev/null -w '%{url_effective}' "https://github.c
       "https://github.com/neovim/neovim/releases/latest/download/nvim-linux-${NVIM_ARCH}.tar.gz" \
       | tar -xz -C /opt \
     && ln -s "/opt/nvim-linux-${NVIM_ARCH}/bin/nvim" /usr/local/bin/nvim \
-    # opencode (f5xc fork — install script handles arch detection)
-    && curl ${CURL_RETRY} -fsSL "https://raw.githubusercontent.com/f5xc-salesdemos/opencode/dev/install" \
+    # opencode (official upstream — install script handles arch detection)
+    && curl ${CURL_RETRY} -fsSL "https://opencode.ai/install" \
       | bash -s -- --no-modify-path \
     && ln -sf "$HOME/.opencode/bin/opencode" /usr/local/bin/opencode
 
@@ -1146,8 +1146,8 @@ RUN npx playwright install \
 RUN npm exec chrome-devtools-mcp@0.20.2 -- --version 2>/dev/null || true
 
 # oh-my-opencode (OpenCode plugin system — "ultrawork" / "ulw" command)
-# Build-time install uses upstream oh-my-opencode (needs platform binaries).
-# The forked runtime plugin is pre-installed so opencode skips download.
+# Build-time install uses upstream oh-my-opencode for config scaffolding.
+# The f5xc fork runtime plugin is pre-installed so opencode skips download.
 # hadolint ignore=DL3059
 RUN npx -y oh-my-opencode install --no-tui \
     --claude=max20 --openai=no --gemini=no --copilot=no \
@@ -1162,7 +1162,7 @@ RUN OPENCODE_CACHE="$HOME/.cache/opencode" \
     && printf '21' > "$OPENCODE_CACHE/version" \
     && printf '{"dependencies":{}}\n' > "$OPENCODE_CACHE/package.json" \
     && bun add --cwd "$OPENCODE_CACHE" --force --exact \
-        @robinmordasiewicz/oh-my-opencode@3.11.0-fork.3 \
+        @f5xc-salesdemos/oh-my-openagent@3.14.0-f5xc.5 \
         @ai-sdk/anthropic \
         @ai-sdk/openai-compatible \
         opencode-anthropic-auth@0.0.13

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -4,7 +4,7 @@
 > Launch `opencode`, paste the URL to this file, and OpenCode will execute each step.
 >
 > **Platform**: macOS on Apple Silicon (arm64). Homebrew is already installed.
-> OpenCode is already installed via `brew tap f5xc-salesdemos/tap && brew install f5xc-salesdemos/tap/opencode`.
+> OpenCode is already installed via `brew install anomalyco/tap/opencode`.
 >
 > **First-time setup**: If this is a fresh OpenCode install, you **must** complete Step 0 manually
 > before running `opencode run`. Step 0 grants the AI agent permission to access directories
@@ -1533,7 +1533,7 @@ The four packages are:
 
 | Package | Purpose |
 | ------- | ------- |
-| `@robinmordasiewicz/oh-my-opencode` | Oh-My-OpenCode plugin — multi-agent orchestration (Sisyphus, Oracle, Librarian, etc.) |
+| `@f5xc-salesdemos/oh-my-openagent` | Oh-My-OpenCode plugin — multi-agent orchestration (Sisyphus, Oracle, Librarian, etc.) |
 | `@ai-sdk/anthropic` | Vercel AI SDK provider for Anthropic models (Claude) |
 | `@ai-sdk/openai-compatible` | Vercel AI SDK provider for OpenAI-compatible proxy endpoints |
 | `opencode-anthropic-auth` | Authentication module for Anthropic API access |
@@ -1552,7 +1552,7 @@ Write the file `~/.cache/opencode/package.json` with the following content (vers
 ```json
 {
   "dependencies": {
-    "@robinmordasiewicz/oh-my-opencode": "3.11.0-fork.3",
+    "@f5xc-salesdemos/oh-my-openagent": "3.14.0-f5xc.5",
     "@ai-sdk/anthropic": "^3.0.64",
     "@ai-sdk/openai-compatible": "^2.0.37",
     "opencode-anthropic-auth": "0.0.13"
@@ -1571,7 +1571,7 @@ This populates `~/.cache/opencode/node_modules/` with the plugin and AI provider
 ### Verify Runtime Cache
 
 ```bash
-ls ~/.cache/opencode/node_modules/@robinmordasiewicz/oh-my-opencode/   # Expected: directory exists
+ls ~/.cache/opencode/node_modules/@f5xc-salesdemos/oh-my-openagent/     # Expected: directory exists
 ls ~/.cache/opencode/node_modules/@ai-sdk/anthropic/                   # Expected: directory exists
 ls ~/.cache/opencode/node_modules/@ai-sdk/openai-compatible/           # Expected: directory exists
 ls ~/.cache/opencode/node_modules/opencode-anthropic-auth/             # Expected: directory exists
@@ -2103,7 +2103,7 @@ if [ -n "$LITELLM_API_KEY" ] && [ -n "$LITELLM_BASE_URL" ]; then
   "small_model": "anthropic-proxy/claude-sonnet-4-6",
   "permission": "allow",
   "plugin": [
-    "@robinmordasiewicz/oh-my-opencode@3.11.0-fork.3"
+    "@f5xc-salesdemos/oh-my-openagent@3.14.0-f5xc.5"
   ],
   "lsp": {
     "marksman": { "command": ["marksman", "server"], "extensions": [".md", ".mdx"] },
@@ -2153,7 +2153,7 @@ elif [ -n "$CLAUDE_CODE_OAUTH_TOKEN" ]; then
       }
     }
   },
-  "plugin": ["opencode-claude-auth", "@robinmordasiewicz/oh-my-opencode@3.11.0-fork.3"],
+  "plugin": ["opencode-claude-auth", "@f5xc-salesdemos/oh-my-openagent@3.14.0-f5xc.5"],
   "mcp": {
     "chrome-devtools": {
       "type": "local",
@@ -2246,7 +2246,7 @@ if [ -n "$LITELLM_API_KEY" ] && [ -n "$LITELLM_BASE_URL" ]; then
   echo "Writing oh-my-opencode.json (proxy mode — multi-provider agents)..."
   cat > ~/.config/opencode/oh-my-opencode.json << 'ENDOFJSON'
 {
-  "$schema": "https://raw.githubusercontent.com/code-yeongyu/oh-my-opencode/master/assets/oh-my-opencode.schema.json",
+  "$schema": "https://raw.githubusercontent.com/code-yeongyu/oh-my-openagent/dev/assets/oh-my-opencode.schema.json",
   "agents": {
     "sisyphus": { "model": "anthropic-proxy/claude-opus-4-6" },
     "oracle": { "model": "anthropic-proxy/claude-opus-4-6" },
@@ -2294,7 +2294,7 @@ else
   echo "Writing oh-my-opencode.json (OAuth mode — Anthropic models only)..."
   cat > ~/.config/opencode/oh-my-opencode.json << 'ENDOFJSON'
 {
-  "$schema": "https://raw.githubusercontent.com/code-yeongyu/oh-my-opencode/master/assets/oh-my-opencode.schema.json",
+  "$schema": "https://raw.githubusercontent.com/code-yeongyu/oh-my-openagent/dev/assets/oh-my-opencode.schema.json",
   "agents": {
     "sisyphus": { "model": "anthropic/claude-opus-4-6" },
     "oracle": { "model": "anthropic/claude-opus-4-6" },
@@ -2773,7 +2773,7 @@ All files should exist and be owned by the current user.
 ### 16.8 — OpenCode Runtime Cache
 
 ```bash
-ls ~/.cache/opencode/node_modules/@robinmordasiewicz/oh-my-opencode/package.json  # Expected: file exists
+ls ~/.cache/opencode/node_modules/@f5xc-salesdemos/oh-my-openagent/package.json  # Expected: file exists
 ls ~/.cache/opencode/node_modules/@ai-sdk/anthropic/package.json                  # Expected: file exists
 ls ~/.cache/opencode/node_modules/@ai-sdk/openai-compatible/package.json          # Expected: file exists
 ls ~/.cache/opencode/node_modules/opencode-anthropic-auth/package.json            # Expected: file exists

--- a/opencode-config/oh-my-opencode-anthropic.json
+++ b/opencode-config/oh-my-opencode-anthropic.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/code-yeongyu/oh-my-opencode/master/assets/oh-my-opencode.schema.json",
+  "$schema": "https://raw.githubusercontent.com/code-yeongyu/oh-my-openagent/dev/assets/oh-my-opencode.schema.json",
   "agents": {
     "sisyphus": { "model": "anthropic/claude-opus-4-6" },
     "oracle": { "model": "anthropic/claude-opus-4-6" },

--- a/opencode-config/oh-my-opencode-proxy.json
+++ b/opencode-config/oh-my-opencode-proxy.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/code-yeongyu/oh-my-opencode/master/assets/oh-my-opencode.schema.json",
+  "$schema": "https://raw.githubusercontent.com/code-yeongyu/oh-my-openagent/dev/assets/oh-my-opencode.schema.json",
   "agents": {
     "sisyphus": { "model": "anthropic-proxy/claude-opus-4-6" },
     "oracle": { "model": "anthropic-proxy/claude-opus-4-6" },

--- a/opencode-config/opencode-anthropic.json
+++ b/opencode-config/opencode-anthropic.json
@@ -3,7 +3,7 @@
   "permission": "allow",
   "model": "anthropic/claude-opus-4-6",
   "small_model": "anthropic/claude-sonnet-4-6",
-  "plugin": ["opencode-claude-auth", "@robinmordasiewicz/oh-my-opencode@3.11.0-fork.3"],
+  "plugin": ["opencode-claude-auth", "@f5xc-salesdemos/oh-my-openagent@3.14.0-f5xc.5"],
   "mcp": {},
   "lsp": {
     "marksman": {

--- a/opencode-config/opencode.json
+++ b/opencode-config/opencode.json
@@ -71,7 +71,7 @@
   },
   "model": "anthropic-proxy/claude-opus-4-6",
   "small_model": "anthropic-proxy/claude-sonnet-4-6",
-  "plugin": ["@robinmordasiewicz/oh-my-opencode@3.11.0-fork.3"],
+  "plugin": ["@f5xc-salesdemos/oh-my-openagent@3.14.0-f5xc.5"],
   "mcp": {},
   "lsp": {
     "marksman": {


### PR DESCRIPTION
## Summary

Closes #729

- Switch the oh-my-opencode OpenCode plugin from the upstream `oh-my-opencode@3.14.0` to the f5xc fork `@f5xc-salesdemos/oh-my-openagent@3.14.0-f5xc.5` which includes bugfixes not yet upstream
- Revert the OpenCode binary installer to official upstream sources (`opencode.ai/install` for container, `anomalyco/tap` for macOS)
- Update schema URLs from `code-yeongyu/oh-my-opencode/master` to `code-yeongyu/oh-my-openagent/dev`

## Files Changed

- `Dockerfile` — bun cache package ref + comment update
- `INSTALL.md` — 6 package/path references updated
- `opencode-config/opencode.json` — plugin ref
- `opencode-config/opencode-anthropic.json` — plugin ref
- `opencode-config/oh-my-opencode-proxy.json` — schema URL
- `opencode-config/oh-my-opencode-anthropic.json` — schema URL

## Notes

- Config file names (`oh-my-opencode.json`) are unchanged — the fork preserves the same convention
- The `npx -y oh-my-opencode install` scaffolding step in Dockerfile still uses upstream (binary name is the same)
- The `bun add` cache step uses the fork so opencode loads the patched version at runtime