### PR TITLE
fix: move MDX import before content in getting-started

### DIFF
--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -5,6 +5,8 @@ sidebar:
   order: 2
 ---
 
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+
 :::tip[macOS Quick Install]
 If you're on macOS with Apple Silicon, skip this page and use the [one-line installer](/devcontainer/install/):
 
@@ -13,9 +15,8 @@ curl -fsSL https://f5xc-salesdemos.github.io/devcontainer/scripts/install.sh | b
 ```
 
 It handles Homebrew packages, iTerm2 config, Podman setup, and downloads everything you need.
-:::
+::::
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
 ## Prerequisites
 
 ### Container Runtime


### PR DESCRIPTION
Closes #996

The import was placed after the :::tip content block, causing acorn to choke on `#` characters in markdown headings. MDX requires imports before content.