### PR TITLE
feat: add f5xc TUI theme installation to laptop installer

### DIFF
--- a/INSTALL-opencode.md
+++ b/INSTALL-opencode.md
@@ -1001,13 +1001,32 @@ Write `~/.config/opencode/AGENTS.md`:
 
 ---
 
-## Step 11 — Write `tui.json`
+## Step 11 — Install F5XC TUI Theme
+
+The F5XC theme provides branded syntax highlighting and UI chrome for OpenCode's terminal interface.
+
+```bash
+mkdir -p ~/.config/opencode/themes
+curl -fsSL https://raw.githubusercontent.com/f5xc-salesdemos/xcsh-theme/main/tui/f5xc.json \
+  -o ~/.config/opencode/themes/f5xc.json
+```
+
+### Verify Step 11 — F5XC TUI Theme
+
+```bash
+jq '.name' ~/.config/opencode/themes/f5xc.json  # VERIFY: "F5XC"
+```
+
+---
+
+## Step 12 — Write `tui.json`
 
 Write `~/.config/opencode/tui.json`:
 
 ```json
 {
   "$schema": "https://opencode.ai/tui.json",
+  "theme": "f5xc",
   "scroll_acceleration": {
     "enabled": true
   }
@@ -1016,7 +1035,7 @@ Write `~/.config/opencode/tui.json`:
 
 ---
 
-## Step 12 — Write `.gitignore`
+## Step 13 — Write `.gitignore`
 
 Write `~/.config/opencode/.gitignore`:
 
@@ -1029,7 +1048,7 @@ bun.lock
 
 ---
 
-## Step 13 — Smoke-Test OpenCode Configuration
+## Step 14 — Smoke-Test OpenCode Configuration
 
 ```bash
 echo "Validating config file syntax..."
@@ -1084,7 +1103,7 @@ cd - > /dev/null
 
 ---
 
-## Step 14 — Configure `.zshrc` (OpenCode-Specific Entries)
+## Step 15 — Configure `.zshrc` (OpenCode-Specific Entries)
 
 These entries add OpenCode-specific environment variables and completions to `~/.zshrc`. They are appended idempotently using `grep -q` guards.
 
@@ -1116,11 +1135,13 @@ bun --version               # VERIFY: 1.3.x+
 # LSP servers on PATH
 which bash-language-server yaml-language-server marksman terraform-ls shellcheck shfmt pyright-langserver
 
-# OpenCode config files
+# OpenCode config files and theme
 ls -la ~/.config/opencode/opencode.json
 ls -la ~/.config/opencode/oh-my-opencode.json
 ls -la ~/.config/opencode/AGENTS.md
 ls -la ~/.config/opencode/tui.json
+ls -la ~/.config/opencode/themes/f5xc.json
+jq '.theme' ~/.config/opencode/tui.json          # Expected: "f5xc"
 ls -la ~/.config/opencode/package.json
 ls -la ~/.config/opencode/node_modules/@opencode-ai/plugin/
 


### PR DESCRIPTION
## Summary

- Add new Step 11 to download the F5XC TUI theme from `f5xc-salesdemos/xcsh-theme` repo
- Update `tui.json` to activate the theme with `"theme": "f5xc"`
- Renumber subsequent steps (12-15) and add theme verification to final checks
- Brings laptop installer to parity with the Dockerfile theme installation

Closes #803

## Test plan

- [ ] CI checks pass
- [ ] Follow INSTALL-opencode.md Step 11 on a clean machine and confirm `~/.config/opencode/themes/f5xc.json` is downloaded
- [ ] Verify `tui.json` includes `"theme": "f5xc"` after Step 12
- [ ] Confirm OpenCode TUI launches with the F5XC branded theme