### PR TITLE
fix: add crush-config to .dockerignore allow list

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,6 +7,7 @@
 !hermes-config/
 !xcsh-config/
 !opencode-config/
+!crush-config/
 !.devcontainer/scripts/
 !scripts/
 !configs/


### PR DESCRIPTION
## Summary

The Docker Publish CI failed because `.dockerignore` uses a deny-all (`*`) pattern and `crush-config/` was not in the allow list, causing the `COPY` instruction in the Dockerfile to fail with "not found". This adds `!crush-config/` to the allow list alongside the other config directories.

Closes #925

## Test plan

- [ ] CI checks pass
- [ ] Docker build succeeds with crush-config directory included