### PR TITLE
fix: correct Grok Code Fast 1 output token limit to 16384

### DIFF
--- a/opencode-config/opencode.json
+++ b/opencode-config/opencode.json
@@ -63,7 +63,7 @@
           },
           "limit": {
             "context": 256000,
-            "output": 16000
+            "output": 16384
           }
         }
       }


### PR DESCRIPTION
## Summary

- Corrects the Grok Code Fast 1 output token limit from 16,000 to 16,384 in `opencode-config/opencode.json` to match official xAI documentation

Closes #945

## Test plan

- [ ] CI checks pass
- [ ] Verify opencode.json is valid JSON with correct token limit value