### PR TITLE
fix: correct superfile tarball extraction path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -555,8 +555,8 @@ RUN DPKG_ARCH=$(dpkg --print-architecture) && UNAME_ARCH=$(uname -m) \
       "https://github.com/yorukot/superfile/releases/latest" | sed 's|.*/||') \
     && curl ${CURL_RETRY} -fsSL \
       "https://github.com/yorukot/superfile/releases/latest/download/superfile-linux-${SPF_VERSION}-${DPKG_ARCH}.tar.gz" \
-      | tar -xz --strip-components=1 -C /usr/local/bin \
-        superfile-linux-${SPF_VERSION}-${DPKG_ARCH}/spf
+      | tar -xz --strip-components=2 -C /usr/local/bin \
+        dist/superfile-linux-${SPF_VERSION}-${DPKG_ARCH}/spf
 
 # ============================================================
 # 10c. iTerm2 terminal image utilities


### PR DESCRIPTION
## Summary

- The superfile release tarball contains a `dist/` prefix in its internal directory structure (`./dist/superfile-linux-v1.5.0-arm64/spf`), but the Dockerfile was extracting with `--strip-components=1` expecting only one level
- Changed `--strip-components` from 1 to 2 and updated the extraction path to include the `dist/` prefix
- Fixes the Docker build failure introduced by PR #957

Closes #978

## Test plan

- [ ] CI checks pass (Docker build completes successfully)
- [ ] The `spf` binary is correctly extracted to `/usr/local/bin/spf`