### PR TITLE
feat: enable json-lsp plugin for vscode-json-language-server

### DIFF
--- a/claude-config/settings.json
+++ b/claude-config/settings.json
@@ -26,6 +26,7 @@
     "pyright-lsp@claude-plugins-official": true,
     "rust-analyzer-lsp@claude-plugins-official": true,
     "terraform-lsp@f5xc-salesdemos-marketplace": true,
+    "json-lsp@f5xc-salesdemos-marketplace": true,
     "security-guidance@claude-plugins-official": true,
     "claude-md-management@claude-plugins-official": true,
     "pr-review-toolkit@claude-plugins-official": true,


### PR DESCRIPTION
## Summary

- Enable `json-lsp@f5xc-salesdemos-marketplace` plugin in `claude-config/settings.json`
- The `vscode-json-language-server` binary is already pre-installed in the Dockerfile but Claude Code had no LSP plugin configured to use it
- The json-lsp plugin was added to the f5xc-salesdemos-marketplace (PR marketplace#227) and this change activates it for devcontainer sessions

Closes #901

## Test plan

- [ ] CI checks pass
- [ ] Verify `json-lsp@f5xc-salesdemos-marketplace` appears in the plugins section of `claude-config/settings.json`
- [ ] Confirm container builds successfully with the updated settings