### PR TITLE
fix: restore pd-claude-opus-4-7 routing for crush/pi/omp/xcsh

### DIFF
--- a/crush-config/crush.json
+++ b/crush-config/crush.json
@@ -1,7 +1,30 @@
 {
   "$schema": "https://charm.land/crush.json",
+  "options": {
+    "disable_provider_auto_update": true
+  },
+  "providers": {
+    "anthropic": {
+      "base_url": "__CRUSH_BASE_URL__",
+      "api_key": "$LITELLM_API_KEY",
+      "models": [
+        {
+          "id": "pd-claude-opus-4-7",
+          "name": "Claude Opus 4.7 (PD)",
+          "cost_per_1m_in": 5,
+          "cost_per_1m_out": 25,
+          "cost_per_1m_in_cached": 6.25,
+          "cost_per_1m_out_cached": 0.5,
+          "context_window": 1000000,
+          "default_max_tokens": 128000,
+          "can_reason": true,
+          "supports_attachments": true
+        }
+      ]
+    }
+  },
   "models": {
     "large": { "model": "pd-claude-opus-4-7", "provider": "anthropic" },
-    "small": { "model": "claude-haiku-4-5", "provider": "anthropic" }
+    "small": { "model": "pd-claude-opus-4-7", "provider": "anthropic" }
   }
 }

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -174,28 +174,116 @@ if [ -n "$LITELLM_BASE_URL" ]; then
 fi
 
 # ============================================================
-# Pi & Oh-My-Pi — write models.json with LiteLLM proxy base URL.
-# Neither tool reads ANTHROPIC_BASE_URL from the environment;
-# they require a models.json provider override instead.
+# Pi & Oh-My-Pi — write models.json registering pd-claude-opus-4-7
+# as a custom model under the anthropic provider.
+#
+# Pi-ai (both @mariozechner/pi-ai and @oh-my-pi/pi-ai forks) keep a
+# built-in Anthropic model registry that does not include the custom
+# proxy ID `pd-claude-opus-4-7`. Without an explicit entry, the
+# resolver treats the ID as unknown, falls back to a built-in name
+# (e.g. `claude-opus-4-7` with no prefix), rewrites settings.json,
+# and the proxy rejects the stripped ID with 400. Declaring the
+# model here makes the resolver exact-match and stops the rewrite.
 # ============================================================
 if [ -n "$LITELLM_BASE_URL" ]; then
-  _pi_models='{"providers":{"anthropic":{"baseUrl":"'"${LITELLM_BASE_URL}/anthropic"'"}}}'
+  _pi_models=$(cat <<EOF
+{
+  "providers": {
+    "anthropic": {
+      "baseUrl": "${LITELLM_BASE_URL}/anthropic",
+      "apiKey": "LITELLM_API_KEY",
+      "api": "anthropic-messages",
+      "models": [
+        {
+          "id": "pd-claude-opus-4-7",
+          "name": "Claude Opus 4.7 (PD)",
+          "api": "anthropic-messages",
+          "reasoning": true,
+          "input": ["text", "image"],
+          "cost": {"input": 5, "output": 25, "cacheRead": 0.5, "cacheWrite": 6.25},
+          "contextWindow": 1000000,
+          "maxTokens": 128000
+        }
+      ]
+    }
+  }
+}
+EOF
+)
   mkdir -p "$HOME/.pi/agent" "$HOME/.omp/agent"
   printf '%s\n' "$_pi_models" >"$HOME/.pi/agent/models.json"
   printf '%s\n' "$_pi_models" >"$HOME/.omp/agent/models.json"
+  # Reset pi's defaultModel on every boot — pi-ai's fallback path
+  # overwrites this file with the stripped ID; without this reset
+  # the corruption survives container restart when $HOME is mounted.
+  printf '{"defaultProvider":"anthropic","defaultModel":"pd-claude-opus-4-7"}\n' \
+    >"$HOME/.pi/agent/settings.json"
   unset _pi_models
 fi
 
 # ============================================================
-# xcsh — write models.json + models.yml with LiteLLM proxy base URL.
-# xcsh reads provider routing from ~/.xcsh/agent/models.json.
+# xcsh — write models.json + models.yml registering the custom
+# pd-claude-opus-4-7 model (same rationale as pi/omp above).
 # ============================================================
 if [ -n "$LITELLM_BASE_URL" ]; then
-  _xcsh_models='{"providers":{"anthropic":{"baseUrl":"'"${LITELLM_BASE_URL}/anthropic"'"}}}'
+  _xcsh_models=$(cat <<EOF
+{
+  "providers": {
+    "anthropic": {
+      "baseUrl": "${LITELLM_BASE_URL}/anthropic",
+      "apiKey": "LITELLM_API_KEY",
+      "api": "anthropic-messages",
+      "models": [
+        {
+          "id": "pd-claude-opus-4-7",
+          "name": "Claude Opus 4.7 (PD)",
+          "api": "anthropic-messages",
+          "reasoning": true,
+          "input": ["text", "image"],
+          "cost": {"input": 5, "output": 25, "cacheRead": 0.5, "cacheWrite": 6.25},
+          "contextWindow": 1000000,
+          "maxTokens": 128000
+        }
+      ]
+    },
+    "litellm": {
+      "baseUrl": "${LITELLM_BASE_URL}/api/v1",
+      "apiKey": "LITELLM_API_KEY",
+      "api": "openai-completions"
+    }
+  }
+}
+EOF
+)
   mkdir -p "$HOME/.xcsh/agent"
   printf '%s\n' "$_xcsh_models" >"$HOME/.xcsh/agent/models.json"
-  printf 'providers: \n  anthropic: \n    baseUrl: %s\n' "${LITELLM_BASE_URL}/anthropic" \
-    >"$HOME/.xcsh/agent/models.yml"
+  cat >"$HOME/.xcsh/agent/models.yml" <<EOF
+configVersion: 2
+providers:
+  anthropic:
+    baseUrl: "${LITELLM_BASE_URL}/anthropic"
+    apiKey: LITELLM_API_KEY
+    api: anthropic-messages
+    models:
+      - id: pd-claude-opus-4-7
+        name: "Claude Opus 4.7 (PD)"
+        api: anthropic-messages
+        reasoning: true
+        input: [text, image]
+        cost:
+          input: 5
+          output: 25
+          cacheRead: 0.5
+          cacheWrite: 6.25
+        contextWindow: 1000000
+        maxTokens: 128000
+  litellm:
+    baseUrl: "${LITELLM_BASE_URL}/api/v1"
+    apiKey: LITELLM_API_KEY
+    api: openai-completions
+    discovery:
+      type: openai-compat
+EOF
   unset _xcsh_models
 fi
 
@@ -213,11 +301,49 @@ if [ -n "$LITELLM_BASE_URL" ]; then
 fi
 
 # ============================================================
-# Crush — route Anthropic provider through LiteLLM proxy.
-# Crush reads ANTHROPIC_API_ENDPOINT for the Anthropic base URL.
+# Crush — render base URL placeholder into crush.json.
+#
+# The tracked crush-config/crush.json uses __CRUSH_BASE_URL__ as a
+# placeholder so no internal hostnames live in the public repo.
+# Resolve it at container start to the LiteLLM Anthropic passthrough.
+#
+# crush.json also carries `options.disable_provider_auto_update: true`
+# plus a full `providers.anthropic.models[]` entry for
+# pd-claude-opus-4-7. Without the disable flag crush re-fetches the
+# upstream Catwalk catalog on every invocation, wiping custom models.
+# Without the inline models[] entry crush's embedded catalog has no
+# pd-claude-opus-4-7 and the proxy rejects the fallback ID.
 # ============================================================
 if [ -n "$LITELLM_BASE_URL" ]; then
+  _crush_config="$HOME/.config/crush/crush.json"
+  if [ -f "$_crush_config" ]; then
+    sed -i "s|__CRUSH_BASE_URL__|${LITELLM_BASE_URL}/anthropic|g" "$_crush_config"
+  fi
+  unset _crush_config
   export ANTHROPIC_API_ENDPOINT="${LITELLM_BASE_URL}/anthropic"
+fi
+
+# ============================================================
+# Proxy sanity probe.
+#
+# After all per-tool configs are rendered, POST a 1-token request
+# to the LiteLLM Anthropic passthrough to confirm pd-claude-opus-4-7
+# is accepted. Warns (non-fatal) on any non-200 response so the next
+# regression surfaces immediately instead of at first tool invocation.
+# ============================================================
+if [ -n "$LITELLM_BASE_URL" ] && [ -n "$LITELLM_API_KEY" ] && command -v curl >/dev/null 2>&1; then
+  _probe_status=$(curl -sS -o /dev/null -w '%{http_code}' \
+    -X POST "${LITELLM_BASE_URL}/anthropic/v1/messages" \
+    -H "x-api-key: ${LITELLM_API_KEY}" \
+    -H 'content-type: application/json' \
+    -H 'anthropic-version: 2023-06-01' \
+    -d '{"model":"pd-claude-opus-4-7","max_tokens":4,"messages":[{"role":"user","content":"hi"}]}' \
+    2>/dev/null || true)
+  if [ "$_probe_status" != "200" ]; then
+    printf 'WARN: LiteLLM proxy probe for pd-claude-opus-4-7 returned %s (expected 200)\n' \
+      "${_probe_status:-no-response}" >&2
+  fi
+  unset _probe_status
 fi
 
 # Re-sync Codex agents from Claude Code plugins (catches plugin updates)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -186,7 +186,8 @@ fi
 # model here makes the resolver exact-match and stops the rewrite.
 # ============================================================
 if [ -n "$LITELLM_BASE_URL" ]; then
-  _pi_models=$(cat <<EOF
+  _pi_models=$(
+    cat <<EOF
 {
   "providers": {
     "anthropic": {
@@ -209,7 +210,7 @@ if [ -n "$LITELLM_BASE_URL" ]; then
   }
 }
 EOF
-)
+  )
   mkdir -p "$HOME/.pi/agent" "$HOME/.omp/agent"
   printf '%s\n' "$_pi_models" >"$HOME/.pi/agent/models.json"
   printf '%s\n' "$_pi_models" >"$HOME/.omp/agent/models.json"
@@ -226,7 +227,8 @@ fi
 # pd-claude-opus-4-7 model (same rationale as pi/omp above).
 # ============================================================
 if [ -n "$LITELLM_BASE_URL" ]; then
-  _xcsh_models=$(cat <<EOF
+  _xcsh_models=$(
+    cat <<EOF
 {
   "providers": {
     "anthropic": {
@@ -254,7 +256,7 @@ if [ -n "$LITELLM_BASE_URL" ]; then
   }
 }
 EOF
-)
+  )
   mkdir -p "$HOME/.xcsh/agent"
   printf '%s\n' "$_xcsh_models" >"$HOME/.xcsh/agent/models.json"
   cat >"$HOME/.xcsh/agent/models.yml" <<EOF

--- a/opencode-config/opencode.json
+++ b/opencode-config/opencode.json
@@ -10,7 +10,7 @@
       },
       "models": {
         "pd-claude-opus-4-7": {
-          "name": "Claude Opus 4.6",
+          "name": "Claude Opus 4.7 (PD)",
           "modalities": {
             "input": ["text", "image"],
             "output": ["text"]


### PR DESCRIPTION
## Summary

- Register `pd-claude-opus-4-7` as a first-class custom Anthropic model in pi/omp/xcsh `models.json` and inline in `crush.json`, so their resolvers stop stripping the `pd-` prefix and emitting `claude-opus-4-7` (which the F5 liteLLM proxy rejects with `400 Invalid model name`).
- Defeat pi-ai's in-place `defaultModel` fallback rewrite by overwriting `~/.pi/agent/settings.json` on every boot, and stop crush re-fetching its embedded Catwalk catalog via `options.disable_provider_auto_update: true`.
- Fix stale `"Claude Opus 4.6"` display name on the `pd-claude-opus-4-7` entry in `opencode.json`.

Closes #986

## Changes

- `entrypoint.sh` — pi/omp/xcsh `models.json` template now includes `pd-claude-opus-4-7` under the anthropic provider (ModelDefinitionSchema: id/api/reasoning/input/cost/contextWindow/maxTokens). Overwrites `~/.pi/agent/settings.json` every boot. Runs `sed 's|__CRUSH_BASE_URL__|${LITELLM_BASE_URL}/anthropic|'` against the committed crush config. Adds a non-fatal startup curl probe that warns if the proxy returns non-200 for `pd-claude-opus-4-7`.
- `crush-config/crush.json` — rewritten with `options.disable_provider_auto_update: true` and an inline `providers.anthropic.models[]` entry for `pd-claude-opus-4-7`. Uses the `__CRUSH_BASE_URL__` placeholder so no F5 hostname is committed. Both `large` and `small` point at `pd-claude-opus-4-7` as a temporary workaround for crush's embedded short-id alias (follow-up tracked separately).
- `opencode-config/opencode.json` — corrected display name to `Claude Opus 4.7`.

## Test plan

- [x] `bash -n entrypoint.sh` passes
- [x] `jq .` validates `crush.json` and `opencode.json`
- [x] `sed "s|__CRUSH_BASE_URL__|...|" crush.json` renders a correct absolute URL
- [x] `pi --print --provider anthropic --model pd-claude-opus-4-7 --no-session 'hi'` returns a response (no 400)
- [x] `xcsh -p --model pd-claude-opus-4-7 --no-session 'hi'` returns a response (no 400)
- [x] `crush run 'hi'` returns a response; logs show no 400 errors
- [x] `opencode run -m anthropic-proxy/pd-claude-opus-4-7 'hi'` returns a response
- [x] `hermes chat -Q -q 'hi'` returns a response (OpenAI pass-through regression guard)
- [x] `~/.pi/agent/settings.json` `defaultModel` remains `pd-claude-opus-4-7` after pi runs
- [ ] CI checks pass (`Check linked issues`, `Lint Code Base`, any other required)

## Follow-ups (not in this PR)

- `@oh-my-pi/pi-natives` arm64 native-addon build failure blocks `omp` start; needs a devcontainer issue.
- Charmbracelet/crush: custom `providers.<name>.models[]` entries don't override embedded short-id aliases; needs an upstream issue.