### PR TITLE
fix: use strip-components=3 for superfile tarball extraction

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -555,8 +555,7 @@ RUN DPKG_ARCH=$(dpkg --print-architecture) && UNAME_ARCH=$(uname -m) \
       "https://github.com/yorukot/superfile/releases/latest" | sed 's|.*/||') \
     && curl ${CURL_RETRY} -fsSL \
       "https://github.com/yorukot/superfile/releases/latest/download/superfile-linux-${SPF_VERSION}-${DPKG_ARCH}.tar.gz" \
-      | tar -xz --strip-components=2 -C /usr/local/bin \
-        dist/superfile-linux-${SPF_VERSION}-${DPKG_ARCH}/spf
+      | tar -xz --strip-components=3 -C /usr/local/bin
 
 # ============================================================
 # 10c. iTerm2 terminal image utilities


### PR DESCRIPTION
## Summary

- The superfile release tarball entries are prefixed with `./` (e.g. `./dist/superfile-linux-v1.5.0-arm64/spf`). The previous fix in PR #979 used `--strip-components=2` with a `dist/` file filter, but GNU tar fails to match the filter against `./`-prefixed entries.
- Use `--strip-components=3` with no file filter since the tarball contains only the single `spf` binary. The three path components stripped are `.`, `dist`, and `superfile-linux-VERSION-ARCH`.

Closes #980

## Test plan

- [ ] CI Docker build succeeds on both amd64 and arm64 architectures
- [ ] Post-merge Docker Publish workflow completes successfully