### PR TITLE
fix: add LiteLLM proxy base URL to opencode Anthropic provider config

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -210,6 +210,19 @@ if [ -n "$LITELLM_BASE_URL" ]; then
   export ANTHROPIC_API_ENDPOINT="${LITELLM_BASE_URL}/anthropic"
 fi
 
+# ============================================================
+# OpenCode — substitute Anthropic base URL placeholder.
+# OpenCode's bundled Anthropic SDK appends /messages (not /v1/messages),
+# so the base URL must include the /v1 path segment.
+# ============================================================
+if [ -n "$LITELLM_BASE_URL" ]; then
+  _oc_cfg="$HOME/.config/opencode/opencode.json"
+  if [ -f "$_oc_cfg" ]; then
+    sed -i "s|__OPENCODE_ANTHROPIC_BASE_URL__|${LITELLM_BASE_URL}/anthropic/v1|g" "$_oc_cfg"
+  fi
+  unset _oc_cfg
+fi
+
 # Re-sync Codex agents from Claude Code plugins (catches plugin updates)
 if [ -x /opt/codex-config/sync-agents.sh ]; then
   /opt/codex-config/sync-agents.sh >/dev/null 2>&1 || true

--- a/opencode-config/opencode.json
+++ b/opencode-config/opencode.json
@@ -33,5 +33,12 @@
       "command": ["pyright-langserver", "--stdio"],
       "extensions": [".py", ".pyi"]
     }
+  },
+  "provider": {
+    "anthropic": {
+      "options": {
+        "baseURL": "__OPENCODE_ANTHROPIC_BASE_URL__"
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary

- OpenCode's bundled Anthropic SDK constructs URLs as `${baseURL}/messages` (not `/v1/messages`)
- This was calling `/anthropic/messages` which returns 405 from LiteLLM
- Adding `provider.anthropic.options.baseURL` with a placeholder substituted to `${LITELLM_BASE_URL}/anthropic/v1` fixes the path

Closes #941

## Test plan

- [ ] CI checks pass
- [ ] Container builds successfully
- [ ] OpenCode can connect to Anthropic via LiteLLM proxy