### PR TITLE
fix: replace deprecated npm packages with modern equivalents

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -826,18 +826,16 @@ RUN npm install -g \
     puppeteer-extra-plugin-stealth \
     eslint \
     @biomejs/biome \
-    standard \
-    ts-standard \
     stylelint \
     htmlhint \
     textlint \
     textlint-rule-terminology \
     jscpd \
-    coffeelint \
+    @coffeelint/cli \
     npm-groovy-lint \
     @stoplight/spectral-cli \
-    gherkin-lint \
-    tekton-lint \
+    gplint \
+    @ibm/tekton-lint \
     asl-validator \
     renovate \
     markdownlint-cli \


### PR DESCRIPTION
Replaces 3 deprecated/archived npm packages with modern equivalents and removes 2 abandoned ones. These tools mirror super-linter for local pre-commit use.

## Changes

| Action | Old | New | Reason |
|--------|-----|-----|--------|
| REMOVE | `standard` | — | Locked to eslint 8, abandoned. eslint + biome cover both. |
| REMOVE | `ts-standard` | — | Same: eslint 8 only, last published Jul 2023 |
| REPLACE | `coffeelint` | `@coffeelint/cli` | Original archived 2018. Community fork matches super-linter. Same binary. |
| REPLACE | `gherkin-lint` | `gplint` | Pulls deprecated fstream + cucumber-messages. gplint is the active successor. |
| REPLACE | `tekton-lint` | `@ibm/tekton-lint` | Stale since 2022. IBM re-scoped, maintained v1.1.0. Same binary. |

## Deprecated deps eliminated

`inflight@1.0.6` (memory leak), `glob@6/7` (security vulns), `fstream@1.0.12`, `cucumber-messages@8`, `gherkin@9`, `eslint-config-standard-with-typescript@23`, `@humanwhocodes/object-schema`, `@humanwhocodes/config-array`, `rimraf@2/3`

Closes #757