### PR TITLE
refactor: update references for xcsh clean break rename

### DIFF
--- a/INSTALL-xcsh.md
+++ b/INSTALL-xcsh.md
@@ -27,7 +27,7 @@ if ! jq -e '
   echo ""
   echo '  mkdir -p ~/.config/xcsh'
   echo '  cat > ~/.config/xcsh/xcsh.json << '"'"'EOF'"'"''
-  echo '  { "$schema": "https://opencode.ai/config.json", "permission": "allow" }'
+  echo '  { "$schema": "https://f5xc-salesdemos.github.io/xcsh/config.json", "permission": "allow" }'
   echo '  EOF'
   echo ""
   exit 1
@@ -558,7 +558,7 @@ Write `~/.config/xcsh/package.json`:
 ```json
 {
   "dependencies": {
-    "@opencode-ai/plugin": "^1.3.3"
+    "@f5xc-salesdemos/plugin": "^1.3.3"
   }
 }
 ```
@@ -737,7 +737,7 @@ if [ -n "$LITELLM_API_KEY" ] && [ -n "$LITELLM_BASE_URL" ]; then
   echo "Writing xcsh.json (LiteLLM proxy mode — OpenAI only)..."
   cat > ~/.config/xcsh/xcsh.json << ENDOFJSON
 {
-  "\$schema": "https://opencode.ai/config.json",
+  "\$schema": "https://f5xc-salesdemos.github.io/xcsh/config.json",
   "mcp": {
     "chrome-devtools": {
       "type": "local",
@@ -972,7 +972,7 @@ ls -la ~/.config/xcsh/xcsh.json
 ls -la ~/.config/xcsh/oh-my-xcsh.json
 ls -la ~/.config/xcsh/AGENTS.md
 ls -la ~/.config/xcsh/package.json
-ls -la ~/.config/xcsh/node_modules/@opencode-ai/plugin/
+ls -la ~/.config/xcsh/node_modules/@f5xc-salesdemos/plugin/
 
 # Runtime cache
 ls ~/.cache/xcsh/node_modules/@f5xc-salesdemos/oh-my-xcsh/package.json

--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -57,7 +57,7 @@ This is **not recommended** for production use. Only set this when you trust the
 
 ### xcsh
 
-The container automatically configures [xcsh](https://opencode.ai/) (our fork of OpenCode) based on which credentials are available. OAuth mode takes priority when both are set.
+The container automatically configures [xcsh](https://github.com/f5xc-salesdemos/xcsh) based on which credentials are available. OAuth mode takes priority when both are set.
 
 #### OAuth mode (Claude Max)
 
@@ -89,7 +89,7 @@ The container includes several AI coding agents in addition to Claude Code:
 
 | Agent | Command | Provider |
 |-------|---------|----------|
-| [xcsh](https://opencode.ai/) | `xcsh` | Anthropic (OAuth) or OpenAI-compatible (proxy) |
+| [xcsh](https://github.com/f5xc-salesdemos/xcsh) | `xcsh` | Anthropic (OAuth) or OpenAI-compatible (proxy) |
 | [Codex](https://github.com/openai/codex) | `codex` | OpenAI-compatible |
 | [Aider](https://aider.chat/) | `aider` | Multi-provider (configure at runtime) |
 | [Pi](https://github.com/mariozechner/pi-coding-agent) | `pi` | Multi-provider (configure at runtime) |

--- a/xcsh-config/xcsh-permissions.json
+++ b/xcsh-config/xcsh-permissions.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://f5xc-salesdemos.github.io/xcsh/config.json",
   "permission": {
     "read": {
       "*": "allow",

--- a/xcsh-config/xcsh.json
+++ b/xcsh-config/xcsh.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://f5xc-salesdemos.github.io/xcsh/config.json",
   "provider": {
     "openai-proxy": {
       "npm": "@ai-sdk/openai",


### PR DESCRIPTION
## Summary

Closes #842

- Update `$schema` URLs from `opencode.ai` → `f5xc-salesdemos.github.io/xcsh` in `xcsh-config/xcsh.json` and `xcsh-config/xcsh-permissions.json`
- Update `@opencode-ai/plugin` → `@f5xc-salesdemos/plugin` in `INSTALL-xcsh.md`
- Update `docs/configuration.mdx` links to point to new xcsh GitHub repo

## Test plan

- [ ] Container builds successfully
- [ ] Super-linter passes
- [ ] Schema URLs resolve (once GitHub Pages deployed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)