### PR TITLE
fix: pre-enable rust-analyzer-lsp plugin to prevent repeated install prompts

### DIFF
--- a/claude-config/settings.json
+++ b/claude-config/settings.json
@@ -24,6 +24,7 @@
     "ralph-loop@claude-plugins-official": true,
     "typescript-lsp@claude-plugins-official": true,
     "pyright-lsp@claude-plugins-official": true,
+    "rust-analyzer-lsp@claude-plugins-official": true,
     "security-guidance@claude-plugins-official": true,
     "claude-md-management@claude-plugins-official": true,
     "pr-review-toolkit@claude-plugins-official": true,
@@ -71,6 +72,18 @@
             "type": "command",
             "command": "/opt/claude-config/neutralize-hooks.sh",
             "timeout": 10
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "for _i in 1 2 3; do curl -sf http://localhost:37777/api/readiness >/dev/null 2>&1 && exit 0; sleep 1; done; exit 0",
+            "timeout": 5
           }
         ]
       }


### PR DESCRIPTION
## Summary

- Pre-enable `rust-analyzer-lsp@claude-plugins-official` in `claude-config/settings.json` to eliminate repeated install prompts on every fresh container startup
- The rust-analyzer binary is already installed via `rustup component add rust-analyzer` in the Dockerfile; the plugin is configuration-only and tells Claude Code how to connect to the existing binary
- Add `UserPromptSubmit` hook for claude-mem worker readiness gate to ensure the memory service is available before processing user prompts
- See [anthropics/claude-code#19275](https://github.com/anthropics/claude-code/issues/19275) for the upstream race condition

Closes #897

## Test plan

- [ ] CI checks pass (Check linked issues + Lint Code Base)
- [ ] Fresh container startup no longer prompts to install rust-analyzer-lsp plugin
- [ ] rust-analyzer LSP features work correctly in Rust files
- [ ] claude-mem readiness hook fires without blocking prompt submission