### PR TITLE
fix: authenticated GitHub API with per_page=1 for opencode fork release

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -75,6 +75,8 @@ jobs:
           build-args: |
             BUILD_COMMIT=${{ github.sha }}
             BUILD_DATE=${{ steps.buildmeta.outputs.build_date }}
+          secrets: |
+            GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
           cache-from: type=registry,ref=${{ env.MAIN_IMAGE }}:cache-${{ matrix.cache-scope }}
           cache-to: type=registry,ref=${{ env.MAIN_IMAGE }}:cache-${{ matrix.cache-scope }},mode=max
           outputs: type=image,push-by-digest=true,name-canonical=true,push=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -433,13 +433,24 @@ RUN ghlatest() { curl -fsSL -o /dev/null -w '%{url_effective}' "https://github.c
     && curl ${CURL_RETRY} -fsSL \
       "https://github.com/neovim/neovim/releases/latest/download/nvim-linux-${NVIM_ARCH}.tar.gz" \
       | tar -xz -C /opt \
-    && ln -s "/opt/nvim-linux-${NVIM_ARCH}/bin/nvim" /usr/local/bin/nvim \
-    # opencode (f5xc fork — download pre-built binary from fork GitHub releases)
-    # The fork adds persistent footer with git status, LiteLLM fixes, etc.
-    # Resolves latest release tag and downloads the matching platform binary.
-    && OPENCODE_TAG=$(curl -fsSL "https://api.github.com/repos/f5xc-salesdemos/opencode/releases" \
+    && ln -s "/opt/nvim-linux-${NVIM_ARCH}/bin/nvim" /usr/local/bin/nvim
+
+# opencode (f5xc fork — pre-built binary from fork GitHub releases)
+# Separate RUN with --mount=type=secret for authenticated GitHub API.
+# Uses per_page=1 to fetch only the latest release (includes pre-releases).
+# Falls back to unauthenticated call for local builds without secrets.
+# hadolint ignore=DL3059
+RUN --mount=type=secret,id=GITHUB_TOKEN \
+    DPKG_ARCH=$(dpkg --print-architecture) \
+    && AUTH_HEADER="" \
+    && if [ -f /run/secrets/GITHUB_TOKEN ]; then \
+      AUTH_HEADER="Authorization: token $(cat /run/secrets/GITHUB_TOKEN)"; \
+    fi \
+    && OPENCODE_TAG=$(curl -fsSL ${AUTH_HEADER:+-H "$AUTH_HEADER"} \
+        "https://api.github.com/repos/f5xc-salesdemos/opencode/releases?per_page=1" \
         | grep -m1 '"tag_name"' | sed 's/.*"tag_name": *"//;s/".*//') \
     && if [ "$DPKG_ARCH" = "amd64" ]; then OC_PLATFORM="linux-x64"; else OC_PLATFORM="linux-arm64"; fi \
+    && echo "Installing opencode ${OPENCODE_TAG} for ${OC_PLATFORM}" \
     && curl ${CURL_RETRY} -fsSL \
         "https://github.com/f5xc-salesdemos/opencode/releases/download/${OPENCODE_TAG}/opencode-${OC_PLATFORM}.tar.gz" \
         | tar -xz -C /usr/local/bin opencode \


### PR DESCRIPTION
Fixes the Docker build failure downloading the opencode fork binary.

**Root cause chain:**
1. `/releases/latest` → skips pre-releases → resolves to old v1.2.27 → 404
2. `/releases` (full list) → curl exit 23 (SIGPIPE: grep -m1 closes pipe while curl streams large JSON)

**Fix:**
- Use `/releases?per_page=1` — returns only the most recent release (1 item, includes pre-releases)
- Pass `GITHUB_TOKEN` as Docker build secret via `--mount=type=secret` for authenticated API (5000 req/hr)
- Falls back to unauthenticated for local builds
- Separate `RUN` layer so the secret mount doesn't affect the other binary tools

Closes #753