### PR TITLE
feat: add opencode-config to Docker build triggers and bake lint-staged/turbo

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -11,6 +11,8 @@ on:
       - claude-config/**
       - codex-config/**
       - crush-config/**
+      - hermes-config/**
+      - opencode-config/**
       - pi-config/**
       - omp-config/**
       - scripts/**

--- a/Dockerfile
+++ b/Dockerfile
@@ -842,6 +842,7 @@ RUN UNAME_ARCH=$(uname -m) \
 # hadolint ignore=DL3016,DL3059
 RUN npm install -g \
     pnpm \
+    turbo \
     @anthropic-ai/claude-code \
     @mariozechner/pi-coding-agent \
     @oh-my-pi/pi-coding-agent \
@@ -863,6 +864,7 @@ RUN npm install -g \
     puppeteer-extra \
     puppeteer-extra-plugin-stealth \
     eslint \
+    lint-staged \
     @biomejs/biome \
     stylelint \
     htmlhint \


### PR DESCRIPTION
## Summary

- Add `hermes-config/**` and `opencode-config/**` to the Docker publish workflow path triggers so changes in those directories trigger container rebuilds
- Add `turbo` and `lint-staged` to the global npm install in the Dockerfile so they are available in the container without runtime installation

Closes #947

## Test plan

- [ ] CI checks pass (Lint Code Base, Check linked issues)
- [ ] Docker image builds successfully with the new npm packages
- [ ] Workflow file validates with actionlint