### PR TITLE
feat: integrate Codex plugin fork and switch OpenCode to @ai-sdk/openai

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1215,11 +1215,15 @@ RUN PLUGIN_BASE="/home/${USERNAME}/.claude/plugins" \
     && git clone --depth=1 --single-branch --branch main \
         https://github.com/thedotmack/claude-mem.git \
         "${PLUGIN_BASE}/marketplaces/thedotmack" \
+    && git clone --depth=1 --single-branch --branch main \
+        https://github.com/f5xc-salesdemos/codex-plugin-cc.git \
+        "${PLUGIN_BASE}/marketplaces/openai-codex" \
     && TS="$(date -u +%Y-%m-%dT%H:%M:%S.000Z)" \
-    && printf '{"claude-plugins-official":{"source":{"source":"github","repo":"anthropics/claude-plugins-official"},"installLocation":"%s","lastUpdated":"%s","autoUpdate":true},"f5xc-salesdemos-marketplace":{"source":{"source":"github","repo":"f5xc-salesdemos/marketplace"},"installLocation":"%s","lastUpdated":"%s","autoUpdate":true},"thedotmack":{"source":{"source":"github","repo":"thedotmack/claude-mem"},"installLocation":"%s","lastUpdated":"%s","autoUpdate":false}}' \
+    && printf '{"claude-plugins-official":{"source":{"source":"github","repo":"anthropics/claude-plugins-official"},"installLocation":"%s","lastUpdated":"%s","autoUpdate":true},"f5xc-salesdemos-marketplace":{"source":{"source":"github","repo":"f5xc-salesdemos/marketplace"},"installLocation":"%s","lastUpdated":"%s","autoUpdate":true},"thedotmack":{"source":{"source":"github","repo":"thedotmack/claude-mem"},"installLocation":"%s","lastUpdated":"%s","autoUpdate":false},"openai-codex":{"source":{"source":"github","repo":"f5xc-salesdemos/codex-plugin-cc"},"installLocation":"%s","lastUpdated":"%s","autoUpdate":false}}' \
         "${PLUGIN_BASE}/marketplaces/claude-plugins-official" "$TS" \
         "${PLUGIN_BASE}/marketplaces/f5xc-salesdemos-marketplace" "$TS" \
         "${PLUGIN_BASE}/marketplaces/thedotmack" "$TS" \
+        "${PLUGIN_BASE}/marketplaces/openai-codex" "$TS" \
         > "${PLUGIN_BASE}/known_marketplaces.json" \
     && printf '{"fetchedAt":"%s","plugins":[]}' "$TS" \
         > "${PLUGIN_BASE}/blocklist.json" \
@@ -1322,7 +1326,7 @@ RUN OPENCODE_CACHE="$HOME/.cache/opencode" \
     && bun add --cwd "$OPENCODE_CACHE" --force \
         @f5xc-salesdemos/oh-my-openagent@f5xc \
         @ai-sdk/anthropic \
-        @ai-sdk/openai-compatible \
+        @ai-sdk/openai \
         opencode-anthropic-auth@0.0.13
 
 # Patch oh-my-opencode config in-place with claude_code integration flags

--- a/claude-config/settings.json
+++ b/claude-config/settings.json
@@ -38,7 +38,16 @@
     "f5xc-devcontainer@f5xc-salesdemos-marketplace": true,
     "f5xc-platform@f5xc-salesdemos-marketplace": true,
     "f5xc-meddpicc@f5xc-salesdemos-marketplace": true,
-    "claude-mem@thedotmack": true
+    "claude-mem@thedotmack": true,
+    "codex@openai-codex": true
+  },
+  "extraKnownMarketplaces": {
+    "openai-codex": {
+      "source": {
+        "source": "github",
+        "repo": "f5xc-salesdemos/codex-plugin-cc"
+      }
+    }
   },
   "env": {
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",

--- a/codex-config/config.toml
+++ b/codex-config/config.toml
@@ -1,5 +1,6 @@
 model = "gpt-5.4"
 model_provider = "litellm"
+sandbox_mode = "danger-full-access"
 
 [model_providers.litellm]
 name = "LiteLLM"

--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -33,7 +33,7 @@ When set, both Claude Code and OpenCode authenticate directly with Anthropic usi
 If your LiteLLM (or other) proxy already speaks the native Anthropic Messages API — including `web_search`, streaming, and tool use — set `LITELLM_BASE_URL` to the proxy domain. The container automatically derives the provider-specific URLs:
 
 - Anthropic endpoint → `${LITELLM_BASE_URL}/anthropic` (used by Claude Code)
-- OpenAI-compatible endpoint → `${LITELLM_BASE_URL}/api/v1` (used by OpenCode)
+- OpenAI-compatible endpoint → `${LITELLM_BASE_URL}/openai/v1` (used by OpenCode)
 
 | Variable | Description | Example |
 |----------|-------------|---------|

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -112,7 +112,7 @@ LITELLM_BASE_URL=https://your-litellm-endpoint.example.com
 LITELLM_API_KEY=your-api-key
 ```
 
-Set the domain only — the container derives provider-specific URL suffixes automatically (e.g. `/anthropic` for Claude Code, `/api/v1` for OpenCode).
+Set the domain only — the container derives provider-specific URL suffixes automatically (e.g. `/anthropic` for Claude Code, `/openai/v1` for OpenCode).
 
 ### Auto-populate from local credentials
 

--- a/opencode-config/opencode.json
+++ b/opencode-config/opencode.json
@@ -34,7 +34,7 @@
       }
     },
     "openai-proxy": {
-      "npm": "@ai-sdk/openai-compatible",
+      "npm": "@ai-sdk/openai",
       "name": "OpenAI Proxy",
       "options": {
         "baseURL": "{env:OPENAI_BASE_URL}",


### PR DESCRIPTION
## Summary

- Clone our Codex plugin fork (`f5xc-salesdemos/codex-plugin-cc`) at build time as a 4th marketplace, register it in `known_marketplaces.json`, and enable via `extraKnownMarketplaces` in `settings.json`. The fork carries API-key auth fallback and danger-full-access sandbox fixes not yet upstream.
- Switch OpenCode `openai-proxy` provider from `@ai-sdk/openai-compatible` to `@ai-sdk/openai` so it targets the `/v1/responses` (Responses API) endpoint that LiteLLM's `/openai` passthrough now natively supports.
- Add `sandbox_mode = "danger-full-access"` to `codex-config/config.toml` so the codex binary skips bubblewrap in containers.
- Fix two stale `/api/v1` endpoint references to `/openai/v1` in docs.

Closes #814

## Test plan

- [ ] CI checks pass (Dockerfile builds, linting, security scan)
- [ ] Codex plugin marketplace is cloned and registered during build
- [ ] OpenCode connects to LiteLLM via Responses API (`/v1/responses`)
- [ ] Codex runs without bubblewrap errors in devcontainer
- [ ] Docs references point to correct `/openai/v1` endpoint