### PR TITLE
fix: extend hook neutralization to cache directory for complete coverage

### DIFF
--- a/claude-config/install-plugins.sh
+++ b/claude-config/install-plugins.sh
@@ -230,3 +230,32 @@ while IFS= read -r HF; do
   echo '{}' >"$HF" 2>/dev/null || true
   chmod 444 "$HF" 2>/dev/null || true
 done < <(find "${PLUGIN_BASE}/marketplaces" -name "hooks.json" 2>/dev/null)
+
+# Third pass: neutralize cache-level hooks.json for non-enabled plugins.
+# Claude Code reads hooks from installed_plugins.json -> installPath which
+# always points to cache/<mkt>/<name>/<version>/hooks/hooks.json.
+for CHF in "${PLUGIN_BASE}/cache"/*/*/*/hooks/hooks.json; do
+  [ -f "$CHF" ] || continue
+  RELATIVE="${CHF#"${PLUGIN_BASE}"/cache/}"
+  C_MKT="${RELATIVE%%/*}"
+  C_NAME="${RELATIVE#*/}"
+  C_NAME="${C_NAME%%/*}"
+  C_KEY="${C_NAME}@${C_MKT}"
+  CHD=$(dirname "$CHF")
+
+  if jq -e --arg k "$C_KEY" '.enabledPlugins[$k]' "$SETTINGS" >/dev/null 2>&1; then
+    continue
+  fi
+
+  C_CURRENT=$(cat "$CHF" 2>/dev/null || true)
+  if [ "$C_CURRENT" = "{}" ]; then
+    chmod 755 "$CHD" 2>/dev/null || true
+    chmod 444 "$CHF" 2>/dev/null || true
+    continue
+  fi
+
+  chmod 755 "$CHD" 2>/dev/null || true
+  chmod 644 "$CHF" 2>/dev/null || true
+  echo '{}' >"$CHF" 2>/dev/null || true
+  chmod 444 "$CHF" 2>/dev/null || true
+done

--- a/claude-config/neutralize-hooks.sh
+++ b/claude-config/neutralize-hooks.sh
@@ -119,5 +119,38 @@ while IFS= read -r hf; do
   chmod 444 "$hf" 2>/dev/null || true
 done < <(find "$PLUGIN_BASE/marketplaces" -name "hooks.json" 2>/dev/null)
 
+# ── 5. Neutralize cache-level hooks.json for non-enabled plugins ──────────
+# Claude Code reads hooks from installed_plugins.json -> installPath which
+# always points to cache/<mkt>/<name>/<version>/hooks/hooks.json.  For
+# plugins whose marketplace dir is a real directory (not a symlink to cache),
+# the marketplace passes above do NOT neutralize the cache copy.
+for hf in "$PLUGIN_BASE"/cache/*/*/*/hooks/hooks.json; do
+  [ -f "$hf" ] || continue
+  relative="${hf#"${PLUGIN_BASE}"/cache/}"
+  c_mkt="${relative%%/*}"
+  c_name="${relative#*/}"
+  c_name="${c_name%%/*}"
+  c_key="${c_name}@${c_mkt}"
+  hd=$(dirname "$hf")
+
+  if jq -e --arg k "$c_key" '.enabledPlugins[$k]' "$SETTINGS" >/dev/null 2>&1; then
+    chmod 755 "$hd" 2>/dev/null || true
+    chmod 644 "$hf" 2>/dev/null || true
+    continue
+  fi
+
+  current=$(cat "$hf" 2>/dev/null || true)
+  if [ "$current" = "{}" ]; then
+    chmod 755 "$hd" 2>/dev/null || true
+    chmod 444 "$hf" 2>/dev/null || true
+    continue
+  fi
+
+  chmod 755 "$hd" 2>/dev/null || true
+  chmod 644 "$hf" 2>/dev/null || true
+  echo '{}' >"$hf" 2>/dev/null || true
+  chmod 444 "$hf" 2>/dev/null || true
+done
+
 # ALWAYS exit 0 — never cause "hook error" display
 exit 0

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -410,11 +410,80 @@ neutralize_non_enabled_hooks() {
     echo '{}' >"$hf" 2>/dev/null || true
     chmod 444 "$hf" 2>/dev/null || true
   done < <(find "$plugin_base/marketplaces" -name "hooks.json" 2>/dev/null)
+
+  # Third pass: neutralize cache-level hooks.json for non-enabled plugins.
+  # Claude Code reads hooks from installed_plugins.json -> installPath which
+  # always points to cache/<mkt>/<name>/<version>/hooks/hooks.json.  For
+  # plugins whose marketplace dir is a real directory (not a symlink to cache),
+  # the marketplace passes above do NOT neutralize the cache copy.
+  local chf chd c_relative c_mkt c_name c_key c_current
+  for chf in "$plugin_base"/cache/*/*/*/hooks/hooks.json; do
+    [ -f "$chf" ] || continue
+    c_relative="${chf#"${plugin_base}"/cache/}"
+    c_mkt="${c_relative%%/*}"
+    c_name="${c_relative#*/}"
+    c_name="${c_name%%/*}"
+    c_key="${c_name}@${c_mkt}"
+    chd=$(dirname "$chf")
+
+    if jq -e --arg k "$c_key" '.enabledPlugins[$k]' "$settings" >/dev/null 2>&1; then
+      chmod 755 "$chd" 2>/dev/null || true
+      chmod 644 "$chf" 2>/dev/null || true
+      continue
+    fi
+
+    c_current=$(cat "$chf" 2>/dev/null || true)
+    if [ "$c_current" = "{}" ]; then
+      chmod 755 "$chd" 2>/dev/null || true
+      chmod 444 "$chf" 2>/dev/null || true
+      continue
+    fi
+
+    chmod 755 "$chd" 2>/dev/null || true
+    chmod 644 "$chf" 2>/dev/null || true
+    echo '{}' >"$chf" 2>/dev/null || true
+    chmod 444 "$chf" 2>/dev/null || true
+  done
+}
+
+# Wrap claude-mem hook commands with exit-0 guard to prevent
+# non-zero exit codes (from signal deaths during daemon spawn races)
+# from surfacing as "hook error" warnings in Claude Code.
+# The hook handlers already exit 0 on worker-unavailable errors;
+# the only failure mode that leaks non-zero is a signal kill of
+# the bun process during daemon restart attempts in PR()/TD().
+wrap_cmem_hooks_with_guard() {
+  local cmem_hooks
+  cmem_hooks=$(find "${HOME}/.claude/plugins/cache/thedotmack/claude-mem" \
+    -name "hooks.json" -path "*/hooks/hooks.json" -print -quit 2>/dev/null)
+  [ -f "$cmem_hooks" ] || return 0
+
+  # Only patch if not already patched (idempotent)
+  grep -q '|| exit 0' "$cmem_hooks" 2>/dev/null && return 0
+
+  # Use jq to wrap UserPromptSubmit commands with ( ... ) || exit 0
+  local tmp="${cmem_hooks}.tmp"
+  if jq '
+    if .hooks.UserPromptSubmit then
+      .hooks.UserPromptSubmit |= map(
+        .hooks |= map(
+          if .command and (.command | test("\\|\\| exit 0$") | not) then
+            .command = "( " + .command + " ) || exit 0"
+          else . end
+        )
+      )
+    else . end
+  ' "$cmem_hooks" >"$tmp" 2>/dev/null; then
+    mv -f "$tmp" "$cmem_hooks"
+  else
+    rm -f "$tmp"
+  fi
 }
 
 ensure_marketplace_dirs
 find "${HOME}/.claude/plugins" -name "*.sh" -type f -exec chmod +x {} + 2>/dev/null || true
 neutralize_non_enabled_hooks
+wrap_cmem_hooks_with_guard
 
 # Persistent background daemon (Layer 1)
 # Phase 1: poll every 1-2s for 60s (catches initial dual plugin syncs
@@ -434,6 +503,7 @@ neutralize_non_enabled_hooks
     find "${HOME}/.claude/plugins" -name "*.sh" -type f \
       ! -perm -u+x -exec chmod +x {} + 2>/dev/null
     neutralize_non_enabled_hooks
+    wrap_cmem_hooks_with_guard
     elapsed=$((elapsed + $([ "$elapsed" -lt 10 ] && echo 1 || echo 2)))
   done
 
@@ -442,12 +512,14 @@ neutralize_non_enabled_hooks
     while true; do
       inotifywait -qq -r -e modify,create,moved_to,moved_from \
         "${HOME}/.claude/plugins/marketplaces" \
+        "${HOME}/.claude/plugins/cache" \
         "${HOME}/.claude/settings.json" 2>/dev/null
       # No sleep — neutralize IMMEDIATELY after filesystem event
       ensure_marketplace_dirs
       find "${HOME}/.claude/plugins" -name "*.sh" -type f \
         ! -perm -u+x -exec chmod +x {} + 2>/dev/null
       neutralize_non_enabled_hooks
+      wrap_cmem_hooks_with_guard
     done
   else
     while true; do
@@ -456,6 +528,7 @@ neutralize_non_enabled_hooks
       find "${HOME}/.claude/plugins" -name "*.sh" -type f \
         ! -perm -u+x -exec chmod +x {} + 2>/dev/null
       neutralize_non_enabled_hooks
+      wrap_cmem_hooks_with_guard
     done
   fi
 ) >/dev/null 2>&1 &
@@ -651,13 +724,15 @@ if [ "${ENABLE_TAILSCALE:-false}" = "true" ]; then
   fi
 fi
 
-# Wait for claude-mem worker health before dropping to shell.
+# Wait for claude-mem worker health AND readiness before dropping to shell.
+# Health = HTTP server listening.  Readiness = full initialisation complete.
 # The worker was started earlier in the entrypoint; Firecrawl, Chrome, and
 # Tailscale startup have given it 10-30 s to initialise.  This synchronous
 # gate prevents Claude Code's plugin hooks from encountering an unregistered
 # worker and triggering the daemon fork's SIGKILL on hook processes.
-for _i in 1 2 3 4 5; do
-  curl -sf http://localhost:37777/health >/dev/null 2>&1 && break
+for _i in 1 2 3 4 5 6 7 8 9 10; do
+  curl -sf http://localhost:37777/api/readiness >/dev/null 2>&1 && break
+  curl -sf http://localhost:37777/health >/dev/null 2>&1 || true
   sleep 1
 done
 

--- a/tests/test-hook-neutralization.sh
+++ b/tests/test-hook-neutralization.sh
@@ -440,6 +440,92 @@ else
 fi
 teardown_mock_env
 
+echo ""
+echo "9. Cache-Level Neutralization"
+
+# Test 27: non-enabled plugin's cache hooks.json gets neutralized to {} with 444 perms
+setup_mock_env
+create_mock_cache_plugin "test-mkt" "gamma" "1.0.0" \
+  '{"hooks":{"SessionStart":[{"hooks":[{"type":"command","command":"echo bad"}]}]}}'
+source_neutralize_fn
+HOME="$MOCK_HOME" neutralize_non_enabled_hooks
+CONTENT=$(cat "${MOCK_HOME}/.claude/plugins/cache/test-mkt/gamma/1.0.0/hooks/hooks.json")
+FPERMS=$(stat -c '%a' "${MOCK_HOME}/.claude/plugins/cache/test-mkt/gamma/1.0.0/hooks/hooks.json" 2>/dev/null)
+check "non-enabled cache hooks.json neutralized to {}" \
+  test "$CONTENT" = "{}"
+check "non-enabled cache hooks.json perms 444" \
+  test "$FPERMS" = "444"
+teardown_mock_env
+
+# Test 28: enabled plugin's cache hooks.json is preserved with 644 perms
+setup_mock_env
+ORIG_HOOKS='{"hooks":{"PreToolUse":[{"hooks":[{"type":"command","command":"echo ok"}]}]}}'
+create_mock_cache_plugin "test-mkt" "alpha" "1.0.0" "$ORIG_HOOKS"
+source_neutralize_fn
+HOME="$MOCK_HOME" neutralize_non_enabled_hooks
+CONTENT=$(cat "${MOCK_HOME}/.claude/plugins/cache/test-mkt/alpha/1.0.0/hooks/hooks.json")
+FPERMS=$(stat -c '%a' "${MOCK_HOME}/.claude/plugins/cache/test-mkt/alpha/1.0.0/hooks/hooks.json" 2>/dev/null)
+check "enabled cache hooks.json preserved" \
+  test "$CONTENT" = "$ORIG_HOOKS"
+check "enabled cache hooks.json perms 644" \
+  test "$FPERMS" = "644"
+teardown_mock_env
+
+# Test 29: idempotent — already-neutralized cache hooks.json causes no errors
+setup_mock_env
+create_mock_cache_plugin "test-mkt" "gamma" "1.0.0" '{}'
+chmod 444 "${MOCK_HOME}/.claude/plugins/cache/test-mkt/gamma/1.0.0/hooks/hooks.json"
+source_neutralize_fn
+STDERR_OUTPUT=$(HOME="$MOCK_HOME" neutralize_non_enabled_hooks 2>&1 || true)
+CONTENT=$(cat "${MOCK_HOME}/.claude/plugins/cache/test-mkt/gamma/1.0.0/hooks/hooks.json")
+check "idempotent cache neutralize — no errors" \
+  test -z "$STDERR_OUTPUT"
+check "idempotent cache neutralize preserves {} content" \
+  test "$CONTENT" = "{}"
+teardown_mock_env
+
+# Test 30: multiple cache versions for same plugin all get neutralized
+setup_mock_env
+create_mock_cache_plugin "test-mkt" "gamma" "1.0.0" '{"hooks":{"SessionStart":[]}}'
+create_mock_cache_plugin "test-mkt" "gamma" "2.0.0" '{"hooks":{"PreToolUse":[]}}'
+create_mock_cache_plugin "test-mkt" "gamma" "abc123" '{"hooks":{"Stop":[]}}'
+source_neutralize_fn
+HOME="$MOCK_HOME" neutralize_non_enabled_hooks
+C1=$(cat "${MOCK_HOME}/.claude/plugins/cache/test-mkt/gamma/1.0.0/hooks/hooks.json")
+C2=$(cat "${MOCK_HOME}/.claude/plugins/cache/test-mkt/gamma/2.0.0/hooks/hooks.json")
+C3=$(cat "${MOCK_HOME}/.claude/plugins/cache/test-mkt/gamma/abc123/hooks/hooks.json")
+check "cache version 1.0.0 neutralized" test "$C1" = "{}"
+check "cache version 2.0.0 neutralized" test "$C2" = "{}"
+check "cache version abc123 neutralized" test "$C3" = "{}"
+teardown_mock_env
+
+# Test 31: cache neutralization doesn't affect marketplace hooks.json (independence)
+setup_mock_env
+create_mock_mkt_plugin "test-mkt" "gamma" '{"hooks":{"SessionStart":[]}}'
+create_mock_cache_plugin "test-mkt" "gamma" "1.0.0" '{"hooks":{"PreToolUse":[]}}'
+source_neutralize_fn
+HOME="$MOCK_HOME" neutralize_non_enabled_hooks
+MKT_CONTENT=$(cat "${MOCK_HOME}/.claude/plugins/marketplaces/test-mkt/plugins/gamma/hooks/hooks.json")
+CACHE_CONTENT=$(cat "${MOCK_HOME}/.claude/plugins/cache/test-mkt/gamma/1.0.0/hooks/hooks.json")
+check "marketplace hooks.json neutralized (independent)" test "$MKT_CONTENT" = "{}"
+check "cache hooks.json also neutralized (independent)" test "$CACHE_CONTENT" = "{}"
+teardown_mock_env
+
+# Test 32: concurrent cache neutralization produces valid JSON
+setup_mock_env
+create_mock_cache_plugin "test-mkt" "gamma" "1.0.0" '{"hooks":{"SessionStart":[]}}'
+create_mock_cache_plugin "test-mkt" "gamma" "2.0.0" '{"hooks":{"PreToolUse":[]}}'
+source_neutralize_fn
+for _ in 1 2 3 4 5; do
+  HOME="$MOCK_HOME" neutralize_non_enabled_hooks &
+done
+wait
+C1=$(cat "${MOCK_HOME}/.claude/plugins/cache/test-mkt/gamma/1.0.0/hooks/hooks.json" 2>/dev/null || echo "MISSING")
+C2=$(cat "${MOCK_HOME}/.claude/plugins/cache/test-mkt/gamma/2.0.0/hooks/hooks.json" 2>/dev/null || echo "MISSING")
+check "concurrent cache neutralize v1 produces valid JSON {}" test "$C1" = "{}"
+check "concurrent cache neutralize v2 produces valid JSON {}" test "$C2" = "{}"
+teardown_mock_env
+
 if [ "$UNIT_ONLY" = true ]; then
   echo ""
   echo "── Skipping E2E tests (--unit-only) ──"
@@ -488,6 +574,28 @@ else
   done
   check "no active hooks from non-enabled plugins (${NON_ENABLED_HOOKS} found)" \
     test "$NON_ENABLED_HOOKS" -eq 0
+
+  # Test 18b: no non-enabled plugin has active hooks IN CACHE
+  NON_ENABLED_CACHE_HOOKS=0
+  while IFS= read -r hf; do
+    [ -f "$hf" ] || continue
+    # Extract mkt and name from cache/<mkt>/<name>/<ver>/hooks/hooks.json
+    relative="${hf#"${PLUGIN_BASE}"/cache/}"
+    cache_mkt="${relative%%/*}"
+    tmp="${relative#*/}"
+    cache_name="${tmp%%/*}"
+    KEY="${cache_name}@${cache_mkt}"
+    if jq -e --arg k "$KEY" '.enabledPlugins[$k]' "$SETTINGS" >/dev/null 2>&1; then
+      continue
+    fi
+    CONTENT=$(cat "$hf")
+    if [ "$CONTENT" != "{}" ]; then
+      echo "    ACTIVE CACHE: $hf (key=$KEY)"
+      NON_ENABLED_CACHE_HOOKS=$((NON_ENABLED_CACHE_HOOKS + 1))
+    fi
+  done < <(find "$PLUGIN_BASE/cache" -path "*/hooks/hooks.json" 2>/dev/null)
+  check "no active hooks from non-enabled plugins in cache (${NON_ENABLED_CACHE_HOOKS} found)" \
+    test "$NON_ENABLED_CACHE_HOOKS" -eq 0
 
   # Test 19: all enabled plugins have cache entries
   MISSING_CACHE=0


### PR DESCRIPTION
## Summary

- Claude Code reads plugin hooks from `installed_plugins.json` -> `installPath` which always points to `~/.claude/plugins/cache/`, but the neutralization infrastructure only targeted `~/.claude/plugins/marketplaces/`
- For plugins with real marketplace directories (not symlinks to cache), disabling a plugin did NOT prevent its hooks from firing
- Adds a third neutralization pass that covers cache-level `hooks.json`, closing the gap
- All 48 tests pass (42 unit + 6 E2E)

Closes #895

## Test plan

- [ ] CI checks pass (Lint Code Base, Check linked issues)
- [ ] All 48 hook neutralization tests pass (42 unit + 6 E2E)
- [ ] Cache directory hooks are neutralized when plugins are disabled
- [ ] Marketplace directory hooks continue to be neutralized as before