### PR TITLE
feat: enhance Codex CLI configuration for frictionless container operation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1178,7 +1178,7 @@ RUN printf '#!/bin/sh\ncd /opt/caldera\nexec .venv/bin/python server.py --insecu
 # 12n. Hermes Agent (NousResearch — self-improving AI agent)
 #      Installed in /opt/hermes-agent using system Python 3.x
 #      (requires >=3.11; system Python 3.13 is compatible).
-#      Reads OPENAI_BASE_URL + OPENAI_API_KEY for LiteLLM proxy,
+#      Reads OPENAI_BASE_URL + OPENAI_API_KEY from ~/.hermes/.env,
 #      ANTHROPIC_TOKEN for Anthropic native auth.
 #      Config baked to ~/.hermes/config.yaml (section 17).
 # ============================================================
@@ -1434,6 +1434,7 @@ RUN ZSH_CUSTOM="${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}" \
     && echo '[[ ! -f ~/.p10k.zsh ]] || source ~/.p10k.zsh' >> "$HOME/.zshrc" \
     && echo 'export PATH="$HOME/.npm-global/bin:$PATH"' >> "$HOME/.zshrc" \
     && echo 'alias vim=nvim' >> "$HOME/.zshrc" \
+    && echo 'alias codex-exec="codex exec --skip-git-repo-check"' >> "$HOME/.zshrc" \
     && echo 'export LESS="-R -F -X -i -J --mouse"' >> "$HOME/.zshrc" \
     && echo 'export LESSHISTFILE="$HOME/.cache/lesshst"' >> "$HOME/.zshrc" \
     && echo 'export LESSOPEN="|~/.lessfilter %s"' >> "$HOME/.zshrc" \

--- a/codex-config/config.toml
+++ b/codex-config/config.toml
@@ -1,6 +1,12 @@
 model = "gpt-5.4"
 model_provider = "litellm"
 sandbox_mode = "danger-full-access"
+approval_policy = "never"
+web_search = "live"
+model_reasoning_effort = "high"
+personality = "pragmatic"
+hide_agent_reasoning = true
+service_tier = "fast"
 
 [model_providers.litellm]
 name = "LiteLLM"
@@ -11,3 +17,14 @@ query_params = {}
 
 [notice.model_migrations]
 "gpt-5.3-codex" = "gpt-5.4"
+
+[features]
+multi_agent = true
+shell_tool = true
+fast_mode = true
+
+[projects."/workspace"]
+trust_level = "trusted"
+
+[projects."/home/vscode"]
+trust_level = "trusted"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -108,8 +108,7 @@ if [ -n "$LITELLM_API_KEY" ]; then
   printf 'ANTHROPIC_API_KEY=%s\n' "$LITELLM_API_KEY" >"$HOME/.claude-mem/.env"
 fi
 if [ -n "$LITELLM_BASE_URL" ]; then
-  export OPENAI_BASE_URL="${LITELLM_BASE_URL}/openai/v1"
-  export OPENAI_API_BASE="${LITELLM_BASE_URL}/openai/v1"
+  _openai_base_url="${LITELLM_BASE_URL}/openai/v1"
   export ANTHROPIC_BASE_URL="${LITELLM_BASE_URL}/anthropic"
 fi
 
@@ -148,7 +147,7 @@ if [ -n "$CLAUDE_CODE_OAUTH_TOKEN" ]; then
 {"anthropic":{"type":"oauth","access":"${CLAUDE_CODE_OAUTH_TOKEN}","refresh":"","expires":9999999999999}}
 AUTHEOF
 elif [ -n "$LITELLM_API_KEY" ]; then
-  _esc_base_url=$(printf '%s' "$OPENAI_BASE_URL" | sed 's/[&\\/]/\\&/g')
+  _esc_base_url=$(printf '%s' "$_openai_base_url" | sed 's/[&\\/]/\\&/g')
   _esc_api_key=$(printf '%s' "$OPENAI_API_KEY" | sed 's/[&\\/]/\\&/g')
   _esc_anthropic_base_url=$(printf '%s' "$ANTHROPIC_BASE_URL" | sed 's/[&\\/]/\\&/g')
   _esc_anthropic_api_key=$(printf '%s' "$ANTHROPIC_API_KEY" | sed 's/[&\\/]/\\&/g')
@@ -174,7 +173,7 @@ HERMES_HOME_DIR="$HOME/.hermes"
 mkdir -p "$HERMES_HOME_DIR"
 if [ -n "$LITELLM_API_KEY" ]; then
   printf 'OPENAI_BASE_URL=%s\nOPENAI_API_KEY=%s\nLLM_MODEL=claude-opus-4-6\n' \
-    "$OPENAI_BASE_URL" "$OPENAI_API_KEY" \
+    "$_openai_base_url" "$OPENAI_API_KEY" \
     >"$HERMES_HOME_DIR/.env"
 elif [ -n "$CLAUDE_CODE_OAUTH_TOKEN" ]; then
   printf 'ANTHROPIC_TOKEN=%s\n' "$ANTHROPIC_OAUTH_TOKEN" \


### PR DESCRIPTION
## Summary

- Add autonomous operation settings to `codex-config/config.toml` (approval_policy, web_search, model_reasoning_effort, personality, feature flags, project trust)
- Replace global `OPENAI_BASE_URL` export with local variable in `entrypoint.sh` to silence Codex deprecation warning; remove redundant `OPENAI_API_BASE`
- Add `codex-exec` alias with `--skip-git-repo-check` in `Dockerfile`; update Hermes comment

Closes #817

## Test plan

- [ ] CI checks pass (lint, Dockerfile lint, shellcheck)
- [ ] Container builds successfully with new config
- [ ] Codex CLI starts without deprecation warning or interactive prompts
- [ ] `codex-exec` alias is available in shell