### PR TITLE
fix: install csharp-ls with --tool-path instead of --global to fix missing binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -822,8 +822,7 @@ RUN ghlatest() { curl -fsSL -o /dev/null -w '%{url_effective}' "https://github.c
 # 10l-2. C# language server (csharp-ls via dotnet global tool)
 # ============================================================
 # hadolint ignore=DL3059
-RUN dotnet tool install --global csharp-ls --version 0.16.0 \
-    && ln -sf /home/vscode/.dotnet/tools/csharp-ls /usr/local/bin/csharp-ls
+RUN dotnet tool install csharp-ls --version 0.16.0 --tool-path /usr/local/bin
 
 # ============================================================
 # 10l. Zig cross-compilation toolchain (needed by napi-rs


### PR DESCRIPTION
## Summary

- Fix broken `csharp-ls` binary by using `dotnet tool install --tool-path /usr/local/bin` instead of `--global`
- The `--global` flag installs to `/root/.dotnet/tools/` during Docker build (running as root), but the symlink pointed to `/home/vscode/.dotnet/tools/` which does not exist at runtime
- Using `--tool-path /usr/local/bin` places the binary directly on PATH, eliminating the broken symlink

Closes #915

## Test plan

- [x] `csharp-ls --version` returns `0.16.0.0`
- [x] Test suite passes 39/39
- [ ] CI checks pass