### PR TITLE
fix: use published NPM packages until oh-my-xcsh is available

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1323,10 +1323,11 @@ USER $USERNAME
 RUN npm exec chrome-devtools-mcp@0.20.2 -- --version 2>/dev/null || true
 
 # oh-my-xcsh (OpenCode plugin system — "ultrawork" / "ulw" command)
-# Build-time install uses upstream oh-my-xcsh for config scaffolding.
+# Build-time install uses upstream oh-my-opencode for config scaffolding
+# (oh-my-xcsh not yet published to NPM; scaffolding is identical).
 # The f5xc fork runtime plugin is pre-installed so opencode skips download.
 # hadolint ignore=DL3059
-RUN npx -y oh-my-xcsh install --no-tui \
+RUN npx -y oh-my-opencode install --no-tui \
     --claude=max20 --openai=no --gemini=no --copilot=no \
     && rm -f ~/.config/opencode/*.bak.*
 # Pre-install npm packages into opencode's XDG cache so it skips
@@ -1339,15 +1340,16 @@ RUN OPENCODE_CACHE="$HOME/.cache/opencode" \
     && printf '21' > "$OPENCODE_CACHE/version" \
     && printf '{"dependencies":{}}\n' > "$OPENCODE_CACHE/package.json" \
     && bun add --cwd "$OPENCODE_CACHE" --force \
-        @f5xc-salesdemos/oh-my-xcsh@f5xc \
+        @f5xc-salesdemos/oh-my-openagent@f5xc \
         @ai-sdk/openai
 
-# Patch oh-my-xcsh config in-place with claude_code integration flags
+# Patch oh-my-opencode config in-place with claude_code integration flags
+# (scaffolding creates oh-my-opencode.json; entrypoint overwrites with oh-my-xcsh.json at runtime)
 # hadolint ignore=DL3059
-RUN if [ -f ~/.config/opencode/oh-my-xcsh.json ]; then \
+RUN if [ -f ~/.config/opencode/oh-my-opencode.json ]; then \
       jq '. + {"claude_code":{"plugins":true,"skills":true,"commands":true,"agents":true,"hooks":true,"mcp":true}}' \
-          ~/.config/opencode/oh-my-xcsh.json > /tmp/omc-patched.json \
-      && mv /tmp/omc-patched.json ~/.config/opencode/oh-my-xcsh.json; \
+          ~/.config/opencode/oh-my-opencode.json > /tmp/omc-patched.json \
+      && mv /tmp/omc-patched.json ~/.config/opencode/oh-my-opencode.json; \
     fi
 
 # ============================================================

--- a/opencode-config/opencode.json
+++ b/opencode-config/opencode.json
@@ -28,7 +28,7 @@
   },
   "model": "openai-proxy/gpt-5.4",
   "small_model": "openai-proxy/gpt-5.4",
-  "plugin": ["@f5xc-salesdemos/oh-my-xcsh@f5xc"],
+  "plugin": ["@f5xc-salesdemos/oh-my-openagent@f5xc"],
   "mcp": {},
   "lsp": {
     "marksman": {


### PR DESCRIPTION
Closes #837

## Summary
- Revert Dockerfile scaffolding from `oh-my-xcsh` to `oh-my-opencode` (published upstream)
- Revert fork plugin from `@f5xc-salesdemos/oh-my-xcsh@f5xc` to `@f5xc-salesdemos/oh-my-openagent@f5xc` (published)
- Config patching targets `oh-my-opencode.json` (what scaffolding creates)
- Entrypoint still uses `oh-my-xcsh-proxy.json` → `oh-my-xcsh.json` at runtime

## Context
Docker Publish failed because `oh-my-xcsh` and `@f5xc-salesdemos/oh-my-xcsh` are not yet published to NPM. This fix uses the existing published packages while preserving the runtime config rename.

## Test plan
- [ ] Docker Publish CI passes for both amd64 and arm64

🤖 Generated with [Claude Code](https://claude.com/claude-code)