### PR TITLE
fix: symlink all system npm packages into user prefix for npx resolution

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1475,17 +1475,24 @@ RUN ZSH_CUSTOM="${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}" \
 # hadolint ignore=DL3059
 RUN mkdir -p "$HOME/.npm-global/lib/node_modules" "$HOME/.npm-global/bin" \
     && npm config set prefix "$HOME/.npm-global" \
-    # Symlink system-installed typescript into user prefix so that
-    # 'npx tsc' resolves the real compiler instead of the deprecated
-    # 'tsc' npm stub package ("This is not the tsc command you are
-    # looking for"). System packages live at /usr/lib/node_modules
-    # but npx only checks the user prefix (~/.npm-global).
-    && ln -sf /usr/lib/node_modules/typescript \
-              "$HOME/.npm-global/lib/node_modules/typescript" \
-    && ln -sf ../lib/node_modules/typescript/bin/tsc \
-              "$HOME/.npm-global/bin/tsc" \
-    && ln -sf ../lib/node_modules/typescript/bin/tsserver \
-              "$HOME/.npm-global/bin/tsserver" \
+    # Symlink every system-installed npm binary into the user prefix.
+    # Without this, 'npx <tool>' cannot see packages installed at the
+    # system prefix (/usr/lib/node_modules) and either downloads the
+    # wrong npm package (e.g. npx biome -> env-var manager instead of
+    # the linter, npx tsc -> deprecated stub) or wastes time
+    # re-downloading the correct one.
+    && for bin in /usr/bin/*; do \
+         target=$(readlink "$bin" 2>/dev/null || true); \
+         [ -z "$target" ] && continue; \
+         case "$target" in */node_modules/*) ;; *) continue ;; esac; \
+         ln -sf "$bin" "$HOME/.npm-global/bin/$(basename "$bin")"; \
+       done \
+    && for pkg in /usr/lib/node_modules/*; do \
+         [ -d "$pkg" ] || continue; \
+         name=$(basename "$pkg"); \
+         [ -e "$HOME/.npm-global/lib/node_modules/$name" ] && continue; \
+         ln -sf "$pkg" "$HOME/.npm-global/lib/node_modules/$name"; \
+       done \
     && git clone --depth=1 https://github.com/tfutils/tfenv.git "$HOME/.tfenv" \
     && "$HOME/.tfenv/bin/tfenv" install latest \
     && "$HOME/.tfenv/bin/tfenv" use latest \

--- a/tests/test-npx-resolution.sh
+++ b/tests/test-npx-resolution.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# npx Resolution Test Suite (TDD)
+#
+# Verifies that 'npx <tool>' resolves the same version as the
+# direct '<tool>' command for all system-installed npm packages.
+# Without the user-prefix symlinks, npx downloads wrong packages
+# (e.g. 'npx biome' → env-var manager instead of the linter).
+#
+# Run:  bash tests/test-npx-resolution.sh
+set -euo pipefail
+
+PASS=0
+FAIL=0
+
+compare_versions() {
+  local name="$1" cmd="$2"
+  local direct_ver npx_ver
+
+  direct_ver=$("$cmd" --version 2>&1 | head -1) || direct_ver="(error)"
+  npx_ver=$(timeout 15 npx "$cmd" --version 2>&1 | head -1) || npx_ver="(error)"
+
+  if [ "$direct_ver" = "$npx_ver" ]; then
+    echo "  PASS: $name — $direct_ver"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $name — direct='$direct_ver' npx='$npx_ver'"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# Test that npx does NOT download the deprecated 'tsc' stub
+test_npx_tsc() {
+  local ver
+  ver=$(timeout 15 npx tsc --version 2>&1 | head -1) || ver="(error)"
+  if echo "$ver" | grep -q "^Version"; then
+    echo "  PASS: npx tsc — $ver"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: npx tsc — got '$ver' (expected TypeScript version)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# Test that npx biome is the linter (v2+), not the env-var manager (v0.3)
+test_npx_biome() {
+  local ver
+  ver=$(timeout 15 npx biome --version 2>&1 | head -1) || ver="(error)"
+  if echo "$ver" | grep -qE "^(Version: )?[1-9]"; then
+    echo "  PASS: npx biome — $ver"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: npx biome — got '$ver' (expected v2+, got wrong package)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+echo "=== Critical conflict tests (wrong package downloaded) ==="
+test_npx_tsc
+test_npx_biome
+
+echo ""
+echo "=== Version match tests (npx should use pre-installed version) ==="
+compare_versions "eslint" "eslint"
+compare_versions "prettier" "prettier"
+compare_versions "pnpm" "pnpm"
+compare_versions "pyright" "pyright"
+compare_versions "stylelint" "stylelint"
+compare_versions "htmlhint" "htmlhint"
+compare_versions "jscpd" "jscpd"
+compare_versions "textlint" "textlint"
+
+echo ""
+echo "=== Results ==="
+echo "PASS: $PASS  FAIL: $FAIL"
+if [ "$FAIL" -eq 0 ]; then
+  echo "ALL TESTS PASSED"
+else
+  echo "SOME TESTS FAILED"
+fi
+exit "$FAIL"


### PR DESCRIPTION
## Summary

- Replaces the 3 typescript-specific symlinks from PR #912 with two generic loops that symlink ALL 45 system npm binaries and 53 packages into `~/.npm-global/`
- Fixes wrong-package conflicts where `npx biome`, `npx spectral`, `npx coffeelint`, `npx tekton-lint`, and `npx devcontainer` all resolved to incorrect registry packages
- Eliminates unnecessary re-downloads for ~12 tools (eslint, prettier, pnpm, etc.) that are already installed at the system level
- Adds `tests/test-npx-resolution.sh` with 10 test cases verifying correct npx resolution

Closes #913

## Test plan

- [ ] CI checks pass (Docker build, super-linter)
- [ ] `tests/test-npx-resolution.sh` passes all 10 test cases inside built container
- [ ] `npx biome --version` resolves to pre-installed linter (2.4.11), not env-var manager (0.3.3)
- [ ] `npx tsc --version` continues to work (regression check for #911)

🤖 Generated with [Claude Code](https://claude.com/claude-code)