### PR TITLE
feat: disable Claude Code auto mode in shipped user settings

### DIFF
--- a/claude-config/settings.json
+++ b/claude-config/settings.json
@@ -13,6 +13,7 @@
   "defaultMode": "bypassPermissions",
   "skipDangerousModePermissionPrompt": true,
   "permissions": {
+    "disableAutoMode": "disable",
     "allow": ["Bash", "Edit", "Write", "mcp__*"]
   },
   "enabledPlugins": {


### PR DESCRIPTION
## Summary

Adds `"disableAutoMode": "disable"` inside the existing `permissions` object in `claude-config/settings.json`.

Claude Code now ships a research-preview "auto mode" permission mode that uses a classifier to decide whether each action is safe. It can be engaged via `Shift+Tab` cycle or `--permission-mode auto`. This devcontainer is a fully sandboxed dev environment and the standard invocation is `claude --dangerously-skip-permissions`, already backed by `defaultMode: "bypassPermissions"` and `skipDangerousModePermissionPrompt: true` in the same file. We don't want the classifier running at all and we don't want it reachable from the UI.

Closes #1006

## Schema verification

Cross-checked against two authoritative sources:

1. https://code.claude.com/docs/en/permissions — *"To prevent ... auto mode from being used, set `permissions.disableAutoMode` to `\"disable\"` in any settings file."*
2. https://code.claude.com/docs/en/settings — settings table confirms key `disableAutoMode` nests under `permissions`, value `"disable"`.

## Effect (per docs)

- Removes `auto` from the Shift+Tab cycle
- Rejects `--permission-mode auto` at startup

## Scope

User settings (baked to `/home/vscode/.claude/settings.json`), not managed settings — mirrors what an actual developer would have. `defaultMode: "bypassPermissions"` and `skipDangerousModePermissionPrompt: true` unchanged; the `--dangerously-skip-permissions` path is untouched.

## Diff

```diff
   "permissions": {
+    "disableAutoMode": "disable",
     "allow": ["Bash", "Edit", "Write", "mcp__*"]
   },
```

## Test plan

- [ ] CI checks pass (super-linter, biome, spelling, editorconfig, secrets)
- [x] `jq .` parses the file cleanly (validated pre-commit)
- [x] Live-applied to `~/.claude/settings.json` in the container; `claude --print` ran with no schema errors