### PR TITLE
feat: enable pyright-lsp plugin for Python code intelligence

### DIFF
--- a/claude-config/settings.json
+++ b/claude-config/settings.json
@@ -23,6 +23,7 @@
     "feature-dev@claude-plugins-official": true,
     "ralph-loop@claude-plugins-official": true,
     "typescript-lsp@claude-plugins-official": true,
+    "pyright-lsp@claude-plugins-official": true,
     "security-guidance@claude-plugins-official": true,
     "claude-md-management@claude-plugins-official": true,
     "pr-review-toolkit@claude-plugins-official": true,


### PR DESCRIPTION
## Summary

- Enable the `pyright-lsp@claude-plugins-official` plugin in `claude-config/settings.json`
- Pyright npm package is already installed in the Dockerfile; this activates the Claude Code LSP plugin so Python files get type checking and code intelligence

Closes #843

## Test plan

- [ ] CI checks pass
- [ ] Verify `pyright-lsp@claude-plugins-official` appears in `enabledPlugins` in settings.json
- [ ] Confirm Claude Code sessions in the devcontainer have Python LSP support via the LSP tool