### PR TITLE
feat: run as vscode (no sudo), 196-assertion smoke tests, xcsh modelRoles

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -17,6 +17,7 @@ on:
       - omp-config/**
       - scripts/**
       - docker-compose.yml
+      - tests/**
       - .devcontainer/**
       - .github/workflows/docker-publish.yml
   schedule:
@@ -137,3 +138,25 @@ jobs:
           sources=$(printf '${{ env.MAIN_IMAGE }}@sha256:%s ' *)
           # shellcheck disable=SC2086
           docker buildx imagetools create $tags $sources
+
+
+  # ── Post-build smoke test (render-only in CI, no VPN/API keys) ──
+  smoke-test:
+    runs-on: ubuntu-24.04-arm
+    needs: merge
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull published image
+        run: docker pull ${{ env.MAIN_IMAGE }}:latest
+
+      - name: Run smoke test (render-only)
+        run: ./tests/smoke-test.sh ${{ env.MAIN_IMAGE }}:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -999,12 +999,34 @@ RUN rm -rf /opt/firecrawl/.git
 
 WORKDIR /
 
-# Relax PostgreSQL auth for local socket connections (entrypoint manages lifecycle)
-# hadolint ignore=DL3059
-RUN PG_HBA=$(find /etc/postgresql -name pg_hba.conf -print -quit 2>/dev/null) \
+# PostgreSQL: create a vscode-owned cluster so the entrypoint can start it without sudo.
+# Drop the default postgres-user cluster and replace with one owned by vscode.
+# Auth is set to 'trust' for local socket connections (single-user container).
+# hadolint ignore=DL3059,SC2046
+RUN pg_dropcluster --stop $(pg_lsclusters -h | awk 'NR==1{print $1, $2}') 2>/dev/null || true \
+    && mkdir -p /home/${USERNAME}/.local/run/postgresql \
+       /home/${USERNAME}/.local/lib/postgresql \
+    && chown -R ${USERNAME}:${USERNAME} \
+       /home/${USERNAME}/.local/run/postgresql \
+       /home/${USERNAME}/.local/lib/postgresql \
+    && su - ${USERNAME} -c "pg_createcluster \
+       --datadir=/home/${USERNAME}/.local/lib/postgresql/data \
+       --socketdir=/home/${USERNAME}/.local/run/postgresql \
+       --start-conf=manual \
+       $(dpkg -l 'postgresql-*' | awk '/^ii.*postgresql-[0-9]/{gsub(/postgresql-/,\"\");print \$2;exit}') main" \
+    && PG_HBA=$(find /home/${USERNAME}/.local/lib/postgresql -name pg_hba.conf -print -quit 2>/dev/null) \
     && if [ -n "$PG_HBA" ]; then \
         sed -i 's/peer/trust/g; s/scram-sha-256/trust/g' "$PG_HBA"; \
       fi
+
+# RabbitMQ: configure user-writable data and log directories.
+# hadolint ignore=DL3059
+RUN mkdir -p /home/${USERNAME}/.local/lib/rabbitmq \
+       /home/${USERNAME}/.local/log/rabbitmq \
+    && chown -R ${USERNAME}:${USERNAME} \
+       /home/${USERNAME}/.local/lib/rabbitmq \
+       /home/${USERNAME}/.local/log/rabbitmq \
+       /var/lib/rabbitmq /var/log/rabbitmq /etc/rabbitmq 2>/dev/null || true
 
 # ============================================================
 # 12. pip tools
@@ -1501,6 +1523,7 @@ USER $USERNAME
 # ============================================================
 # hadolint ignore=DL3059
 # checkov:skip=CKV2_DOCKER_1:sudo here is a zsh plugin name in a sed argument, not a system call
+# trivy:ignore:DS-0013
 RUN ZSH_CUSTOM="${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}" \
     && git clone --depth=1 https://github.com/zsh-users/zsh-autosuggestions.git \
       "${ZSH_CUSTOM}/plugins/zsh-autosuggestions" \
@@ -1543,7 +1566,8 @@ RUN ZSH_CUSTOM="${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}" \
     # $ZSH_CUSTOM are sourced AFTER plugins, so the unalias wins.
     && echo 'unalias rm cp mv 2>/dev/null || true' > "$HOME/.oh-my-zsh/custom/disable-interactive-safety.zsh" \
     && echo '[ -f /run/entrypoint-env.sh ] && . /run/entrypoint-env.sh' >> "$HOME/.zshenv" \
-    && mkdir -p /etc/zsh && echo '[ -f /run/entrypoint-env.sh ] && . /run/entrypoint-env.sh' >> /etc/zsh/zshenv
+    && mkdir -p /etc/zsh && echo '[ -f /run/entrypoint-env.sh ] && . /run/entrypoint-env.sh' >> /etc/zsh/zshenv \
+    && echo '[ -d /workspace ] && cd /workspace' >> "$HOME/.zshrc"
 
 # ============================================================
 # 16. User shell bootstrap (baked in — eliminates runtime setup)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,5 +32,6 @@ services:
     tty: true
     init: true
     restart: unless-stopped
+    user: vscode
     entrypoint: ["/usr/local/bin/entrypoint.sh"]
     command: zsh

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,10 +3,16 @@
 # Configure user environment (env-var-dependent only)
 # ============================================================
 
-# Ensure Rust toolchain dirs are writable (Dockerfile chown can be
-# lost by layer caching or volume mounts).
+# Resolve HOME to the build-time user's home directory.
+# OCI-format builds and init wrappers may run the entrypoint as
+# root with HOME=/root, but all configs live under /home/vscode.
+if [ -d /home/vscode ] && [ "$HOME" != "/home/vscode" ]; then
+  export HOME=/home/vscode
+fi
+
+# Rust toolchain: warn if not writable (fix ownership in Dockerfile, not at runtime)
 if [ -d /usr/local/rustup ] && [ ! -w /usr/local/rustup ]; then
-  sudo chown -R "$(id -u):$(id -g)" /usr/local/rustup /usr/local/cargo 2>/dev/null || true
+  echo 'WARNING: /usr/local/rustup is not writable — Rust toolchain updates will fail' >&2
 fi
 
 if [ -n "$GIT_AUTHOR_NAME" ]; then
@@ -20,10 +26,8 @@ fi
 
 git config --global --add safe.directory /workspace
 
-if [ -n "$TZ" ]; then
-  sudo ln -snf "/usr/share/zoneinfo/$TZ" /etc/localtime
-  echo "$TZ" | sudo tee /etc/timezone >/dev/null
-fi
+# TZ is handled by the TZ env var; glibc reads it directly.
+# No need to write /etc/localtime (requires root).
 
 if [ -n "$SSH_PRIVATE_KEY" ]; then
   _old_umask=$(umask)
@@ -56,7 +60,9 @@ if [ ! -L "$HOME/.agents/skills" ]; then
   ln -sf "$HOME/.claude/skills" "$HOME/.agents/skills"
 fi
 
-sudo cron 2>/dev/null || true
+# Start cron for user-level scheduled tasks (nightly-update)
+# The user crontab is set at build time in the Dockerfile.
+cron 2>/dev/null || true
 
 # ============================================================
 # gogcli (gog) — restore OAuth credentials and refresh token
@@ -133,6 +139,12 @@ if [ -n "$LITELLM_BASE_URL" ]; then
   export ANTHROPIC_DEFAULT_HAIKU_MODEL="claude-haiku-4-5"
   export ANTHROPIC_DEFAULT_SONNET_MODEL="claude-sonnet-4-6"
   export ANTHROPIC_DEFAULT_OPUS_MODEL="pd-claude-opus-4-7"
+  export ANTHROPIC_API_ENDPOINT="${LITELLM_BASE_URL}/anthropic"
+  # xcsh/pi/omp model defaults (PI_* env vars)
+  export PI_DEFAULT_MODEL="anthropic/claude-sonnet-4-6"
+  export PI_SMOL_MODEL="anthropic/claude-haiku-4-5"
+  export PI_SLOW_MODEL="anthropic/pd-claude-opus-4-7"
+  export PI_PLAN_MODEL="anthropic/pd-claude-opus-4-7"
 fi
 
 # ============================================================
@@ -287,6 +299,8 @@ providers:
       type: openai-compat
 EOF
   unset _xcsh_models
+  # Set default model roles so xcsh works without --model flag
+  xcsh config set modelRoles '{"default":"anthropic/claude-sonnet-4-6","smol":"anthropic/claude-haiku-4-5","slow":"anthropic/pd-claude-opus-4-7","plan":"anthropic/pd-claude-opus-4-7"}' >/dev/null 2>&1 || true
 fi
 
 # ============================================================
@@ -364,8 +378,10 @@ fix_chrome_symlink() {
   chrome_bin=$(find "$HOME/.cache/ms-playwright" \
     -name chrome -path '*/chromium-*/chrome-linux*/chrome' -print -quit 2>/dev/null || true)
   if [ -n "$chrome_bin" ]; then
-    sudo mkdir -p /opt/google/chrome
-    sudo ln -sf "$chrome_bin" /opt/google/chrome/chrome
+    mkdir -p "$HOME/.local/opt/google/chrome"
+    ln -sf "$chrome_bin" "$HOME/.local/opt/google/chrome/chrome"
+    # Add to PATH so chrome-browser.sh and MCP servers find it
+    export PATH="$HOME/.local/opt/google/chrome:$PATH"
   fi
 }
 fix_chrome_symlink
@@ -748,36 +764,39 @@ if [ "${ENABLE_FIRECRAWL:-true}" = "true" ] && [ -d /opt/firecrawl ]; then
   # Redis (daemonised, logs to /tmp/redis.log)
   redis-server --daemonize yes --logfile /tmp/redis.log 2>/dev/null
 
-  # PostgreSQL — ensure runtime dir exists and start cluster
-  sudo mkdir -p /var/run/postgresql
-  sudo chown postgres:postgres /var/run/postgresql
+  # PostgreSQL — vscode-owned cluster (set up in Dockerfile)
+  _pg_socket="$HOME/.local/run/postgresql"
+  mkdir -p "$_pg_socket" 2>/dev/null || true
   _pg_cluster=$(pg_lsclusters -h 2>/dev/null | awk 'NR==1{print $1, $2}')
   if [ -n "$_pg_cluster" ]; then
     # shellcheck disable=SC2086
-    sudo pg_ctlcluster $_pg_cluster start 2>/dev/null || true
+    pg_ctlcluster $_pg_cluster start 2>/dev/null || true
   fi
   unset _pg_cluster
 
   # Wait for PostgreSQL readiness (up to 5s)
   for _i in $(seq 1 10); do
-    pg_isready -h /var/run/postgresql -q 2>/dev/null && break
+    pg_isready -h "$_pg_socket" -q 2>/dev/null && break
     sleep 0.5
   done
   unset _i
 
   # Initialise firecrawl database on first run
-  if pg_isready -h /var/run/postgresql -q 2>/dev/null; then
-    if ! psql -h /var/run/postgresql -U postgres -lqt 2>/dev/null | grep -qw firecrawl; then
-      createdb -h /var/run/postgresql -U postgres firecrawl 2>/dev/null
-      psql -h /var/run/postgresql -U postgres -d firecrawl \
+  if pg_isready -h "$_pg_socket" -q 2>/dev/null; then
+    if ! psql -h "$_pg_socket" -lqt 2>/dev/null | grep -qw firecrawl; then
+      createdb -h "$_pg_socket" firecrawl 2>/dev/null || true
+      psql -h "$_pg_socket" -d firecrawl \
         -f /opt/firecrawl/apps/nuq-postgres/nuq.sql >/dev/null 2>&1 || true
     fi
   fi
+  unset _pg_socket
 
-  # RabbitMQ (required for extract endpoint)
-  sudo rabbitmq-server -detached 2>/dev/null || true
+  # RabbitMQ — user-writable dirs (set up in Dockerfile)
+  RABBITMQ_MNESIA_BASE="$HOME/.local/lib/rabbitmq" \
+    RABBITMQ_LOG_BASE="$HOME/.local/log/rabbitmq" \
+    rabbitmq-server >/dev/null 2>&1 &
   for _i in $(seq 1 10); do
-    sudo rabbitmqctl status >/dev/null 2>&1 && break
+    rabbitmqctl status >/dev/null 2>&1 && break
     sleep 1
   done
   unset _i
@@ -857,16 +876,16 @@ start_chrome_browser
 # Tailscale (userspace networking)
 # ============================================================
 if [ "${ENABLE_TAILSCALE:-false}" = "true" ]; then
-  sudo tailscaled --tun=userspace-networking --state=/var/lib/tailscale/tailscaled.state >/dev/null 2>&1 &
+  tailscaled --tun=userspace-networking --state="$HOME/.local/tailscale/tailscaled.state" >/dev/null 2>&1 &
   if [ -n "$TAILSCALE_AUTHKEY" ]; then
     (
       retries=0
       while [ $retries -lt 50 ]; do
-        sudo tailscale status >/dev/null 2>&1 && break
+        tailscale status >/dev/null 2>&1 && break
         sleep 0.1
         retries=$((retries + 1))
       done
-      sudo tailscale up --authkey="$TAILSCALE_AUTHKEY" --accept-routes >/dev/null 2>&1
+      tailscale up --authkey="$TAILSCALE_AUTHKEY" --accept-routes >/dev/null 2>&1
     ) &
   fi
 fi
@@ -901,6 +920,7 @@ ENVEOF
     ANTHROPIC_DEFAULT_SONNET_MODEL ANTHROPIC_DEFAULT_OPUS_MODEL \
     OPENAI_API_KEY OPENAI_BASE_URL \
     ANTHROPIC_OAUTH_TOKEN \
+    PI_DEFAULT_MODEL PI_SMOL_MODEL PI_SLOW_MODEL PI_PLAN_MODEL \
     GIT_COMMITTER_NAME GIT_COMMITTER_EMAIL; do
     eval "_val=\${${_var}:-}"
     [ -n "$_val" ] && printf 'export %s=%q\n' "$_var" "$_val"

--- a/tests/smoke-test.sh
+++ b/tests/smoke-test.sh
@@ -1,0 +1,543 @@
+#!/bin/bash
+set -euo pipefail
+
+# ============================================================
+# Devcontainer smoke test — validates entrypoint rendering,
+# env var derivation, daemon health, and tool availability.
+#
+# Usage:
+#   ./tests/smoke-test.sh                             # registry image
+#   ./tests/smoke-test.sh localhost/devcontainer:dev   # local build
+#
+# Two modes determined automatically:
+#   LITELLM_API_KEY + LITELLM_BASE_URL set → full test (render + functional)
+#   Not set → render-only test with dummy values (functional tests skipped)
+# ============================================================
+
+# Auto-detect container runtime
+if command -v podman >/dev/null 2>&1; then
+  RT=podman
+elif command -v docker >/dev/null 2>&1; then
+  RT=docker
+else
+  echo "Error: neither podman nor docker found" >&2
+  exit 1
+fi
+
+IMAGE="${1:-ghcr.io/f5xc-salesdemos/devcontainer:latest}"
+CONTAINER="smoke-test-$$"
+COMPOSE_DIR=$(mktemp -d /tmp/smoke-XXXX)
+PASS=0
+FAIL=0
+SKIP=0
+
+# shellcheck disable=SC2329
+cleanup() {
+  "$RT" stop "$CONTAINER" >/dev/null 2>&1 || true
+  "$RT" rm "$CONTAINER" >/dev/null 2>&1 || true
+  rm -rf "$COMPOSE_DIR"
+}
+trap cleanup EXIT
+
+ok() {
+  PASS=$((PASS + 1))
+  printf '  \033[32m✓\033[0m %s\n' "$*"
+}
+fail() {
+  FAIL=$((FAIL + 1))
+  printf '  \033[31m✗\033[0m %s\n' "$*"
+}
+# shellcheck disable=SC2329
+skip() {
+  SKIP=$((SKIP + 1))
+  printf '  \033[33m-\033[0m %s\n' "$*"
+}
+
+assert_eq() {
+  local desc="$1" actual="$2" expected="$3"
+  if [ "$actual" = "$expected" ]; then
+    ok "$desc"
+  else fail "$desc (expected='$expected' got='$actual')"; fi
+}
+
+assert_contains() {
+  local desc="$1" haystack="$2" needle="$3"
+  if echo "$haystack" | grep -q "$needle"; then
+    ok "$desc"
+  else fail "$desc (missing: '$needle')"; fi
+}
+
+assert_not_contains() {
+  local desc="$1" haystack="$2" needle="$3"
+  if echo "$haystack" | grep -q "$needle"; then
+    fail "$desc (unexpected: '$needle')"
+  else ok "$desc"; fi
+}
+
+assert_file() {
+  local desc="$1" path="$2"
+  if run test -f "$path"; then
+    ok "$desc"
+  else fail "$desc ($path missing)"; fi
+}
+
+assert_dir() {
+  local desc="$1" path="$2"
+  if run test -d "$path"; then
+    ok "$desc"
+  else fail "$desc ($path missing)"; fi
+}
+
+assert_bin() {
+  local name="$1"
+  if "$RT" exec -u vscode "$CONTAINER" zsh -c "command -v $name" >/dev/null 2>&1; then
+    ok "$name"
+  else
+    fail "$name (not on PATH)"
+  fi
+}
+
+assert_bin_ver() {
+  local name="$1" cmd="$2" pattern="$3"
+  local out
+  out=$("$RT" exec -u vscode "$CONTAINER" zsh -c "$cmd" 2>&1 || true)
+  if echo "$out" | grep -qi "$pattern"; then
+    ok "$name"
+  else fail "$name (version check failed)"; fi
+}
+
+run() { "$RT" exec -u vscode "$CONTAINER" "$@" 2>/dev/null; }
+zrun() { "$RT" exec -u vscode "$CONTAINER" zsh -c "$*" 2>/dev/null; }
+
+# ============================================================
+# Determine test mode: live (real creds) or render-only (dummy)
+# ============================================================
+DUMMY_URL="https://litellm.example.com"
+DUMMY_KEY="not-a-real-key" # gitleaks:allow
+
+if [ -n "${LITELLM_API_KEY:-}" ] && [ -n "${LITELLM_BASE_URL:-}" ]; then
+  TEST_URL="$LITELLM_BASE_URL"
+  TEST_KEY="$LITELLM_API_KEY"
+  LIVE_API=true
+else
+  TEST_URL="$DUMMY_URL"
+  TEST_KEY="$DUMMY_KEY"
+  LIVE_API=false
+fi
+
+# ============================================================
+# Setup
+# ============================================================
+echo ""
+echo "Devcontainer Smoke Test"
+echo "======================="
+echo "Image: $IMAGE"
+if [ "$LIVE_API" = true ]; then
+  echo "Mode:  LIVE (functional tests enabled)"
+else
+  echo "Mode:  RENDER-ONLY (functional tests skipped — no LITELLM credentials)"
+fi
+echo ""
+
+cat >"$COMPOSE_DIR/docker-compose.yml" <<YAML
+---
+services:
+  dev:
+    image: $IMAGE
+    pull_policy: never
+    container_name: $CONTAINER
+    hostname: $CONTAINER
+    env_file:
+      - path: .env
+        required: false
+    environment:
+      - TZ=America/Toronto
+      - GH_TOKEN=test-gh-token-12345
+    cap_drop:
+      - ALL
+    cap_add:
+      - CHOWN
+      - DAC_OVERRIDE
+      - FOWNER
+      - SETUID
+      - SETGID
+      - NET_RAW
+      - NET_ADMIN
+    mem_limit: 4g
+    cpus: 2
+    tmpfs:
+      - /tmp:size=256m
+    stdin_open: true
+    tty: true
+    init: true
+    restart: "no"
+    user: vscode
+    entrypoint: ["/usr/local/bin/entrypoint.sh"]
+    command: sleep infinity
+YAML
+
+cat >"$COMPOSE_DIR/.env" <<EOF
+LITELLM_BASE_URL=$TEST_URL
+LITELLM_API_KEY=$TEST_KEY
+GIT_AUTHOR_NAME=Smoke Tester
+GIT_AUTHOR_EMAIL=smoke@test.local
+EOF
+
+echo "Starting container ..."
+"$RT" compose -f "$COMPOSE_DIR/docker-compose.yml" up -d >/dev/null 2>&1
+
+echo "Waiting for entrypoint ..."
+for _ in $(seq 1 90); do
+  if run test -f /run/entrypoint-env.sh; then break; fi
+  sleep 1
+done
+sleep 5
+
+# ============================================================
+# 1. Entrypoint env rendering (always runs — real or dummy values)
+# ============================================================
+echo ""
+echo "Entrypoint env derivation"
+echo "-------------------------"
+ENV_FILE=$(run cat /run/entrypoint-env.sh)
+assert_file "/run/entrypoint-env.sh exists" "/run/entrypoint-env.sh"
+assert_contains "ANTHROPIC_API_KEY derived" "$ENV_FILE" "ANTHROPIC_API_KEY=$TEST_KEY"
+assert_contains "ANTHROPIC_BASE_URL derived" "$ENV_FILE" "ANTHROPIC_BASE_URL=${TEST_URL}/anthropic"
+assert_contains "ANTHROPIC_API_ENDPOINT derived" "$ENV_FILE" "ANTHROPIC_API_ENDPOINT=${TEST_URL}/anthropic"
+assert_contains "OPENAI_API_KEY derived" "$ENV_FILE" "OPENAI_API_KEY=$TEST_KEY"
+assert_contains "OPENAI_BASE_URL derived" "$ENV_FILE" "OPENAI_BASE_URL=${TEST_URL}/openai/v1"
+assert_contains "ANTHROPIC_SMALL_FAST_MODEL" "$ENV_FILE" "claude-haiku-4-5"
+assert_contains "ANTHROPIC_DEFAULT_HAIKU_MODEL" "$ENV_FILE" "claude-haiku-4-5"
+assert_contains "ANTHROPIC_DEFAULT_SONNET_MODEL" "$ENV_FILE" "claude-sonnet-4-6"
+assert_contains "ANTHROPIC_DEFAULT_OPUS_MODEL" "$ENV_FILE" "pd-claude-opus-4-7"
+assert_contains "GIT_COMMITTER_NAME derived" "$ENV_FILE" "GIT_COMMITTER_NAME="
+assert_contains "GIT_COMMITTER_EMAIL derived" "$ENV_FILE" "GIT_COMMITTER_EMAIL=smoke@test.local"
+
+assert_contains "PI_DEFAULT_MODEL set" "$ENV_FILE" "PI_DEFAULT_MODEL=anthropic/claude-sonnet-4-6"
+assert_contains "PI_SMOL_MODEL set" "$ENV_FILE" "PI_SMOL_MODEL=anthropic/claude-haiku-4-5"
+assert_contains "PI_SLOW_MODEL set" "$ENV_FILE" "PI_SLOW_MODEL=anthropic/pd-claude-opus-4-7"
+assert_contains "PI_PLAN_MODEL set" "$ENV_FILE" "PI_PLAN_MODEL=anthropic/pd-claude-opus-4-7"
+
+# Verify shell inheritance of PI_* model vars (xcsh/pi/omp read these)
+SHELL_PI_DEFAULT=$(zrun 'echo $PI_DEFAULT_MODEL')
+assert_eq "zsh inherits PI_DEFAULT_MODEL" "$SHELL_PI_DEFAULT" "anthropic/claude-sonnet-4-6"
+SHELL_PI_SMOL=$(zrun 'echo $PI_SMOL_MODEL')
+assert_eq "zsh inherits PI_SMOL_MODEL" "$SHELL_PI_SMOL" "anthropic/claude-haiku-4-5"
+SHELL_PI_SLOW=$(zrun 'echo $PI_SLOW_MODEL')
+assert_eq "zsh inherits PI_SLOW_MODEL" "$SHELL_PI_SLOW" "anthropic/pd-claude-opus-4-7"
+
+# ============================================================
+# 2. Shell sourcing
+# ============================================================
+echo ""
+echo "Shell env sourcing"
+echo "------------------"
+assert_file "/etc/zsh/zshenv" "/etc/zsh/zshenv"
+assert_contains "System zshenv sources env" "$(run cat /etc/zsh/zshenv)" "entrypoint-env"
+assert_file "vscode .zshenv" "/home/vscode/.zshenv"
+assert_contains "User zshenv sources env" "$(run cat /home/vscode/.zshenv)" "entrypoint-env"
+PROFILED=$(run readlink /etc/profile.d/99-entrypoint-env.sh)
+assert_eq "profile.d symlink" "$PROFILED" "/run/entrypoint-env.sh"
+SHELL_KEY=$(zrun 'echo $ANTHROPIC_API_KEY')
+assert_eq "zsh -c inherits ANTHROPIC_API_KEY" "$SHELL_KEY" "$TEST_KEY"
+
+# ============================================================
+# 3. Environment
+# ============================================================
+echo ""
+echo "Environment"
+echo "-----------"
+assert_eq "TZ=EDT" "$(run date +%Z)" "EDT"
+assert_eq "GH_TOKEN" "$(run printenv GH_TOKEN)" "test-gh-token-12345"
+assert_eq "git user.name" "$(run git config --global user.name)" "Smoke Tester"
+assert_eq "git user.email" "$(run git config --global user.email)" "smoke@test.local"
+assert_eq "HOME=/home/vscode" "$(run printenv HOME)" "/home/vscode"
+assert_eq "user=vscode" "$(run whoami)" "vscode"
+
+# ============================================================
+# 4. AI assistant configs (always runs — validates rendering)
+# ============================================================
+echo ""
+echo "AI assistant configs"
+echo "--------------------"
+
+# Claude Code
+CS=$(run cat /home/vscode/.claude/settings.json)
+assert_contains "Claude: sonnet model in settings" "$CS" "claude-sonnet-4-6"
+assert_contains "Claude: opus model in settings" "$CS" "pd-claude-opus-4-7"
+assert_contains "Claude: haiku model in settings" "$CS" "claude-haiku-4-5"
+CJ=$(run cat /home/vscode/.claude.json)
+assert_contains "Claude: auto-approve key" "$CJ" "customApiKeyResponses"
+
+# Crush
+CRUSH=$(run cat /home/vscode/.config/crush/crush.json)
+assert_not_contains "Crush: no __CRUSH_BASE_URL__ placeholder" "$CRUSH" "__CRUSH_BASE_URL__"
+assert_contains "Crush: base_url rendered" "$CRUSH" "${TEST_URL}/anthropic"
+assert_contains "Crush: opus model" "$CRUSH" "pd-claude-opus-4-7"
+assert_contains "Crush: auto-update disabled" "$CRUSH" "disable_provider_auto_update"
+
+# Pi
+PI=$(run cat /home/vscode/.pi/agent/settings.json)
+assert_contains "Pi: provider=anthropic" "$PI" "anthropic"
+assert_contains "Pi: model=opus" "$PI" "pd-claude-opus-4-7"
+
+# OMP
+OMP_S=$(run cat /home/vscode/.omp/agent/settings.json)
+assert_contains "OMP: provider=anthropic" "$OMP_S" "anthropic"
+assert_contains "OMP: model=opus" "$OMP_S" "pd-claude-opus-4-7"
+OMP_C=$(run cat /home/vscode/.omp/agent/config.yml)
+assert_contains "OMP: haiku role" "$OMP_C" "claude-haiku-4-5"
+assert_contains "OMP: opus default role" "$OMP_C" "pd-claude-opus-4-7"
+
+# Codex
+CODEX=$(run cat /home/vscode/.codex/config.toml)
+assert_contains "Codex: litellm provider" "$CODEX" 'model_provider = "litellm"'
+assert_contains "Codex: base_url rendered" "$CODEX" "${TEST_URL}/openai/v1"
+assert_contains "Codex: reads OPENAI_API_KEY" "$CODEX" 'env_key = "OPENAI_API_KEY"'
+
+# OpenCode
+OC=$(run cat /home/vscode/.config/opencode/opencode.json)
+assert_contains "OpenCode: anthropic-proxy provider" "$OC" "anthropic-proxy"
+assert_contains "OpenCode: opus model" "$OC" "pd-claude-opus-4-7"
+assert_contains "OpenCode: sonnet model" "$OC" "claude-sonnet-4-6"
+assert_contains "OpenCode: openai-proxy provider" "$OC" "openai-proxy"
+
+# xcsh: models.json registered, models.yml written, modelRoles configured
+assert_file "xcsh models.json" "/home/vscode/.xcsh/agent/models.json"
+assert_file "xcsh models.yml" "/home/vscode/.xcsh/agent/models.yml"
+XCSH_ROLES=$(zrun 'xcsh config get modelRoles 2>/dev/null')
+assert_contains "xcsh: default role = sonnet" "$XCSH_ROLES" "claude-sonnet-4-6"
+assert_contains "xcsh: slow role = opus" "$XCSH_ROLES" "pd-claude-opus-4-7"
+assert_contains "xcsh: smol role = haiku" "$XCSH_ROLES" "claude-haiku-4-5"
+
+# ============================================================
+# 5. AI assistant CLIs
+# ============================================================
+echo ""
+echo "AI assistants"
+echo "-------------"
+assert_bin_ver "claude" "claude --version" "claude"
+assert_bin_ver "crush" "crush --version" "crush"
+assert_bin_ver "pi" "pi --version" "[0-9]"
+assert_bin_ver "omp" "omp --version" "[0-9]"
+assert_bin_ver "xcsh" "xcsh --version" "xcsh"
+assert_bin_ver "opencode" "opencode --version" "."
+assert_bin_ver "codex" "codex --version" "codex"
+
+# ============================================================
+# 5b. AI functional tests (LIVE mode only)
+# ============================================================
+echo ""
+echo "AI functional tests"
+echo "-------------------"
+
+if [ "$LIVE_API" = true ]; then
+  PROMPT="reply with only the single word: hello"
+  EXPECTED="hello"
+
+  _out=$(timeout 60 "$RT" exec -u vscode "$CONTAINER" zsh -c "claude -p '$PROMPT'" 2>&1 || true)
+  if echo "$_out" | grep -qi "$EXPECTED"; then
+    ok "claude prompt"
+  else fail "claude prompt (got: $(echo "$_out" | head -1))"; fi
+
+  _out=$(timeout 60 "$RT" exec -u vscode "$CONTAINER" zsh -c "pi -p '$PROMPT'" 2>&1 || true)
+  if echo "$_out" | grep -qi "$EXPECTED"; then
+    ok "pi prompt"
+  else fail "pi prompt (got: $(echo "$_out" | head -1))"; fi
+
+  _out=$(timeout 60 "$RT" exec -u vscode "$CONTAINER" zsh -c "crush run '$PROMPT'" 2>&1 || true)
+  if echo "$_out" | grep -qi "$EXPECTED"; then
+    ok "crush prompt"
+  else fail "crush prompt (got: $(echo "$_out" | head -1))"; fi
+
+  # xcsh: reads PI_DEFAULT_MODEL from env (no explicit --provider/--model needed)
+  _out=$(timeout 60 "$RT" exec -u vscode "$CONTAINER" zsh -c "xcsh -p '$PROMPT'" 2>&1 || true)
+  if echo "$_out" | grep -qi "$EXPECTED"; then
+    ok "xcsh prompt"
+  else fail "xcsh prompt (got: $(echo "$_out" | head -1))"; fi
+
+  _out=$(timeout 60 "$RT" exec -u vscode "$CONTAINER" zsh -c "mkdir -p /tmp/codex-test && cd /tmp/codex-test && git init -q 2>/dev/null; codex exec --skip-git-repo-check '$PROMPT'" 2>&1 || true)
+  if echo "$_out" | grep -qi "$EXPECTED"; then
+    ok "codex prompt"
+  else fail "codex prompt (got: $(echo "$_out" | head -1))"; fi
+
+  _out=$(timeout 60 "$RT" exec -u vscode "$CONTAINER" zsh -c "cd /tmp && opencode run '$PROMPT'" 2>&1 || true)
+  if echo "$_out" | grep -qi "$EXPECTED"; then
+    ok "opencode prompt"
+  else fail "opencode prompt (got: $(echo "$_out" | head -1))"; fi
+
+  _out=$("$RT" exec -u vscode "$CONTAINER" zsh -c 'curl -sf "$ANTHROPIC_BASE_URL/v1/messages" -X POST -H "x-api-key: $ANTHROPIC_API_KEY" -H "content-type: application/json" -H "anthropic-version: 2023-06-01" -d "{\"model\":\"claude-sonnet-4-6\",\"max_tokens\":5,\"messages\":[{\"role\":\"user\",\"content\":\"reply only: hello\"}]}" | jq -r ".content[0].text"' 2>&1 || true)
+  if echo "$_out" | grep -qi "hello"; then
+    ok "API direct curl"
+  else fail "API direct curl (got: $(echo "$_out" | head -1))"; fi
+else
+  skip "claude prompt (no live API)"
+  skip "pi prompt (no live API)"
+  skip "crush prompt (no live API)"
+  skip "xcsh prompt (no live API)"
+  skip "codex prompt (no live API)"
+  skip "opencode prompt (no live API)"
+  skip "API direct curl (no live API)"
+fi
+
+# ============================================================
+# 6. Daemons
+# ============================================================
+echo ""
+echo "Daemons"
+echo "-------"
+REDIS=$(zrun 'redis-cli ping 2>/dev/null || echo FAIL')
+assert_eq "Redis responds PONG" "$REDIS" "PONG"
+
+PG=$(zrun 'pg_isready -h $HOME/.local/run/postgresql -q 2>/dev/null && echo OK || echo FAIL')
+assert_eq "PostgreSQL ready" "$PG" "OK"
+
+# rabbitmqctl refuses non-root/non-rabbitmq users; check AMQP port instead
+RMQ=$(zrun 'timeout 2 bash -c "echo | nc -w1 localhost 5672" >/dev/null 2>&1 && echo OK || echo FAIL')
+assert_eq "RabbitMQ listening on 5672" "$RMQ" "OK"
+
+CRON=$(zrun 'crontab -l 2>/dev/null | grep -c nightly-update')
+assert_eq "Cron: nightly-update scheduled" "$CRON" "1"
+
+# ============================================================
+# 7. Languages & runtimes
+# ============================================================
+echo ""
+echo "Languages"
+echo "---------"
+assert_bin_ver "node" "node --version" "v"
+assert_bin_ver "python3" "python3 --version" "Python"
+assert_bin_ver "go" "go version" "go"
+assert_bin_ver "rustc" "rustc --version" "rustc"
+assert_bin_ver "cargo" "cargo --version" "cargo"
+assert_bin_ver "java" "java -version 2>&1" "openjdk"
+assert_bin_ver "ruby" "ruby --version" "ruby"
+assert_bin_ver "php" "php --version" "PHP"
+assert_bin_ver "perl" "perl --version" "perl"
+assert_bin_ver "dart" "dart --version 2>&1" "Dart"
+assert_bin_ver "dotnet" "dotnet --version" "."
+assert_bin_ver "zig" "zig version" "."
+assert_bin_ver "bun" "bun --version" "."
+assert_bin_ver "lua" "lua5.4 -v 2>&1" "Lua"
+assert_bin_ver "Rscript" "Rscript --version 2>&1" "."
+
+# ============================================================
+# 8. Cloud CLIs
+# ============================================================
+echo ""
+echo "Cloud CLIs"
+echo "----------"
+assert_bin_ver "aws" "aws --version" "aws-cli"
+assert_bin_ver "gcloud" "gcloud --version 2>&1 | head -1" "Google Cloud"
+assert_bin_ver "az" "az --version 2>&1 | head -1" "azure-cli"
+assert_bin_ver "kubectl" "kubectl version --client 2>&1" "Client"
+assert_bin_ver "helm" "helm version 2>&1" "Version"
+assert_bin_ver "terraform" "terraform --version" "Terraform"
+assert_bin_ver "gh" "gh --version" "gh"
+assert_bin_ver "ibmcloud" "ibmcloud version 2>&1" "ibmcloud"
+
+# ============================================================
+# 9. Package managers & build tools
+# ============================================================
+echo ""
+echo "Build tools"
+echo "-----------"
+assert_bin_ver "npm" "npm --version" "."
+assert_bin_ver "pnpm" "pnpm --version" "."
+assert_bin_ver "pip" "pip --version" "pip"
+assert_bin_ver "uv" "uv --version" "uv"
+assert_bin_ver "mvn" "mvn --version 2>&1 | head -1" "Maven"
+assert_bin_ver "gradle" "gradle --version 2>&1 | grep Gradle" "Gradle"
+assert_bin_ver "gem" "gem --version" "."
+
+# ============================================================
+# 10. Linters & formatters
+# ============================================================
+echo ""
+echo "Linters & formatters"
+echo "--------------------"
+for tool in \
+  shellcheck shfmt black pylint ruff flake8 isort mypy yamllint \
+  eslint prettier biome markdownlint-cli2 hadolint actionlint \
+  tflint terraform-docs terragrunt ansible-lint cfn-lint codespell \
+  golangci-lint editorconfig-checker gitleaks phpcs rubocop; do
+  assert_bin "$tool"
+done
+
+# ============================================================
+# 11. LSP servers
+# ============================================================
+echo ""
+echo "LSP servers"
+echo "-----------"
+for lsp in \
+  gopls rust-analyzer clangd taplo marksman \
+  bash-language-server yaml-language-server \
+  typescript-language-server pyright jdtls; do
+  assert_bin "$lsp"
+done
+
+# ============================================================
+# 12. Security & pentest tools
+# ============================================================
+echo ""
+echo "Security tools"
+echo "--------------"
+for sec in \
+  nmap tshark nuclei subfinder httpx ffuf gobuster feroxbuster \
+  dalfox amass trufflehog grype syft testssl searchsploit \
+  sherlock recon-ng spiderfoot hydra john sslscan nikto sqlmap; do
+  assert_bin "$sec"
+done
+
+# ============================================================
+# 13. Binary utilities
+# ============================================================
+echo ""
+echo "Utilities"
+echo "---------"
+for util in \
+  git jq yq fzf fd rg bat eza tree tmux htop nvim \
+  ffmpeg qrencode dos2unix curl wget socat dig mtr; do
+  assert_bin "$util"
+done
+
+# ============================================================
+# 14. Browser & automation
+# ============================================================
+echo ""
+echo "Browser & automation"
+echo "--------------------"
+assert_bin "playwright"
+assert_dir "Playwright Chromium cache" "/home/vscode/.cache/ms-playwright"
+
+# ============================================================
+# 15. Key paths
+# ============================================================
+echo ""
+echo "Key paths"
+echo "---------"
+assert_dir "/opt/zaproxy" "/opt/zaproxy"
+assert_dir "/opt/ghidra" "/opt/ghidra"
+assert_dir "/opt/seclists" "/opt/seclists"
+assert_dir "/opt/firecrawl" "/opt/firecrawl"
+assert_dir "Nerd fonts" "/usr/local/share/fonts/nerd-fonts"
+assert_file "Build fingerprint" "/etc/devcontainer-version"
+assert_file "Entrypoint" "/usr/local/bin/entrypoint.sh"
+assert_dir "Oh-My-Zsh" "/home/vscode/.oh-my-zsh"
+assert_dir "Powerlevel10k" "/home/vscode/.oh-my-zsh/custom/themes/powerlevel10k"
+assert_dir "Claude plugins" "/home/vscode/.claude/plugins/marketplaces"
+
+# ============================================================
+# Summary
+# ============================================================
+TOTAL=$((PASS + FAIL + SKIP))
+echo ""
+echo "=============================="
+printf 'Results: \033[32m%d passed\033[0m' "$PASS"
+[ "$FAIL" -gt 0 ] && printf ', \033[31m%d failed\033[0m' "$FAIL"
+[ "$SKIP" -gt 0 ] && printf ', \033[33m%d skipped\033[0m' "$SKIP"
+printf ' (%d total)\n' "$TOTAL"
+echo "=============================="
+
+exit "$FAIL"


### PR DESCRIPTION
Closes #1022

## Summary

Container runs entirely as `vscode` — zero sudo in the entrypoint. All daemons (postgres, rabbitmq, redis, cron) configured for non-root operation.

## Smoke test (tests/smoke-test.sh)

196 assertions, dual mode:
- **Render-only** (CI): validates entrypoint env rendering, config files, shell sourcing, daemons, 15 languages, 8 cloud CLIs, 7 build tools, 26 linters, 10 LSPs, 23 security tools, 20 utilities with dummy credentials
- **Live** (local VPN): adds functional prompt tests for claude, pi, crush, xcsh, codex, opencode + API curl

Auto-detects podman/docker runtime.

## Key fixes
- xcsh: `config set modelRoles` in entrypoint so it works without `--model` flag
- PI_DEFAULT_MODEL/PI_SMOL_MODEL/PI_SLOW_MODEL/PI_PLAN_MODEL exported
- HOME resolution for OCI-format images
- Interactive shells default to `/workspace`
- docker-publish.yml: post-build smoke-test job