### PR TITLE
fix: add command zsh and increase mem_limit to 12g

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - SETGID
       - NET_RAW
       - NET_ADMIN
-    mem_limit: 8g
+    mem_limit: 12g
     cpus: 4
     pids_limit: 4096
     tmpfs:
@@ -30,3 +30,4 @@ services:
     tty: true
     init: true
     restart: unless-stopped
+    command: zsh


### PR DESCRIPTION
Closes #984

## Changes

1. **`command: zsh`** — The image CMD is `sleep infinity`. Without this override, `podman attach` connects to a non-interactive process and `podman exec` bypasses the entrypoint (losing `ANTHROPIC_API_KEY`, `ANTHROPIC_BASE_URL`, model overrides, service startup). Adding `command: zsh` passes it to the entrypoint's `exec \$@`, producing a fully initialized interactive shell.

2. **`mem_limit: 12g`** (was 8g) — Concurrent Claude Code instances in tmux with active subagents regularly exceed 8g. With proper VM-level zram tuning (4 GB zstd + 16 GB disk swap), 12g leaves 4 GB headroom for the VM while giving the container 24 GB total (12g RAM + 12g swap).