### PR TITLE
fix: pre-create /home/linuxbrew as root for arm64 homebrew install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1241,6 +1241,10 @@ RUN if [ -f ~/.config/opencode/oh-my-opencode.json ]; then \
 ENV FORCE_AUTOUPDATE_PLUGINS=true
 ENV PATH="/home/vscode/.local/bin:${PATH}"
 
+USER root
+RUN mkdir -p /home/linuxbrew && chown ${USERNAME}:${USERNAME} /home/linuxbrew
+USER $USERNAME
+
 # hadolint ignore=DL3059
 RUN DPKG_ARCH=$(dpkg --print-architecture) && UNAME_ARCH=$(uname -m) \
     && if [ "$UNAME_ARCH" = "x86_64" ]; then AIR_ARCH="x86_64"; else AIR_ARCH="aarch64"; fi \


### PR DESCRIPTION
After #769 removed sudo, the arm64 Docker build fails at the linuxbrew install step:
```
mkdir: cannot create directory '/home/linuxbrew': Permission denied
```

Fix: Add a USER root block before the formatter RUN to pre-create `/home/linuxbrew` with vscode ownership. Only affects arm64 (the `else` branch uses linuxbrew for nixfmt/ormolu since they don't publish arm64 binaries).

Closes #774