### PR TITLE
feat: add Pango/JPEG/GIF/RSVG dev libs for native node module builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -91,7 +91,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # hadolint ignore=DL3008
 RUN apt-get update && apt-get install -y --no-install-recommends \
     # System essentials
-    build-essential pkg-config libssl-dev libffi-dev libcairo2-dev cmake lld \
+    build-essential pkg-config libssl-dev libffi-dev cmake lld \
+    # Graphics / image libraries (Cairo + companions for native node modules, e.g. canvas)
+    libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev \
     # Media / utilities
     ffmpeg poppler-utils qrencode \
     # Network tools


### PR DESCRIPTION
## Summary

Adds four apt packages alongside the existing `libcairo2-dev` so that JavaScript projects relying on canvas/SVG-rendering native modules (e.g. `node-canvas`) can build inside the devcontainer:

- `libpango1.0-dev`
- `libjpeg-dev`
- `libgif-dev`
- `librsvg2-dev`

The xcsh CI workflow installs these same packages; this brings the devcontainer Dockerfile to parity.

The existing "System essentials" apt line is split into two logical groups (essentials + "Graphics / image libraries") for readability. `libcairo2-dev` remains installed; net effect is four additional packages.

Closes #1002

## Scope

- apt packages only
- No changes to `entrypoint.sh` (no auto `bun install`)
- `gcc-aarch64-linux-gnu` intentionally NOT added (xcsh-CI-matrix-only)

## Test plan

- [ ] CI checks pass (Check linked issues, Lint Code Base)
- [ ] Docker image builds cleanly with the expanded apt list
- [ ] Hadolint remains green (DL3008 already ignored at the RUN)
- [ ] After rebuild, `dpkg -l | grep -E 'libpango|libjpeg|libgif|librsvg'` shows the new packages inside the container