### PR TITLE
fix: widen pre-USER-switch chown to entire /home/vscode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1375,9 +1375,13 @@ RUN mkdir -p "/home/${USERNAME}/.agents" \
 # hadolint ignore=DL3059
 RUN npx playwright install-deps
 
-# Fix ownership of dirs created by root under /home/vscode (e.g. .cache from playwright)
+# Fix ownership of dirs created by root under /home/vscode.
+# Earlier stages create intermediate parents (e.g. /home/vscode/.local from the
+# postgres setup's mkdir -p, /home/vscode/.cache from playwright) that chown -R
+# on their leaf paths does not cover. Widening the chown to the entire home dir
+# ensures the USER switch below lands on a tree vscode fully owns.
 # hadolint ignore=DL3059
-RUN chown -R ${USERNAME}:${USERNAME} /home/${USERNAME}/.cache
+RUN chown -R ${USERNAME}:${USERNAME} /home/${USERNAME}
 
 # ============================================================
 # User setup


### PR DESCRIPTION
## Summary

Fixes `mkdir: Permission denied` at Dockerfile instruction 59/118 of the final stage in docker-publish.yml on main:

```
mkdir: cannot create directory '/home/vscode/.local/bin': Permission denied
mkdir: cannot create directory '/home/vscode/.local/share': Permission denied
```

## Root cause

Earlier `RUN` commands (postgres cluster setup at Dockerfile:1008-1011) create `/home/vscode/.local/lib/postgresql` and `/home/vscode/.local/run/postgresql` via `mkdir -p` while running as root. The subsequent `chown -R` only targets those specific leaf paths, leaving the intermediate `/home/vscode/.local` parent root-owned.

Commit c1f228a (`feat: run as vscode (no sudo)`) then landed `USER $USERNAME` at Dockerfile:1385, and the next `RUN mkdir -p ...` at line 1388 fails because vscode can't write to a root-owned parent.

## Change

Widen the pre-USER-switch `chown -R` from `/home/vscode/.cache` to the entire `/home/vscode` tree. Line 1713 already does the same `chown -R /home/vscode` later in the Dockerfile, so there's precedent.

Closes #1046

## Test plan

- [x] `hadolint Dockerfile` exits clean
- [ ] Required CI checks pass
- [ ] `docker-publish.yml` run on merge SHA succeeds on both amd64 and arm64 past instruction 59/118