### PR TITLE
fix: entrypoint and env persistence for OCI-format local builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1542,7 +1542,8 @@ RUN ZSH_CUSTOM="${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}" \
     # which hang automated scripts on "overwrite? (y/n)" prompts. Custom zsh files in
     # $ZSH_CUSTOM are sourced AFTER plugins, so the unalias wins.
     && echo 'unalias rm cp mv 2>/dev/null || true' > "$HOME/.oh-my-zsh/custom/disable-interactive-safety.zsh" \
-    && echo '[ -f /run/entrypoint-env.sh ] && . /run/entrypoint-env.sh' >> "$HOME/.zshenv"
+    && echo '[ -f /run/entrypoint-env.sh ] && . /run/entrypoint-env.sh' >> "$HOME/.zshenv" \
+    && mkdir -p /etc/zsh && echo '[ -f /run/entrypoint-env.sh ] && . /run/entrypoint-env.sh' >> /etc/zsh/zshenv
 
 # ============================================================
 # 16. User shell bootstrap (baked in — eliminates runtime setup)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,4 @@
+---
 services:
   dev:
     image: ghcr.io/f5xc-salesdemos/devcontainer:latest
@@ -31,4 +32,5 @@ services:
     tty: true
     init: true
     restart: unless-stopped
+    entrypoint: ["/usr/local/bin/entrypoint.sh"]
     command: zsh


### PR DESCRIPTION
Closes #1010

Three fixes for local arm64 builds:
1. `docker-compose.yml`: explicit `entrypoint:` — OCI format drops Dockerfile `ENTRYPOINT`
2. `Dockerfile`: `/etc/zsh/zshenv` sources `/run/entrypoint-env.sh` for all users
3. `Dockerfile`: pwsh wrapped in subshell to survive SIGILL on arm64 VM