### PR TITLE
fix: add missing plugins to settings.json enabledPlugins

### DIFF
--- a/claude-config/settings.json
+++ b/claude-config/settings.json
@@ -29,6 +29,7 @@
     "skill-creator@claude-plugins-official": true,
     "claude-code-setup@claude-plugins-official": true,
     "hookify@claude-plugins-official": true,
+    "commit-commands@claude-plugins-official": true,
     "f5xc-sales-engineer@f5xc-salesdemos-marketplace": true,
     "f5xc-docs-tools@f5xc-salesdemos-marketplace": true,
     "f5xc-github-ops@f5xc-salesdemos-marketplace": true,
@@ -36,6 +37,7 @@
     "f5xc-brand@f5xc-salesdemos-marketplace": true,
     "f5xc-devcontainer@f5xc-salesdemos-marketplace": true,
     "f5xc-platform@f5xc-salesdemos-marketplace": true,
+    "f5xc-meddpicc@f5xc-salesdemos-marketplace": true,
     "claude-mem@thedotmack": true
   },
   "env": {


### PR DESCRIPTION
Closes #786

## Summary

Plugin audit revealed two plugins present in `INSTALL-opencode.md`'s install loop but absent from `claude-config/settings.json` (which drives Dockerfile plugin installation via `install-plugins.sh`):

- `commit-commands@claude-plugins-official` — confirmed to exist in upstream `anthropics/claude-plugins-official` marketplace
- `f5xc-meddpicc@f5xc-salesdemos-marketplace` — exists in `f5xc-salesdemos/marketplace`

Without these entries in `settings.json`, `install-plugins.sh` would not install or enable these plugins in the container build.

## Changes

- `claude-config/settings.json`: Added `commit-commands@claude-plugins-official` and `f5xc-meddpicc@f5xc-salesdemos-marketplace` to `enabledPlugins`

## Verification

All 8 f5xc marketplace plugins and all intended official plugins are now consistently present in both `settings.json` and `INSTALL-opencode.md`.