### PR TITLE
fix: restore rustup permissions at container startup

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,6 +3,12 @@
 # Configure user environment (env-var-dependent only)
 # ============================================================
 
+# Ensure Rust toolchain dirs are writable (Dockerfile chown can be
+# lost by layer caching or volume mounts).
+if [ -d /usr/local/rustup ] && [ ! -w /usr/local/rustup ]; then
+  sudo chown -R "$(id -u):$(id -g)" /usr/local/rustup /usr/local/cargo 2>/dev/null || true
+fi
+
 if [ -n "$GIT_AUTHOR_NAME" ]; then
   git config --global user.name "$GIT_AUTHOR_NAME"
   export GIT_COMMITTER_NAME="${GIT_COMMITTER_NAME:-$GIT_AUTHOR_NAME}"


### PR DESCRIPTION
Closes #880

## Summary

- Add defensive permission fixup to `entrypoint.sh` that restores `/usr/local/rustup` and `/usr/local/cargo` ownership to the vscode user if they are not writable
- Fixes rust-analyzer LSP startup failure in xcsh caused by root-owned rustup directories

## Root Cause

The Dockerfile correctly runs `chown -R vscode:vscode /usr/local/rustup /usr/local/cargo` at build time, but layer caching or volume mounts can reset ownership to root. When xcsh launches rust-analyzer, it reads `rust-toolchain.toml` and tries to sync the nightly toolchain, which fails with `Permission denied` when writing to `/usr/local/rustup/tmp/`.

## Test plan

- [x] Verified on running container: `stat` shows `root:root` ownership before fix
- [x] After running fixup: ownership changes to `vscode:vscode`
- [x] `rust-analyzer --version` succeeds
- [x] `rustup show` syncs nightly toolchain without permission errors
- [x] Shell lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)