### PR TITLE
feat: tune compose resource limits

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,8 +23,9 @@ services:
       - SETGID
       - NET_RAW
       - NET_ADMIN
-    mem_limit: 12g
-    cpus: 4
+    mem_limit: 14g
+    memswap_limit: 30g
+    cpus: 2
     pids_limit: 4096
     tmpfs:
       - /tmp:size=256m


### PR DESCRIPTION
Closes #1028

- mem_limit 14g, memswap_limit 30g, cpus 2
- Verified via podman inspect: all three applied correctly