### PR TITLE
fix: disable interactive mv/cp/rm aliases from common-aliases plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1520,6 +1520,10 @@ RUN ZSH_CUSTOM="${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}" \
     && echo 'export BAT_THEME="Coldark-Dark"' >> "$HOME/.zshrc" \
     && echo 'export BROWSER="browsh"' >> "$HOME/.zshrc" \
     && sed -i '/^source \$ZSH\/oh-my-zsh.sh/i export ZSH_DOTENV_PROMPT=false' "$HOME/.zshrc" \
+    # Override common-aliases plugin's interactive safety shims (rm -i, cp -i, mv -i),
+    # which hang automated scripts on "overwrite? (y/n)" prompts. Custom zsh files in
+    # $ZSH_CUSTOM are sourced AFTER plugins, so the unalias wins.
+    && echo 'unalias rm cp mv 2>/dev/null || true' > "$HOME/.oh-my-zsh/custom/disable-interactive-safety.zsh" \
     && echo '[ -f /run/entrypoint-env.sh ] && . /run/entrypoint-env.sh' >> "$HOME/.zshenv"
 
 # ============================================================


### PR DESCRIPTION
## Summary

The oh-my-zsh `common-aliases` plugin ships three interactive safety shims
(`rm -i`, `cp -i`, `mv -i`) defined at
`plugins/common-aliases/common-aliases.plugin.zsh:49-51`. In an
automation-heavy dev container these prompts hang non-interactive
workflows on overwrite confirmations (observed symptom: scripts reporting
"The mv -i alias blocked the overwrites. Retrying with command mv to bypass.").

This keeps the plugin (33 other useful aliases — `h`, `hgrep`, archive
`extract`, etc.) and drops a one-line override file into `$ZSH_CUSTOM/`
that unalias-es only the three interactive shims. oh-my-zsh sources every
`*.zsh` under `$ZSH_CUSTOM/` AFTER plugins, so the override wins cleanly
without patching a plugin file that oh-my-zsh upgrades would clobber.

Closes #1004

## Changes

- `Dockerfile`: inside the existing zsh-plugin `RUN` block, insert a
  chained step that writes `unalias rm cp mv 2>/dev/null || true` to
  `$HOME/.oh-my-zsh/custom/disable-interactive-safety.zsh`, with a
  3-line comment above explaining intent.

## Test plan

- [x] Pre-commit gate (governance, hadolint, secrets, etc.) green locally
- [x] Manual verification in the running container:
  - [x] Created the same override file; confirmed `rm`, `cp`, `mv`
        aliases no longer present in `alias` output
  - [x] Confirmed sibling aliases (`h`, `hgrep`, `p`, `sortnr`) still resolve
  - [x] `mv src dst` with pre-existing `dst` completes silently in interactive zsh
- [ ] CI: `Check linked issues` + `Lint Code Base` pass on this PR
- [ ] Post-merge: next container rebuild ships without the interactive shims