### PR TITLE
fix: unescape awk $2 in pg_createcluster version extraction

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1003,7 +1003,7 @@ WORKDIR /
 # Drop the default postgres-user cluster and replace with one owned by vscode.
 # Auth is set to 'trust' for local socket connections (single-user container).
 # hadolint ignore=DL3059,SC2046
-RUN PG_VER=$(dpkg -l 'postgresql-*' | awk '/^ii.*postgresql-[0-9]/{gsub(/postgresql-/,"");print \$2;exit}') \
+RUN PG_VER=$(dpkg -l 'postgresql-*' | awk '/^ii.*postgresql-[0-9]/{gsub(/postgresql-/,"");print $2;exit}') \
     && pg_dropcluster --stop $(pg_lsclusters -h | awk 'NR==1{print $1, $2}') 2>/dev/null || true \
     && mkdir -p /etc/postgresql /var/log/postgresql \
        /home/${USERNAME}/.local/run/postgresql \


### PR DESCRIPTION
## Summary

One-character fix for `Dockerfile:1006`. The backslash before `$2` was leftover from when the `awk` call lived inside a `su -c "..."` wrapper (where shell needed to protect `$`). Commit `da47181` moved it out of that wrapper into bare single-quoted `awk`, where the backslash is passed literally to `awk` and rejected with `awk: 1: unexpected character '\'`.

Every `docker-publish` run (both `amd64` and `arm64`) has been red since `da47181` on 2026-04-19. The failure is hidden because `docker-publish.yml` only runs post-merge, not on PRs.

The adjacent line 1007 (`awk 'NR==1{print $1, $2}'`) already uses the correct bare form, confirming this is just a lingering backslash that should not be there.

Closes #1042

## Test plan

- [x] `hadolint Dockerfile` clean
- [x] Reproduced the bug locally: `awk '/foo/{print \$2}'` fails with the exact error seen in CI
- [x] Confirmed the fix prints `16` for the actual `dpkg -l postgresql-*` pipeline
- [ ] CI checks pass on this PR
- [ ] `docker-publish.yml` runs green on the merge SHA (both `amd64` and `arm64`)
- [ ] `pg_createcluster` step completes cleanly in the post-merge build log