### PR TITLE
feat: pre-warm opencode npm dependencies to eliminate 13.5s startup delay

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1610,6 +1610,20 @@ COPY --chown=${USERNAME}:${USERNAME} opencode-config/opencode-permissions.json /
 COPY --chown=${USERNAME}:${USERNAME} hermes-config/config.yaml /home/${USERNAME}/.hermes/config.yaml
 COPY --chown=${USERNAME}:${USERNAME} crush-config/crush.json /home/${USERNAME}/.config/crush/crush.json
 
+# ────────────────────────────────────────────────────────────
+# OpenCode npm pre-warm: pre-install base SDK and plugin deps
+# to eliminate the ~13.5 s first-run npm download delay.
+#   Phase 1: reify ~/.config/opencode/package.json
+#   Phase 2: pre-install oh-my-openagent plugin into cache
+# ────────────────────────────────────────────────────────────
+# hadolint ignore=DL3059
+RUN cd /home/${USERNAME}/.config/opencode \
+    && npm install --no-audit --no-fund \
+    && mkdir -p /home/${USERNAME}/.cache/opencode/packages/oh-my-openagent \
+    && printf '{"dependencies":{"oh-my-openagent":"latest"}}\n' \
+       > /home/${USERNAME}/.cache/opencode/packages/oh-my-openagent/package.json \
+    && cd /home/${USERNAME}/.cache/opencode/packages/oh-my-openagent \
+    && npm install --no-audit --no-fund
 
 # Map CLAUDE_CODE_OAUTH_TOKEN → ANTHROPIC_OAUTH_TOKEN for tools
 # that read the Anthropic-native env var (e.g. Pi).

--- a/opencode-config/opencode.json
+++ b/opencode-config/opencode.json
@@ -71,7 +71,7 @@
   },
   "model": "anthropic-proxy/claude-opus-4-6",
   "small_model": "anthropic-proxy/claude-sonnet-4-6",
-  "plugin": ["@f5xc-salesdemos/oh-my-openagent@f5xc"],
+  "plugin": ["oh-my-openagent"],
   "mcp": {},
   "lsp": {
     "marksman": {


### PR DESCRIPTION
## Summary

- Add a Docker build-time pre-warm step that pre-installs OpenCode's npm dependencies (base SDK + oh-my-openagent plugin), eliminating the ~13.5s first-run download delay
- Switch from the custom fork (`@f5xc-salesdemos/oh-my-openagent@f5xc`) to the official `oh-my-openagent` package

Closes #952

## Test plan

- [ ] CI checks pass (Dockerfile lint, JSON lint)
- [ ] Docker image builds successfully with the new RUN block
- [ ] OpenCode starts without npm download delay in a fresh container
- [ ] oh-my-openagent plugin loads correctly from the official package