### PR TITLE
refactor: move OpenCode-used linters and formatters to INSTALL-opencode.md

### DIFF
--- a/INSTALL-devtools.md
+++ b/INSTALL-devtools.md
@@ -42,9 +42,8 @@ brew_install tree
 brew_install bat
 brew_install eza
 brew_install fzf
-brew_install yq
 brew_install poppler
-brew_install dos2unix
+brew_install tmux
 
 # Media tools
 brew_install ffmpeg
@@ -63,9 +62,8 @@ tree --version               # VERIFY: contains "tree v"
 bat --version                # VERIFY: starts with "bat"
 eza --version                # VERIFY: starts with "v"
 fzf --version                # VERIFY: a version number
-yq --version                 # VERIFY: "yq" followed by a version
 pdftotext -v 2>&1 | head -1 # VERIFY: contains "pdftotext version"
-dos2unix --version 2>&1 | head -1  # VERIFY: contains "dos2unix"
+tmux -V                      # VERIFY: tmux 3.x+
 ffmpeg -version | head -1    # VERIFY: starts with "ffmpeg version"
 yt-dlp --version             # VERIFY: a version string
 ```
@@ -131,15 +129,8 @@ terraform-docs --version # VERIFY: a version number
 ```bash
 brew_install hadolint
 brew_install actionlint
-brew_install yamllint
-brew_install codespell
 brew_install checkov
 brew_install zizmor
-brew_install prettier
-brew_install biome
-brew_install markdownlint-cli2
-brew_install editorconfig-checker
-brew_install taplo
 brew_install pre-commit
 ```
 
@@ -148,15 +139,8 @@ brew_install pre-commit
 ```bash
 hadolint --version               # VERIFY: "Haskell Dockerfile Linter"
 actionlint -version              # VERIFY: a version number
-yamllint --version               # VERIFY: starts with "yamllint"
-codespell --version              # VERIFY: starts with "codespell"
 checkov --version                # VERIFY: a version number
 zizmor --version                 # VERIFY: a version number
-prettier --version               # VERIFY: a version number
-biome --version                  # VERIFY: a version number
-markdownlint-cli2 --version     # VERIFY: a version number
-ec --version                     # VERIFY: a version number
-taplo --version                  # VERIFY: a version number
 pre-commit --version             # VERIFY: "pre-commit 4" or higher
 ```
 
@@ -342,7 +326,7 @@ curl --version | head -1
 bat --version
 eza --version
 fzf --version
-yq --version
+tmux -V
 
 # Runtimes
 python3 --version
@@ -358,18 +342,11 @@ gog --version
 tflint --version
 terraform-docs --version
 
-# Linters & scanners
+# Linters & scanners (CI-focused)
 hadolint --version
 actionlint -version
-yamllint --version
-codespell --version
 checkov --version
 zizmor --version
-prettier --version
-biome --version
-markdownlint-cli2 --version
-ec --version
-taplo --version
 pre-commit --version
 
 # Containers

--- a/INSTALL-opencode.md
+++ b/INSTALL-opencode.md
@@ -69,8 +69,15 @@ brew_install jq
 # GitHub CLI (used by opencode for PR/issue operations)
 brew_install gh
 
-# Terminal multiplexer (used by opencode for interactive sessions)
-brew_install tmux
+# Formatters and linters (used by opencode agents and LSP)
+brew_install yq
+brew_install dos2unix
+brew_install prettier
+brew_install biome
+brew_install markdownlint-cli2
+brew_install editorconfig-checker
+brew_install yamllint
+brew_install codespell
 
 # LSP servers (opencode auto-detects these on PATH)
 brew_install marksman
@@ -90,8 +97,15 @@ node --version         # VERIFY: v25.x+
 npm --version          # VERIFY: 11.x+
 rg --version           # VERIFY: contains "ripgrep"
 gh --version           # VERIFY: gh version 2.x+
-tmux -V                # VERIFY: tmux 3.x+
 jq --version           # VERIFY: jq-1.x+
+yq --version           # VERIFY: "yq" followed by a version
+dos2unix --version 2>&1 | head -1  # VERIFY: contains "dos2unix"
+prettier --version     # VERIFY: a version number
+biome --version        # VERIFY: a version number
+markdownlint-cli2 --version  # VERIFY: a version number
+ec --version           # VERIFY: a version number
+yamllint --version     # VERIFY: starts with "yamllint"
+codespell --version    # VERIFY: starts with "codespell"
 marksman --version     # VERIFY: prints a version string
 shellcheck --version   # VERIFY: version 0.10+
 shfmt --version        # VERIFY: v3.x+


### PR DESCRIPTION
Reorganize tool installation between the two install guides based on what actually depends on what.

**Moved to INSTALL-opencode.md** (OpenCode agents/LSP need these):
yq, dos2unix, prettier, biome, markdownlint-cli2, editorconfig-checker, yamllint, codespell

**Moved to INSTALL-devtools.md** (general-purpose, not OpenCode-specific):
tmux

**Kept in INSTALL-devtools.md** (CI-focused tools):
hadolint, actionlint, checkov, zizmor, pre-commit

Closes #751