### PR TITLE
feat: enable terraform-lsp plugin for terraform-ls language server

### DIFF
--- a/claude-config/settings.json
+++ b/claude-config/settings.json
@@ -25,6 +25,7 @@
     "typescript-lsp@claude-plugins-official": true,
     "pyright-lsp@claude-plugins-official": true,
     "rust-analyzer-lsp@claude-plugins-official": true,
+    "terraform-lsp@f5xc-salesdemos-marketplace": true,
     "security-guidance@claude-plugins-official": true,
     "claude-md-management@claude-plugins-official": true,
     "pr-review-toolkit@claude-plugins-official": true,


### PR DESCRIPTION
## Summary

- Enable the `terraform-lsp` plugin from `f5xc-salesdemos-marketplace` in `claude-config/settings.json`
- The terraform-ls binary (v0.38.6) is already pre-installed in the Dockerfile but had no LSP plugin connecting Claude Code to it
- The terraform-lsp plugin was published to the marketplace (PR marketplace#223); this commit activates it in the devcontainer

Closes #899

## Test plan

- [ ] CI checks pass (`Check linked issues` and `Lint Code Base`)
- [ ] Verify `settings.json` is valid JSON with the new plugin entry
- [ ] On container rebuild, confirm Claude Code loads the terraform-lsp plugin on startup