### PR TITLE
fix: remove opinionated window/pane color overrides from tmux config

### DIFF
--- a/configs/.tmux.conf
+++ b/configs/.tmux.conf
@@ -72,12 +72,6 @@ bind -T copy-mode-vi y send-keys -X copy-selection-and-cancel
 set -g @plugin 'tmux-plugins/tpm'
 set -g @plugin 'tmux-plugins/tmux-sensible'
 
-# ── Appearance (VSCode Dark+ inspired) ────────────────────
-set -g window-active-style 'bg=colour235,fg=colour253'
-set -g window-style 'bg=colour235,fg=colour253'
-set -g pane-border-style 'bg=colour235,fg=colour59'
-set -g pane-active-border-style 'bg=colour235,fg=colour59'
-
 # ── Status bar ─────────────────────────────────────────────
 set -g status-position bottom
 set -g status-interval 5


### PR DESCRIPTION
## Summary

- Remove 4 opinionated color override lines from the "Appearance (VSCode Dark+ inspired)" section in `configs/.tmux.conf`
- These settings forced specific bg/fg colors on `window-style`, `window-active-style`, `pane-border-style`, and `pane-active-border-style`, overriding user terminal themes
- The blue statusline styling is preserved as intended

Closes #789

## Test plan

- [ ] CI checks pass
- [ ] tmux inherits terminal theme colors for windows and panes
- [ ] Statusline retains blue styling