### PR TITLE
fix: update workaround tracking from closed #648 to open cc#40013

### DIFF
--- a/claude-config/neutralize-hooks.sh
+++ b/claude-config/neutralize-hooks.sh
@@ -2,6 +2,10 @@
 # Plugin hook neutralization and marketplace directory repair.
 # Called from settings.json SessionStart hook.
 #
+# Workaround for cc#40013: Claude Code fires hooks from ALL installed
+# plugins, not just enabled ones.  (Issue #648 — .sh permission resets —
+# was closed 2026-03-27; chmod sweep kept as defence-in-depth.)
+#
 # Three responsibilities:
 #   1. Ensure marketplace directories exist for all enabled cached plugins
 #   2. Fix .sh execute permissions across all plugin directories

--- a/claude-config/self-test.sh
+++ b/claude-config/self-test.sh
@@ -287,14 +287,19 @@ for hf in "$HOME/.claude/plugins/marketplaces"/*/plugins/*/hooks/hooks.json; do
 done
 check "no active hooks from non-enabled plugins (${NON_ENABLED_HOOKS} found)" \
   test "$NON_ENABLED_HOOKS" -eq 0
-# Track upstream workaround — warn when issue #648 is closed so the
-# SessionStart hook and entrypoint chmod sweep can be reviewed for removal
-ISSUE_STATE=$(gh issue view 648 --repo f5xc-salesdemos/devcontainer \
+# Track upstream workarounds — the SessionStart hook and entrypoint chmod
+# sweep exist for TWO upstream bugs.  The workaround can only be removed
+# when BOTH are resolved:
+#   - #648  (f5xc-salesdemos/devcontainer) — plugin syncs reset .sh perms  [CLOSED 2026-03-27]
+#   - #40013 (anthropics/claude-code)       — hooks fire from ALL plugins   [still open]
+CC_STATE=$(gh issue view 40013 --repo anthropics/claude-code \
   --json state --jq '.state' 2>/dev/null || echo "UNKNOWN")
-if [ "$ISSUE_STATE" = "CLOSED" ]; then
-  warn "workaround for #648 may be removable — issue is closed, review settings.json hooks and entrypoint.sh" false
-elif [ "$ISSUE_STATE" = "UNKNOWN" ]; then
-  echo "  SKIP: could not check issue #648 status (no GH_TOKEN or network)"
+if [ "$CC_STATE" = "CLOSED" ]; then
+  warn "cc#40013 is closed — neutralize-hooks workaround in settings.json hooks and entrypoint.sh can be removed" false
+elif [ "$CC_STATE" = "UNKNOWN" ]; then
+  echo "  SKIP: could not check cc#40013 status (no GH_TOKEN or network)"
+else
+  echo "  INFO: cc#40013 still open — neutralize-hooks workaround still required"
 fi
 
 echo ""

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -282,10 +282,11 @@ fi
 # ============================================================
 # Fix plugin script permissions and neutralize disabled hooks
 #
-# Two upstream bugs require workarounds:
-#   - Issue #648: Plugin syncs reset .sh permissions to 644
+# Upstream bug requiring workaround:
 #   - cc#40013: Claude Code fires hooks from ALL plugins, not
 #     just enabled ones (causes SessionStart errors)
+#   (Issue #648 — plugin syncs reset .sh perms — was closed 2026-03-27,
+#    but the chmod sweep is kept as defence-in-depth while cc#40013 remains.)
 #
 # Two-layer fix:
 #   1. Persistent background daemon (inotifywait or polling)
@@ -297,7 +298,7 @@ fi
 # Build-time: install-plugins.sh also sets permissions and
 # neutralizes at image build time (baseline state).
 #
-# Remove all when upstream issues #648 and cc#40013 are resolved.
+# Remove all when cc#40013 is resolved.
 # ============================================================
 
 # Ensure every enabled cached plugin has a marketplace directory entry.


### PR DESCRIPTION
## Summary

- Issue #648 (plugin syncs reset .sh permissions) was closed 2026-03-27
- cc#40013 (hooks fire from all plugins) is still open and is the primary reason the neutralize-hooks workaround remains necessary
- The self-test was falsely warning that the workaround "may be removable" because it checked #648 which is now closed
- Updated `claude-config/self-test.sh` to check cc#40013 instead — now correctly shows "INFO: still required"
- Updated comments in `entrypoint.sh` and `claude-config/neutralize-hooks.sh` to reflect that #648 is closed and the workaround now primarily serves cc#40013

Closes #917

## Test plan

- [ ] CI checks pass
- [ ] `claude-self-test` no longer falsely warns that the neutralize-hooks workaround may be removable
- [ ] Self-test correctly reports "INFO: still required" when cc#40013 is open