### PR TITLE
fix: chown /home/vscode/.cache before USER switch to fix claude install permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1254,6 +1254,10 @@ RUN git clone --depth=1 --single-branch --branch main \
 # hadolint ignore=DL3059
 RUN npx playwright install-deps
 
+# Fix ownership of dirs created by root under /home/vscode (e.g. .cache from playwright)
+# hadolint ignore=DL3059
+RUN chown -R ${USERNAME}:${USERNAME} /home/${USERNAME}/.cache
+
 # ============================================================
 # User setup
 # ============================================================


### PR DESCRIPTION
## Summary

- Fix EACCES permission error during `claude install --force` in Docker build
- Add `chown -R vscode:vscode /home/vscode/.cache` before the USER switch
- Root-owned `.cache` directory was created by Playwright chromium install, blocking Claude CLI setup

Closes #823

## Test plan

- [ ] CI checks pass (amd64 and arm64 Docker builds succeed)
- [ ] Build no longer fails at step 58/113 with EACCES on `/home/vscode/.cache/claude`