### PR TITLE
fix: add libcairo2-dev to apt deps for OSINT pip install (pycairo build)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -86,7 +86,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # hadolint ignore=DL3008
 RUN apt-get update && apt-get install -y --no-install-recommends \
     # System essentials
-    build-essential pkg-config libssl-dev libffi-dev cmake lld \
+    build-essential pkg-config libssl-dev libffi-dev libcairo2-dev cmake lld \
     # Media / utilities
     ffmpeg poppler-utils qrencode \
     # Network tools


### PR DESCRIPTION
## Summary

- Add `libcairo2-dev` to the system essentials apt-get install line in the Dockerfile
- The OSINT pip install step (section 12a) transitively requires pycairo via `maigret -> xhtml2pdf -> svglib -> rlpycairo -> pycairo`, and building pycairo from source needs the cairo C headers
- Without this package, the Docker Publish workflow fails on both amd64 and arm64

Closes #885

## Test plan

- [ ] CI checks pass (Check linked issues, Lint Code Base)
- [ ] Docker Publish workflow succeeds on both amd64 and arm64
- [ ] OSINT pip install step completes without pycairo build errors