### PR TITLE
feat: add Charmbracelet Crush coding agent with LiteLLM proxy configuration

### DIFF
--- a/.devcontainer/scripts/post-start.sh
+++ b/.devcontainer/scripts/post-start.sh
@@ -26,7 +26,7 @@ fi
 # Check installed tools
 echo "  Installed tools:"
 for cmd in node python3 go rustc javac git gh kubectl helm terraform \
-  pre-commit uv claude codex opencode xcsh prettier markdownlint-cli2 \
+  pre-commit uv claude codex opencode crush xcsh prettier markdownlint-cli2 \
   actionlint act terraform-docs ansible black pylint yamllint yt-dlp \
   aws az pwsh devcontainer brew playwright pnpm redis-cli psql tirith \
   marksman terraform-ls taplo yaml-language-server bash-language-server \

--- a/Dockerfile
+++ b/Dockerfile
@@ -892,6 +892,7 @@ RUN npm install -g \
     react-dom \
     sharp \
     opencode-ai \
+    @charmland/crush \
     opencode-claude-auth \
     js-deobfuscator
 
@@ -1574,6 +1575,7 @@ COPY --chown=${USERNAME}:${USERNAME} opencode-config/opencode.json /home/${USERN
 COPY --chown=${USERNAME}:${USERNAME} opencode-config/oh-my-openagent.json /home/${USERNAME}/.config/opencode/oh-my-openagent.json
 COPY --chown=${USERNAME}:${USERNAME} opencode-config/opencode-permissions.json /home/${USERNAME}/.config/opencode/opencode-permissions.json
 COPY --chown=${USERNAME}:${USERNAME} hermes-config/config.yaml /home/${USERNAME}/.hermes/config.yaml
+COPY --chown=${USERNAME}:${USERNAME} crush-config/crush.json /home/${USERNAME}/.config/crush/crush.json
 
 
 # Map CLAUDE_CODE_OAUTH_TOKEN → ANTHROPIC_OAUTH_TOKEN for tools

--- a/claude-config/self-test.sh
+++ b/claude-config/self-test.sh
@@ -40,6 +40,7 @@ check "firefox-esr installed" command -v firefox-esr
 check "claude CLI installed" command -v claude
 check "pi CLI installed" command -v pi
 check "omp CLI installed" command -v omp
+check "crush CLI installed" command -v crush
 check "node installed" command -v node
 check "python installed" command -v python3
 check "git installed" command -v git
@@ -239,6 +240,9 @@ check "Codex agents synced from CC plugins (${CODEX_AGENT_COUNT} found)" \
   test "$CODEX_AGENT_COUNT" -gt 0
 check "Codex chrome-devtools MCP configured" \
   grep -q "chrome-devtools" "$HOME/.codex/config.toml"
+check "crush config exists" test -f "$HOME/.config/crush/crush.json"
+check "crush base URL hydrated" \
+  grep -qv "__CRUSH_BASE_URL__" "$HOME/.config/crush/crush.json"
 # Check permissions by marketplace to pinpoint source (issue #648)
 NON_EXEC_OFFICIAL=$(find "$HOME/.claude/plugins" \
   -path "*/claude-plugins-official/*" -name "*.sh" -type f \

--- a/crush-config/crush.json
+++ b/crush-config/crush.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://charm.land/crush.json",
+  "models": {
+    "large": { "model": "claude-opus-4-6", "provider": "litellm" },
+    "small": { "model": "claude-haiku-4-5", "provider": "litellm" }
+  },
+  "providers": {
+    "litellm": {
+      "type": "openai-compat",
+      "base_url": "__CRUSH_BASE_URL__",
+      "api_key": "$OPENAI_API_KEY"
+    }
+  }
+}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -202,6 +202,19 @@ if [ -n "$LITELLM_BASE_URL" ]; then
   unset _codex_config
 fi
 
+# ============================================================
+# Crush — substitute base URL placeholder in config
+# The litellm provider in crush.json uses __CRUSH_BASE_URL__ as a
+# placeholder; resolve it to the OpenAI passthrough endpoint.
+# ============================================================
+if [ -n "$LITELLM_BASE_URL" ]; then
+  _crush_config="$HOME/.config/crush/crush.json"
+  if [ -f "$_crush_config" ]; then
+    sed -i "s|__CRUSH_BASE_URL__|${LITELLM_BASE_URL}/openai/v1|g" "$_crush_config"
+  fi
+  unset _crush_config
+fi
+
 # Re-sync Codex agents from Claude Code plugins (catches plugin updates)
 if [ -x /opt/codex-config/sync-agents.sh ]; then
   /opt/codex-config/sync-agents.sh >/dev/null 2>&1 || true


### PR DESCRIPTION
## Summary

- Add Charmbracelet Crush as a coding agent in the devcontainer, following the same integration pattern as Codex, Hermes, and OpenCode
- Configure Crush with LiteLLM proxy via `__CRUSH_BASE_URL__` placeholder substitution in entrypoint
- Add health check in self-test and post-start initialization

Closes #925

## Test plan

- [ ] CI checks pass (Lint Code Base, Check linked issues)
- [ ] Container builds successfully with crush installed
- [ ] `crush --version` works inside the container
- [ ] Crush config is hydrated with correct LiteLLM proxy URL at container start
- [ ] Self-test includes crush health check