### PR TITLE
feat: rename oh-my-openagent references to oh-my-xcsh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1313,11 +1313,11 @@ USER $USERNAME
 # hadolint ignore=DL3059
 RUN npm exec chrome-devtools-mcp@0.20.2 -- --version 2>/dev/null || true
 
-# oh-my-opencode (OpenCode plugin system — "ultrawork" / "ulw" command)
-# Build-time install uses upstream oh-my-opencode for config scaffolding.
+# oh-my-xcsh (OpenCode plugin system — "ultrawork" / "ulw" command)
+# Build-time install uses upstream oh-my-xcsh for config scaffolding.
 # The f5xc fork runtime plugin is pre-installed so opencode skips download.
 # hadolint ignore=DL3059
-RUN npx -y oh-my-opencode install --no-tui \
+RUN npx -y oh-my-xcsh install --no-tui \
     --claude=max20 --openai=no --gemini=no --copilot=no \
     && rm -f ~/.config/opencode/*.bak.*
 # Pre-install npm packages into opencode's XDG cache so it skips
@@ -1330,15 +1330,15 @@ RUN OPENCODE_CACHE="$HOME/.cache/opencode" \
     && printf '21' > "$OPENCODE_CACHE/version" \
     && printf '{"dependencies":{}}\n' > "$OPENCODE_CACHE/package.json" \
     && bun add --cwd "$OPENCODE_CACHE" --force \
-        @f5xc-salesdemos/oh-my-openagent@f5xc \
+        @f5xc-salesdemos/oh-my-xcsh@f5xc \
         @ai-sdk/openai
 
-# Patch oh-my-opencode config in-place with claude_code integration flags
+# Patch oh-my-xcsh config in-place with claude_code integration flags
 # hadolint ignore=DL3059
-RUN if [ -f ~/.config/opencode/oh-my-opencode.json ]; then \
+RUN if [ -f ~/.config/opencode/oh-my-xcsh.json ]; then \
       jq '. + {"claude_code":{"plugins":true,"skills":true,"commands":true,"agents":true,"hooks":true,"mcp":true}}' \
-          ~/.config/opencode/oh-my-opencode.json > /tmp/omc-patched.json \
-      && mv /tmp/omc-patched.json ~/.config/opencode/oh-my-opencode.json; \
+          ~/.config/opencode/oh-my-xcsh.json > /tmp/omc-patched.json \
+      && mv /tmp/omc-patched.json ~/.config/opencode/oh-my-xcsh.json; \
     fi
 
 # ============================================================
@@ -1520,7 +1520,7 @@ COPY --chown=${USERNAME}:${USERNAME} claude-config/user-CLAUDE.md /home/${USERNA
 # --- OpenCode: bake config to final paths ---
 # Entrypoint substitutes env-var placeholders at runtime.
 COPY --chown=${USERNAME}:${USERNAME} opencode-config/opencode.json /home/${USERNAME}/.config/opencode/opencode.json
-COPY --chown=${USERNAME}:${USERNAME} opencode-config/oh-my-opencode-proxy.json /home/${USERNAME}/.config/opencode/oh-my-opencode-proxy.json
+COPY --chown=${USERNAME}:${USERNAME} opencode-config/oh-my-xcsh-proxy.json /home/${USERNAME}/.config/opencode/oh-my-xcsh-proxy.json
 COPY --chown=${USERNAME}:${USERNAME} opencode-config/opencode-permissions.json /home/${USERNAME}/.opencode/opencode.json
 
 

--- a/INSTALL-opencode.md
+++ b/INSTALL-opencode.md
@@ -579,7 +579,7 @@ Write `~/.cache/opencode/package.json`:
 ```json
 {
   "dependencies": {
-    "@f5xc-salesdemos/oh-my-openagent": "f5xc",
+    "@f5xc-salesdemos/oh-my-xcsh": "f5xc",
     "@ai-sdk/openai-compatible": "^2.0.37"
   }
 }
@@ -592,7 +592,7 @@ Write `~/.cache/opencode/package.json`:
 ### Verify Runtime Cache
 
 ```bash
-ls ~/.cache/opencode/node_modules/@f5xc-salesdemos/oh-my-openagent/     # Expected: directory exists
+ls ~/.cache/opencode/node_modules/@f5xc-salesdemos/oh-my-xcsh/     # Expected: directory exists
 ls ~/.cache/opencode/node_modules/@ai-sdk/openai-compatible/           # Expected: directory exists
 ```
 
@@ -773,7 +773,7 @@ if [ -n "$LITELLM_API_KEY" ] && [ -n "$LITELLM_BASE_URL" ]; then
   "model": "openai-proxy/gpt-5.4",
   "small_model": "openai-proxy/gpt-5.4",
   "permission": "allow",
-  "plugin": ["@f5xc-salesdemos/oh-my-openagent@f5xc"],
+  "plugin": ["@f5xc-salesdemos/oh-my-xcsh@f5xc"],
   "lsp": {
     "marksman": { "command": ["marksman", "server"], "extensions": [".md", ".mdx"] },
     "mdx": { "command": ["mdx-language-server", "--stdio"], "extensions": [".mdx"] },
@@ -794,13 +794,13 @@ fi
 
 ---
 
-## Step 9 — Write `oh-my-opencode.json`
+## Step 9 — Write `oh-my-xcsh.json`
 
 ```bash
-echo "Writing oh-my-opencode.json (OpenAI proxy — optimized with variant settings)..."
-cat > ~/.config/opencode/oh-my-opencode.json << 'ENDOFJSON'
+echo "Writing oh-my-xcsh.json (OpenAI proxy — optimized with variant settings)..."
+cat > ~/.config/opencode/oh-my-xcsh.json << 'ENDOFJSON'
 {
-  "$schema": "https://raw.githubusercontent.com/code-yeongyu/oh-my-openagent/dev/assets/oh-my-opencode.schema.json",
+  "$schema": "https://raw.githubusercontent.com/f5xc-salesdemos/oh-my-xcsh/dev/assets/oh-my-xcsh.schema.json",
   "agents": {
     "sisyphus": { "model": "openai-proxy/gpt-5.4", "color": "#e4002b", "variant": "high" },
     "oracle": { "model": "openai-proxy/gpt-5.4", "color": "#e4002b", "variant": "high" },
@@ -884,7 +884,7 @@ bun.lock
 
 ```bash
 echo "Validating config file syntax..."
-for f in opencode.json oh-my-opencode.json; do
+for f in opencode.json oh-my-xcsh.json; do
   if ! jq . "$HOME/.config/opencode/$f" > /dev/null 2>&1; then
     echo "ERROR: $f is not valid JSON."
     exit 1
@@ -969,13 +969,13 @@ which bash-language-server yaml-language-server marksman terraform-ls shellcheck
 
 # OpenCode config files
 ls -la ~/.config/opencode/opencode.json
-ls -la ~/.config/opencode/oh-my-opencode.json
+ls -la ~/.config/opencode/oh-my-xcsh.json
 ls -la ~/.config/opencode/AGENTS.md
 ls -la ~/.config/opencode/package.json
 ls -la ~/.config/opencode/node_modules/@opencode-ai/plugin/
 
 # Runtime cache
-ls ~/.cache/opencode/node_modules/@f5xc-salesdemos/oh-my-openagent/package.json
+ls ~/.cache/opencode/node_modules/@f5xc-salesdemos/oh-my-xcsh/package.json
 ls ~/.cache/opencode/node_modules/@ai-sdk/openai-compatible/package.json
 
 # Claude Code plugins

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -154,8 +154,8 @@ if [ -n "$LITELLM_API_KEY" ]; then
     >"$OPENCODE_CONFIG_DIR/opencode.json.tmp" &&
     mv "$OPENCODE_CONFIG_DIR/opencode.json.tmp" "$OPENCODE_CONFIG_DIR/opencode.json"
   unset _esc_base_url _esc_api_key
-  cp "$OPENCODE_CONFIG_DIR/oh-my-opencode-proxy.json" \
-    "$OPENCODE_CONFIG_DIR/oh-my-opencode.json"
+  cp "$OPENCODE_CONFIG_DIR/oh-my-xcsh-proxy.json" \
+    "$OPENCODE_CONFIG_DIR/oh-my-xcsh.json"
 fi
 
 # ============================================================

--- a/opencode-config/oh-my-xcsh-proxy.json
+++ b/opencode-config/oh-my-xcsh-proxy.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/code-yeongyu/oh-my-openagent/dev/assets/oh-my-opencode.schema.json",
+  "$schema": "https://raw.githubusercontent.com/f5xc-salesdemos/oh-my-xcsh/dev/assets/oh-my-opencode.schema.json",
   "agents": {
     "sisyphus": { "model": "openai-proxy/gpt-5.4", "color": "#e4002b", "variant": "high" },
     "oracle": { "model": "openai-proxy/gpt-5.4", "color": "#e4002b", "variant": "high" },

--- a/opencode-config/opencode.json
+++ b/opencode-config/opencode.json
@@ -28,7 +28,7 @@
   },
   "model": "openai-proxy/gpt-5.4",
   "small_model": "openai-proxy/gpt-5.4",
-  "plugin": ["@f5xc-salesdemos/oh-my-openagent@f5xc"],
+  "plugin": ["@f5xc-salesdemos/oh-my-xcsh@f5xc"],
   "mcp": {},
   "lsp": {
     "marksman": {


### PR DESCRIPTION
Closes #836

## Summary
- Renames all `oh-my-openagent` and `oh-my-opencode` references to `oh-my-xcsh` after the fork rename
- Plugin entry: `@f5xc-salesdemos/oh-my-openagent@f5xc` → `@f5xc-salesdemos/oh-my-xcsh@f5xc`
- Config file: `oh-my-opencode-proxy.json` → `oh-my-xcsh-proxy.json`
- Dockerfile install commands, config paths, and documentation updated

## Context
The `f5xc-salesdemos/oh-my-openagent` fork has been renamed to `f5xc-salesdemos/oh-my-xcsh` to avoid name collisions with the upstream `oh-my-openagent` package. Downstream users can now install both side-by-side.

## Test plan
- [ ] Verify container builds successfully with new package references
- [ ] Verify `opencode` starts and loads the `oh-my-xcsh` plugin correctly
- [ ] Verify entrypoint.sh copies the renamed proxy config file

🤖 Generated with [Claude Code](https://claude.com/claude-code)