### PR TITLE
fix: add missing frontmatter to superpowers plan file

### DIFF
--- a/docs/superpowers/plans/2026-03-28-remove-non-opencode-ai-tools.md
+++ b/docs/superpowers/plans/2026-03-28-remove-non-opencode-ai-tools.md
@@ -1,4 +1,8 @@
-# Remove Non-OpenCode AI Tools from INSTALL.md Implementation Plan
+---
+title: "Plan: Remove Non-OpenCode AI Tools"
+sidebar:
+  hidden: true
+---
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
@@ -104,6 +108,7 @@ grep -n 'cursor\|codex\|antigravity\|agy\|zed\b\|vscode\|VSCODE\|VS Code\|Visual
 ```
 
 Surviving matches must only be LSP binary names:
+
 - `vscode-langservers-extracted` (npm package)
 - `vscode-json/css/html-language-server` (LSP binary names in opencode.json)
 


### PR DESCRIPTION
Closes #994

Pages deploy has been failing since April 16 because `docs/superpowers/plans/2026-03-28-remove-non-opencode-ai-tools.md` lacks YAML frontmatter. Astro Starlight requires it for all content files.

Added minimal frontmatter with `sidebar: hidden: true` since it's an internal plan.