### PR TITLE
feat: unique container names to protect running workloads

### DIFF
--- a/devcontainer.sh
+++ b/devcontainer.sh
@@ -260,7 +260,17 @@ fi
 # ============================================================
 cd "$(dirname "$0")"
 
-echo "Starting devcontainer ..."
+# --- container name (stable per directory, unique across workspaces) ---
+NAME_FILE=".devcontainer-name"
+if [ -f "$NAME_FILE" ]; then
+  DEVCONTAINER_NAME=$(cat "$NAME_FILE")
+else
+  DEVCONTAINER_NAME="devcontainer-$(date +%Y%m%d%H%M%S)"
+  echo "$DEVCONTAINER_NAME" >"$NAME_FILE"
+fi
+export DEVCONTAINER_NAME
+
+echo "Starting $DEVCONTAINER_NAME ..."
 echo ""
 
 # --- preflight checks ---

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,8 @@ services:
   dev:
     image: ghcr.io/f5xc-salesdemos/devcontainer:latest
     pull_policy: missing
-    container_name: devcontainer
-    hostname: devcontainer
+    container_name: ${DEVCONTAINER_NAME:-devcontainer}
+    hostname: ${DEVCONTAINER_NAME:-devcontainer}
     env_file:
       - path: .env
         required: false


### PR DESCRIPTION
Closes #998

Each workspace directory gets a stable, unique container name (e.g. `devcontainer-20260418195800`) generated on first run and persisted in `.devcontainer-name`. Subsequent `./devcontainer.sh` reuses the same name.

This prevents `podman compose up -d` from silently recreating a container with active work when run from a different directory.