### PR TITLE
fix: update xcsh config defaults to powerline preset with handoff save

### DIFF
--- a/xcsh-config/config.yml
+++ b/xcsh-config/config.yml
@@ -1,10 +1,10 @@
-lastChangelogVersion: 14.0.3
+lastChangelogVersion: 15.6.2
 modelRoles:
   default: anthropic/claude-opus-4-6
 symbolPreset: nerd
 statusLine:
-  separator: slash
-  preset: minimal
+  separator: powerline
+  preset: xcsh
 colorBlindMode: false
 hideThinkingBlock: true
 autoResume: true
@@ -14,6 +14,7 @@ stt:
   enabled: true
 compaction:
   idleEnabled: true
+  handoffSaveToDisk: true
 memories:
   enabled: true
 todo:


### PR DESCRIPTION
## Summary
- Update baked-in `xcsh-config/config.yml` that was overriding xcsh schema defaults
- `statusLine.preset`: `minimal` → `xcsh` (powerline with OS icon, path, git, plan mode)
- `statusLine.separator`: `slash` → `powerline` (solid arrow separators)
- Add `compaction.handoffSaveToDisk: true` to persist auto-handoff documents
- Bump `lastChangelogVersion` from `14.0.3` to `15.6.2`

## Context
The Dockerfile copies this config to `~/.xcsh/agent/config.yml` at container build time. Since `settings.get()` checks the config file before falling back to schema defaults, the old `minimal`/`slash` values were always winning — even though the xcsh schema defines `xcsh`/`powerline` as the intended defaults.

## Test plan
- [ ] Rebuild container image
- [ ] Start xcsh — verify powerline statusline renders with OS icon, path, git segments
- [ ] Open settings panel — confirm preset=xcsh, separator=powerline, Save Handoff Docs=true

🤖 Generated with [Claude Code](https://claude.com/claude-code)