### PR TITLE
fix: add crush-config to Docker Publish workflow paths trigger

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -10,6 +10,7 @@ on:
       - configs/**
       - claude-config/**
       - codex-config/**
+      - crush-config/**
       - pi-config/**
       - omp-config/**
       - scripts/**


### PR DESCRIPTION
## Summary

- Add `crush-config/**` to the `on.push.paths` trigger list in `.github/workflows/docker-publish.yml`
- This ensures changes to crush-config files trigger the Docker Publish workflow
- Completes the fix started in PR #927 (which added crush-config to `.dockerignore` but missed the workflow paths)

Closes #928

## Test plan

- [ ] CI checks pass
- [ ] Verify `crush-config/**` appears in the workflow paths trigger list
- [ ] Confirm future pushes modifying crush-config files trigger Docker Publish