### PR TITLE
fix: use ANTHROPIC_API_ENDPOINT env var for crush LiteLLM routing

### DIFF
--- a/claude-config/self-test.sh
+++ b/claude-config/self-test.sh
@@ -241,8 +241,7 @@ check "Codex agents synced from CC plugins (${CODEX_AGENT_COUNT} found)" \
 check "Codex chrome-devtools MCP configured" \
   grep -q "chrome-devtools" "$HOME/.codex/config.toml"
 check "crush config exists" test -f "$HOME/.config/crush/crush.json"
-check "crush base URL hydrated" \
-  grep -qv "__CRUSH_BASE_URL__" "$HOME/.config/crush/crush.json"
+check "crush ANTHROPIC_API_ENDPOINT set" test -n "$ANTHROPIC_API_ENDPOINT"
 # Check permissions by marketplace to pinpoint source (issue #648)
 NON_EXEC_OFFICIAL=$(find "$HOME/.claude/plugins" \
   -path "*/claude-plugins-official/*" -name "*.sh" -type f \

--- a/crush-config/crush.json
+++ b/crush-config/crush.json
@@ -1,14 +1,7 @@
 {
   "$schema": "https://charm.land/crush.json",
   "models": {
-    "large": { "model": "claude-opus-4-6", "provider": "litellm" },
-    "small": { "model": "claude-haiku-4-5", "provider": "litellm" }
-  },
-  "providers": {
-    "litellm": {
-      "type": "openai-compat",
-      "base_url": "__CRUSH_BASE_URL__",
-      "api_key": "$OPENAI_API_KEY"
-    }
+    "large": { "model": "claude-opus-4-6", "provider": "anthropic" },
+    "small": { "model": "claude-haiku-4-5", "provider": "anthropic" }
   }
 }

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -203,16 +203,11 @@ if [ -n "$LITELLM_BASE_URL" ]; then
 fi
 
 # ============================================================
-# Crush — substitute base URL placeholder in config
-# The litellm provider in crush.json uses __CRUSH_BASE_URL__ as a
-# placeholder; resolve it to the OpenAI passthrough endpoint.
+# Crush — route Anthropic provider through LiteLLM proxy.
+# Crush reads ANTHROPIC_API_ENDPOINT for the Anthropic base URL.
 # ============================================================
 if [ -n "$LITELLM_BASE_URL" ]; then
-  _crush_config="$HOME/.config/crush/crush.json"
-  if [ -f "$_crush_config" ]; then
-    sed -i "s|__CRUSH_BASE_URL__|${LITELLM_BASE_URL}/openai/v1|g" "$_crush_config"
-  fi
-  unset _crush_config
+  export ANTHROPIC_API_ENDPOINT="${LITELLM_BASE_URL}/anthropic"
 fi
 
 # Re-sync Codex agents from Claude Code plugins (catches plugin updates)


### PR DESCRIPTION
## Summary

- Switch crush from custom `openai-compat` / `litellm` provider to the built-in `anthropic` provider, which natively reads `ANTHROPIC_API_ENDPOINT` for its base URL
- Export `ANTHROPIC_API_ENDPOINT` in the entrypoint instead of `sed`-substituting a placeholder in the config file, avoiding crush's auto-generated data dir config override
- Update self-test to verify the env var is set instead of checking for placeholder removal

Closes #932

## Test plan

- [ ] CI checks pass
- [ ] Container builds successfully with crush config changes
- [ ] `crush` routes through LiteLLM proxy when `LITELLM_BASE_URL` is set
- [ ] Self-test passes the updated crush health check