### PR TITLE
fix: correct dagu release asset URL to include version in filename

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -530,9 +530,11 @@ RUN DPKG_ARCH=$(dpkg --print-architecture) && UNAME_ARCH=$(uname -m) \
       | tar -xz --strip-components=1 -C /usr/local/bin nu-${NU_VERSION}-${UNAME_ARCH}-unknown-linux-gnu/nu \
     # mise
     && curl -fsSL https://mise.run | MISE_INSTALL_PATH=/usr/local/bin/mise sh \
-    # dagu
+    # dagu (resolve version — asset name contains version)
+    && DAGU_VERSION=$(curl -fsSL -o /dev/null -w '%{url_effective}' \
+      "https://github.com/daguflow/dagu/releases/latest" | sed 's|.*/||;s|^v||') \
     && curl ${CURL_RETRY} -fsSL \
-      "https://github.com/daguflow/dagu/releases/latest/download/dagu_linux_${DPKG_ARCH}.tar.gz" \
+      "https://github.com/daguflow/dagu/releases/latest/download/dagu_${DAGU_VERSION}_linux_${DPKG_ARCH}.tar.gz" \
       | tar -xz -C /usr/local/bin dagu \
     # wasmtime
     && WASMTIME_VERSION=$(curl -fsSL -o /dev/null -w '%{url_effective}' \


### PR DESCRIPTION
## Summary

- Fixed the dagu download URL in the Dockerfile to include the version number in the filename, matching the actual release asset naming pattern (`dagu_${VERSION}_linux_${ARCH}.tar.gz`)
- Added version resolution via curl redirect (consistent with the existing `ghlatest` pattern used for wasmtime and other tools)

Closes #949

## Test plan

- [ ] CI Docker Publish workflow passes (image builds successfully with the corrected dagu URL)
- [ ] Verify dagu binary is present and functional in the built container