### PR TITLE
fix: pre-start claude-mem worker in entrypoint to eliminate SessionStart hook errors

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -477,6 +477,33 @@ if [ -f "$SETTINGS" ] && [ -f "$TEMPLATE" ] && command -v jq >/dev/null 2>&1; th
 fi
 
 # ============================================================
+# claude-mem worker pre-start (issue #882b)
+# Start the claude-mem worker early so it is healthy before
+# Claude Code's SessionStart hooks fire.  The plugin's hooks
+# poll localhost:37777/health with an 8-second timeout — on a
+# cold start this is not enough time, producing two
+# "SessionStart:startup hook error" warnings.  Pre-starting
+# the worker here (after fuser killed stale instances and
+# after plugin permissions are fixed) eliminates the race.
+# The subsequent Firecrawl / Chrome startup provides 10-15 s
+# of natural delay before the user starts Claude Code.
+# ============================================================
+_CMEM_ROOT=$(find "$HOME/.claude/plugins/cache/thedotmack/claude-mem" -maxdepth 1 -type d -name '[0-9]*' 2>/dev/null | sort -V | tail -1)
+if [ -n "$_CMEM_ROOT" ] && [ -f "$_CMEM_ROOT/scripts/worker-service.cjs" ]; then
+  node "$_CMEM_ROOT/scripts/bun-runner.js" \
+       "$_CMEM_ROOT/scripts/worker-service.cjs" start >/dev/null 2>&1 &
+  # Brief background wait — don't block entrypoint, but give the worker
+  # a head start.  Remaining startup steps provide additional delay.
+  (
+    for _i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15; do
+      curl -sf http://localhost:37777/health >/dev/null 2>&1 && break
+      sleep 1
+    done
+  ) &
+fi
+unset _CMEM_ROOT
+
+# ============================================================
 # Firecrawl — self-hosted web scraper
 # API on port 3002, Playwright on port 3000.
 # Infrastructure: Redis, PostgreSQL, RabbitMQ.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -491,7 +491,7 @@ fi
 _CMEM_ROOT=$(find "$HOME/.claude/plugins/cache/thedotmack/claude-mem" -maxdepth 1 -type d -name '[0-9]*' 2>/dev/null | sort -V | tail -1)
 if [ -n "$_CMEM_ROOT" ] && [ -f "$_CMEM_ROOT/scripts/worker-service.cjs" ]; then
   node "$_CMEM_ROOT/scripts/bun-runner.js" \
-       "$_CMEM_ROOT/scripts/worker-service.cjs" start >/dev/null 2>&1 &
+    "$_CMEM_ROOT/scripts/worker-service.cjs" start >/dev/null 2>&1 &
   # Brief background wait — don't block entrypoint, but give the worker
   # a head start.  Remaining startup steps provide additional delay.
   (


### PR DESCRIPTION
## Summary

- Pre-start the claude-mem worker process in `entrypoint.sh` before Claude Code launches, so the health endpoint on port 37777 is ready before SessionStart hooks fire
- The plugin's hooks poll with an 8-second timeout which is insufficient for cold starts, producing two "SessionStart:startup hook error" warnings
- A background health-check loop (up to 15 seconds) gives the worker a head start without blocking the rest of entrypoint startup

Closes #883

## Test plan

- [ ] CI checks pass
- [ ] Build devcontainer and verify claude-mem worker is running on port 37777 before Claude Code starts
- [ ] Confirm no "SessionStart:startup hook error" warnings appear on first Claude Code launch