### PR TITLE
fix: restore opencode provider config with correct models and token limits

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -120,7 +120,7 @@ if [ -n "$LITELLM_API_KEY" ]; then
   printf 'ANTHROPIC_API_KEY=%s\n' "$LITELLM_API_KEY" >"$HOME/.claude-mem/.env"
 fi
 if [ -n "$LITELLM_BASE_URL" ]; then
-  _openai_base_url="${LITELLM_BASE_URL}/openai/v1"
+  export OPENAI_BASE_URL="${LITELLM_BASE_URL}/openai/v1"
   export ANTHROPIC_BASE_URL="${LITELLM_BASE_URL}/anthropic"
 fi
 
@@ -156,7 +156,7 @@ HERMES_HOME_DIR="$HOME/.hermes"
 mkdir -p "$HERMES_HOME_DIR"
 if [ -n "$LITELLM_API_KEY" ]; then
   printf 'OPENAI_BASE_URL=%s\nOPENAI_API_KEY=%s\nLLM_MODEL=claude-opus-4-6\n' \
-    "$_openai_base_url" "$OPENAI_API_KEY" \
+    "$OPENAI_BASE_URL" "$OPENAI_API_KEY" \
     >"$HERMES_HOME_DIR/.env"
 elif [ -n "$CLAUDE_CODE_OAUTH_TOKEN" ]; then
   printf 'ANTHROPIC_TOKEN=%s\n' "$ANTHROPIC_OAUTH_TOKEN" \
@@ -208,19 +208,6 @@ fi
 # ============================================================
 if [ -n "$LITELLM_BASE_URL" ]; then
   export ANTHROPIC_API_ENDPOINT="${LITELLM_BASE_URL}/anthropic"
-fi
-
-# ============================================================
-# OpenCode — substitute Anthropic base URL placeholder.
-# OpenCode's bundled Anthropic SDK appends /messages (not /v1/messages),
-# so the base URL must include the /v1 path segment.
-# ============================================================
-if [ -n "$LITELLM_BASE_URL" ]; then
-  _oc_cfg="$HOME/.config/opencode/opencode.json"
-  if [ -f "$_oc_cfg" ]; then
-    sed -i "s|__OPENCODE_ANTHROPIC_BASE_URL__|${LITELLM_BASE_URL}/anthropic/v1|g" "$_oc_cfg"
-  fi
-  unset _oc_cfg
 fi
 
 # Re-sync Codex agents from Claude Code plugins (catches plugin updates)

--- a/opencode-config/oh-my-openagent.json
+++ b/opencode-config/oh-my-openagent.json
@@ -1,36 +1,37 @@
 {
   "$schema": "https://raw.githubusercontent.com/code-yeongyu/oh-my-openagent/dev/assets/oh-my-opencode.schema.json",
   "agents": {
-    "sisyphus": { "model": "anthropic/claude-opus-4-6", "variant": "max" },
-    "oracle": { "model": "anthropic/claude-opus-4-6", "variant": "max" },
-    "librarian": { "model": "anthropic/claude-opus-4-6", "variant": "max" },
-    "explore": { "model": "anthropic/claude-haiku-4-5" },
-    "multimodal-looker": { "model": "anthropic/claude-opus-4-6", "variant": "max" },
-    "prometheus": { "model": "anthropic/claude-opus-4-6", "variant": "max" },
-    "metis": { "model": "anthropic/claude-opus-4-6", "variant": "max" },
-    "hephaestus": { "model": "anthropic/claude-opus-4-6", "variant": "max" },
-    "momus": { "model": "anthropic/claude-opus-4-6", "variant": "max" },
-    "atlas": { "model": "anthropic/claude-sonnet-4-6" },
-    "frontend-ui-ux-engineer": { "model": "anthropic/claude-opus-4-6", "variant": "max" },
-    "document-writer": { "model": "anthropic/claude-opus-4-6", "variant": "max" },
-    "build": { "model": "anthropic/claude-opus-4-6", "variant": "max" },
-    "plan": { "model": "anthropic/claude-opus-4-6", "variant": "max" },
-    "sisyphus-junior": { "model": "anthropic/claude-sonnet-4-6" }
+    "sisyphus": { "model": "anthropic-proxy/claude-opus-4-6" },
+    "oracle": { "model": "anthropic-proxy/claude-opus-4-6" },
+    "librarian": { "model": "anthropic-proxy/claude-opus-4-6" },
+    "explore": { "model": "openai-proxy/grok-code-fast-1" },
+    "multimodal-looker": { "model": "anthropic-proxy/claude-opus-4-6" },
+    "prometheus": { "model": "anthropic-proxy/claude-opus-4-6" },
+    "metis": { "model": "anthropic-proxy/claude-opus-4-6" },
+    "hephaestus": { "model": "openai-proxy/gpt-5.4" },
+    "momus": { "model": "anthropic-proxy/claude-opus-4-6" },
+    "atlas": { "model": "anthropic-proxy/claude-sonnet-4-6" },
+    "frontend-ui-ux-engineer": { "model": "openai-proxy/gpt-5.4" },
+    "document-writer": { "model": "anthropic-proxy/claude-opus-4-6" },
+    "build": { "model": "anthropic-proxy/claude-opus-4-6" },
+    "plan": { "model": "anthropic-proxy/claude-opus-4-6" },
+    "sisyphus-junior": { "model": "anthropic-proxy/claude-sonnet-4-6" }
   },
   "categories": {
-    "visual-engineering": { "model": "anthropic/claude-opus-4-6", "variant": "max" },
-    "business-logic": { "model": "anthropic/claude-opus-4-6", "variant": "max" },
-    "ultrabrain": { "model": "anthropic/claude-opus-4-6", "variant": "max" },
-    "deep": { "model": "anthropic/claude-opus-4-6", "variant": "max" },
-    "artistry": { "model": "anthropic/claude-opus-4-6", "variant": "max" },
-    "quick": { "model": "anthropic/claude-haiku-4-5" },
-    "unspecified-low": { "model": "anthropic/claude-sonnet-4-6" },
-    "unspecified-high": { "model": "anthropic/claude-opus-4-6", "variant": "max" },
-    "writing": { "model": "anthropic/claude-sonnet-4-6" }
+    "visual-engineering": { "model": "openai-proxy/gpt-5.4" },
+    "business-logic": { "model": "openai-proxy/gpt-5.4" },
+    "ultrabrain": { "model": "openai-proxy/gpt-5.4" },
+    "deep": { "model": "openai-proxy/gpt-5.4" },
+    "artistry": { "model": "openai-proxy/gpt-5.4" },
+    "quick": { "model": "anthropic-proxy/claude-sonnet-4-6" },
+    "unspecified-low": { "model": "anthropic-proxy/claude-opus-4-6" },
+    "unspecified-high": { "model": "anthropic-proxy/claude-opus-4-6" },
+    "writing": { "model": "anthropic-proxy/claude-opus-4-6" }
   },
   "background_task": {
     "providerConcurrency": {
-      "anthropic": 5
+      "openai-proxy": 5,
+      "anthropic-proxy": 5
     }
   }
 }

--- a/opencode-config/opencode.json
+++ b/opencode-config/opencode.json
@@ -1,8 +1,77 @@
 {
   "$schema": "https://opencode.ai/config.json",
-  "model": "anthropic/claude-opus-4-6",
-  "small_model": "anthropic/claude-haiku-4-5",
-  "plugin": ["oh-my-openagent@latest"],
+  "provider": {
+    "anthropic-proxy": {
+      "npm": "@ai-sdk/anthropic",
+      "name": "Anthropic Proxy",
+      "options": {
+        "baseURL": "{env:ANTHROPIC_BASE_URL}/v1",
+        "apiKey": "{env:ANTHROPIC_API_KEY}"
+      },
+      "models": {
+        "claude-opus-4-6": {
+          "name": "Claude Opus 4.6",
+          "modalities": {
+            "input": ["text", "image"],
+            "output": ["text"]
+          },
+          "limit": {
+            "context": 1000000,
+            "output": 128000
+          }
+        },
+        "claude-sonnet-4-6": {
+          "name": "Claude Sonnet 4.6",
+          "modalities": {
+            "input": ["text", "image"],
+            "output": ["text"]
+          },
+          "limit": {
+            "context": 1000000,
+            "output": 64000
+          }
+        }
+      }
+    },
+    "openai-proxy": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "OpenAI Proxy",
+      "options": {
+        "baseURL": "{env:OPENAI_BASE_URL}",
+        "apiKey": "{env:OPENAI_API_KEY}"
+      },
+      "models": {
+        "gpt-5.4": {
+          "name": "GPT 5.4",
+          "modalities": {
+            "input": ["text", "image"],
+            "output": ["text"]
+          },
+          "limit": {
+            "context": 1050000,
+            "output": 128000
+          },
+          "options": {
+            "reasoningSummary": null
+          }
+        },
+        "grok-code-fast-1": {
+          "name": "Explore",
+          "modalities": {
+            "input": ["text"],
+            "output": ["text"]
+          },
+          "limit": {
+            "context": 256000,
+            "output": 16000
+          }
+        }
+      }
+    }
+  },
+  "model": "anthropic-proxy/claude-opus-4-6",
+  "small_model": "anthropic-proxy/claude-sonnet-4-6",
+  "plugin": ["@f5xc-salesdemos/oh-my-openagent@f5xc"],
   "mcp": {},
   "lsp": {
     "marksman": {
@@ -32,13 +101,6 @@
     "python": {
       "command": ["pyright-langserver", "--stdio"],
       "extensions": [".py", ".pyi"]
-    }
-  },
-  "provider": {
-    "anthropic": {
-      "options": {
-        "baseURL": "__OPENCODE_ANTHROPIC_BASE_URL__"
-      }
     }
   }
 }


### PR DESCRIPTION
## Summary

- Restore dual-provider setup (`anthropic-proxy` and `openai-proxy`) in `opencode.json` with explicit context/output token limits verified against official docs and live proxy testing
- Fix `small_model` to `claude-sonnet-4-6` (was incorrectly `claude-haiku-4-5`), use `anthropic-proxy/` model prefixes in `oh-my-openagent.json`, and export `OPENAI_BASE_URL` in `entrypoint.sh` for native env var interpolation
- Remove the `__OPENCODE_ANTHROPIC_BASE_URL__` sed hack from #942 since `{env:ANTHROPIC_BASE_URL}/v1` in the provider config handles it natively

Closes #943

## Test plan

- [ ] CI checks pass
- [ ] Verify opencode launches with correct provider configuration inside the devcontainer
- [ ] Confirm `OPENAI_BASE_URL` is exported and available for opencode env interpolation
- [ ] Validate token limits: Opus 4.6 (1M/128K), Sonnet 4.6 (1M/64K), GPT-5.4 (1.05M/128K), Grok Code Fast 1 (256K/16K)