### PR TITLE
fix: add retry logic to claude install for CDN 429 rate limits

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1307,8 +1307,14 @@ RUN ln -s /home/vscode/.bun/bin/bun /usr/local/bin/bun \
 USER $USERNAME
 
 # Install native Claude Code binary (replaces npm package)
+# Retry up to 4 times with exponential back-off to handle transient
+# CDN 429 rate-limit responses during parallel multi-arch builds.
 # hadolint ignore=DL3059
-RUN claude install --force
+RUN for attempt in 1 2 3 4; do \
+      claude install --force && break; \
+      echo "claude install attempt $attempt failed, retrying in $((attempt * 15))s..."; \
+      sleep "$((attempt * 15))"; \
+    done
 USER root
 RUN npm uninstall -g @anthropic-ai/claude-code
 USER $USERNAME


### PR DESCRIPTION
## Summary

- Add retry loop with exponential back-off (15s, 30s, 45s, 60s) to the `claude install --force` RUN step in the Dockerfile
- Handles transient CDN 429 rate-limit responses during parallel multi-arch builds (amd64/arm64)
- Prevents Docker Publish workflow failures caused by simultaneous CDN hits

Closes #887

## Test plan

- [x] hadolint passes (pre-commit Dockerfile lint)
- [ ] CI checks pass
- [ ] Docker Publish workflow succeeds on next build