### PR TITLE
feat: disable task toast notifications in opencode TUI

### DIFF
--- a/opencode-config/oh-my-opencode-anthropic.json
+++ b/opencode-config/oh-my-opencode-anthropic.json
@@ -25,11 +25,13 @@
     "unspecified-high": { "model": "anthropic/claude-opus-4-6" },
     "writing": { "model": "anthropic/claude-opus-4-6" }
   },
+  "disabled_hooks": ["startup-toast", "legacy-plugin-toast"],
   "background_task": {
     "defaultConcurrency": 5,
     "providerConcurrency": {
       "anthropic": 5
-    }
+    },
+    "task_toasts_enabled": false
   },
   "claude_code": {
     "plugins": true,

--- a/opencode-config/oh-my-opencode-proxy.json
+++ b/opencode-config/oh-my-opencode-proxy.json
@@ -25,12 +25,14 @@
     "unspecified-high": { "model": "anthropic-proxy/claude-opus-4-6" },
     "writing": { "model": "anthropic-proxy/claude-opus-4-6" }
   },
+  "disabled_hooks": ["startup-toast", "legacy-plugin-toast"],
   "background_task": {
     "defaultConcurrency": 5,
     "providerConcurrency": {
       "openai-proxy": 5,
       "anthropic-proxy": 5
-    }
+    },
+    "task_toasts_enabled": false
   },
   "claude_code": {
     "plugins": true,


### PR DESCRIPTION
## Summary

- Disable distracting task toast popups that fire on every agent subprocess spawn in the opencode TUI
- Add `disabled_hooks` for `startup-toast` and `legacy-plugin-toast` hooks
- Set `task_toasts_enabled: false` in `background_task` config for both anthropic and proxy variants
- Error toasts from opencode core (MCP failures, invalid models) are preserved

Closes #792

## Dependencies

Requires the `task_toasts_enabled` config flag to be applied to our oh-my-openagent fork:
- f5xc-salesdemos/oh-my-openagent#18 — Add `task_toasts_enabled` config flag
- f5xc-salesdemos/oh-my-openagent#19 — Document `disabled_hooks` usage

## Test plan

- [x] Unit tests pass in oh-my-openagent (4 new tests for the config flag)
- [x] UAT: Started opencode in container with changes — task toasts suppressed, error toasts preserved
- [ ] Full container rebuild with updated oh-my-openagent fork

🤖 Generated with [Claude Code](https://claude.com/claude-code)