### PR TITLE
fix: skip PSScriptAnalyzer install on arm64 (illegal instruction)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -716,7 +716,12 @@ RUN curl ${CURL_RETRY} -fsSLo /usr/local/bin/phpcs \
 # 10f. PowerShell modules (PSScriptAnalyzer + arm-ttk)
 # ============================================================
 # hadolint ignore=DL3059
-RUN pwsh -NoProfile -Command 'Set-PSRepository PSGallery -InstallationPolicy Trusted; Install-Module -Name PSScriptAnalyzer -Scope AllUsers -Force' \
+RUN ARCH=$(dpkg --print-architecture) \
+    && if [ "$ARCH" = "amd64" ]; then \
+        pwsh -NoProfile -Command 'Set-PSRepository PSGallery -InstallationPolicy Trusted; Install-Module -Name PSScriptAnalyzer -Scope AllUsers -Force'; \
+    else \
+        echo "SKIP: PSScriptAnalyzer install not supported on ${ARCH} (illegal instruction in .NET JIT)"; \
+    fi \
     && git clone --depth=1 https://github.com/Azure/arm-ttk.git /usr/lib/microsoft/arm-ttk \
     && rm -rf /usr/lib/microsoft/arm-ttk/.git
 ENV ARM_TTK_PSD1="/usr/lib/microsoft/arm-ttk/arm-ttk/arm-ttk.psd1"


### PR DESCRIPTION
Closes #1057

## Problem

Local arm64 builds (`./devcontainer.sh build`) crash at section 10f:

```
Illegal instruction (core dumped)
Error: building at STEP "RUN pwsh -NoProfile -Command 'Set-PSRepository PSGallery ...'": exit status 132
```

`pwsh` / .NET JIT emits x86 instructions that arm64 CPUs cannot execute. CI is unaffected (x86_64 runners).

## Fix

Architecture guard: install PSScriptAnalyzer on amd64 only, skip with a log message on arm64. The `arm-ttk` git clone is arch-neutral and runs unconditionally.