### PR TITLE
fix: chown entire .claude/ dir before USER switch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1093,7 +1093,7 @@ RUN CMEM_PKG=$(find /home/${USERNAME}/.claude/plugins/cache/thedotmack/claude-me
 RUN git clone --depth=1 --single-branch --branch main \
       https://github.com/zarazhangrui/frontend-slides.git \
       "/home/${USERNAME}/.claude/skills/frontend-slides" \
-    && chown -R ${USERNAME}:${USERNAME} "/home/${USERNAME}/.claude/skills"
+    && chown -R ${USERNAME}:${USERNAME} "/home/${USERNAME}/.claude"
 
 # ============================================================
 # 13. Playwright system dependencies (requires root for apt)


### PR DESCRIPTION
## Summary

Closes #732

Docker build fails at line 1114:
```
mkdir: cannot create directory '/home/vscode/.claude/plans': Permission denied
```

Root cause: `~/.claude` created as root at line 1060, but only `~/.claude/skills` was chowned to vscode at line 1096. Changed to `chown -R .claude` (the whole tree) so the vscode user can create subdirectories.