### PR TITLE
fix: use latest.txt for jdtls download instead of HTML parsing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -809,8 +809,8 @@ RUN ghlatest() { curl -fsSL -o /dev/null -w '%{url_effective}' "https://github.c
       | gzip -d > /usr/local/bin/taplo \
     && chmod +x /usr/local/bin/taplo \
     # jdtls (Eclipse JDT Language Server for Java — Python wrapper + plugin jars)
-    && JDTLS_TARBALL=$(curl ${CURL_RETRY} -fsSL "https://download.eclipse.org/jdtls/milestones/1.57.0/" \
-      | grep -oP 'jdt-language-server-[^"<]+\.tar\.gz' | head -1) \
+    && JDTLS_TARBALL=$(curl ${CURL_RETRY} -fsSL \
+      "https://download.eclipse.org/jdtls/milestones/1.57.0/latest.txt") \
     && mkdir -p /opt/jdtls \
     && curl ${CURL_RETRY} -fsSL \
       "https://download.eclipse.org/jdtls/milestones/1.57.0/${JDTLS_TARBALL}" \


### PR DESCRIPTION
## Summary

- Replace fragile HTML parsing (`grep -oP`) with Eclipse's stable `latest.txt` API for jdtls tarball filename resolution
- Fixes the Docker Publish workflow failure from PR #907 where `grep -oP` failed in the build environment

Closes #908

## Test plan

- [ ] CI checks pass (Docker build succeeds with the new download method)
- [ ] Verify `latest.txt` URL returns correct tarball filename (`jdt-language-server-1.57.0-202602261110.tar.gz`)