### PR TITLE
fix: add scripts/ to .dockerignore whitelist

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,4 +5,5 @@
 !codex-config/
 !pi-config/
 !.devcontainer/scripts/
+!scripts/
 !configs/


### PR DESCRIPTION
## Summary

Closes #730

Docker build fails on both amd64 and arm64 with:
```
"/scripts/nightly-update.sh": not found
```

The `.dockerignore` starts with `*` (exclude everything) then whitelists specific directories. `scripts/` was missing from the whitelist — only `.devcontainer/scripts/` was included.

## Fix

Add `!scripts/` to `.dockerignore`.