### PR TITLE
fix: add cache_from to local build compose for layer reuse

### DIFF
--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -7,9 +7,19 @@
 # Or manually:
 #   podman compose -f docker-compose.yml -f docker-compose.build.yml build
 #   podman compose -f docker-compose.yml -f docker-compose.build.yml up -d
+#
+# cache_from: localname without tag is required — podman rejects refs with tags.
+# Use the local image (tagged from previous build or pulled from GHCR) as a
+# layer cache source so unchanged Dockerfile instructions are never re-executed.
+# After the first successful build, retag the result:
+#   podman tag localhost/devcontainer:local localhost/devcontainer
 services:
   dev:
     platform: linux/arm64
     build:
       context: .
       dockerfile: Dockerfile
+      tags:
+        - localhost/devcontainer:local
+      cache_from:
+        - localhost/devcontainer


### PR DESCRIPTION
Closes #1056

podman build without `cache_from` ignores layers from pulled images, causing full rebuilds (~1-2 hours) on every invocation. Adding `cache_from: localhost/devcontainer` (tagless ref required by podman) lets buildah match Dockerfile instructions against the existing local image's layers.

Verified: Steps 1-16 (APT repos, base tooling) cache-hit instantly with this flag.

After a successful build, retag the result:
```bash
podman tag localhost/devcontainer:local localhost/devcontainer
```