### PR TITLE
fix: create package.json before npm install in opencode pre-warm step

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1617,7 +1617,9 @@ COPY --chown=${USERNAME}:${USERNAME} crush-config/crush.json /home/${USERNAME}/.
 #   Phase 2: pre-install oh-my-openagent plugin into cache
 # ────────────────────────────────────────────────────────────
 # hadolint ignore=DL3059
-RUN cd /home/${USERNAME}/.config/opencode \
+RUN printf '{"dependencies":{"@opencode-ai/plugin":"^1.4.3"}}\n' \
+       > /home/${USERNAME}/.config/opencode/package.json \
+    && cd /home/${USERNAME}/.config/opencode \
     && npm install --no-audit --no-fund \
     && mkdir -p /home/${USERNAME}/.cache/opencode/packages/oh-my-openagent \
     && printf '{"dependencies":{"oh-my-openagent":"latest"}}\n' \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1389,10 +1389,10 @@ USER $USERNAME
 # hadolint ignore=DL3059
 RUN npm exec chrome-devtools-mcp@0.20.2 -- --version 2>/dev/null || true
 
-# oh-my-opencode (OpenCode plugin system — "ultrawork" / "ulw" command)
-# Build-time install uses npx oh-my-opencode for config scaffolding.
+# oh-my-openagent (OpenCode plugin system — "ultrawork" / "ulw" command)
+# Build-time install uses npx oh-my-openagent for config scaffolding.
 # hadolint ignore=DL3059
-RUN npx -y oh-my-opencode install --no-tui \
+RUN npx -y oh-my-openagent install --no-tui \
     --claude=max20 --openai=no --gemini=no --copilot=no \
     && rm -f ~/.config/opencode/*.bak.*
 
@@ -1619,13 +1619,11 @@ COPY --chown=${USERNAME}:${USERNAME} crush-config/crush.json /home/${USERNAME}/.
 # hadolint ignore=DL3059
 RUN printf '{"dependencies":{"@opencode-ai/plugin":"^1.4.3"}}\n' \
        > /home/${USERNAME}/.config/opencode/package.json \
-    && cd /home/${USERNAME}/.config/opencode \
-    && npm install --no-audit --no-fund \
+    && npm install --no-audit --no-fund --prefix /home/${USERNAME}/.config/opencode \
     && mkdir -p /home/${USERNAME}/.cache/opencode/packages/oh-my-openagent \
     && printf '{"dependencies":{"oh-my-openagent":"latest"}}\n' \
        > /home/${USERNAME}/.cache/opencode/packages/oh-my-openagent/package.json \
-    && cd /home/${USERNAME}/.cache/opencode/packages/oh-my-openagent \
-    && npm install --no-audit --no-fund
+    && npm install --no-audit --no-fund --prefix /home/${USERNAME}/.cache/opencode/packages/oh-my-openagent
 
 # Map CLAUDE_CODE_OAUTH_TOKEN → ANTHROPIC_OAUTH_TOKEN for tools
 # that read the Anthropic-native env var (e.g. Pi).


### PR DESCRIPTION
## Summary

- Explicitly creates `package.json` with `@opencode-ai/plugin` dependency before running `npm install` in the Dockerfile opencode pre-warm step
- Fixes Docker build failure where `npm install` failed because `package.json` does not exist at build time (opencode generates it at first runtime)

Closes #954

## Test plan

- [ ] CI checks pass
- [ ] Docker image builds successfully with the pre-warm step completing without errors