### PR TITLE
fix: eliminate remaining root-required writes under USER vscode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1565,7 +1565,6 @@ RUN ZSH_CUSTOM="${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}" \
     # $ZSH_CUSTOM are sourced AFTER plugins, so the unalias wins.
     && echo 'unalias rm cp mv 2>/dev/null || true' > "$HOME/.oh-my-zsh/custom/disable-interactive-safety.zsh" \
     && echo '[ -f /run/entrypoint-env.sh ] && . /run/entrypoint-env.sh' >> "$HOME/.zshenv" \
-    && mkdir -p /etc/zsh && echo '[ -f /run/entrypoint-env.sh ] && . /run/entrypoint-env.sh' >> /etc/zsh/zshenv \
     && echo '[ -d /workspace ] && cd /workspace' >> "$HOME/.zshrc"
 
 # ============================================================
@@ -1663,9 +1662,14 @@ COPY --chown=${USERNAME}:${USERNAME} codex-config/sync-agents.sh /opt/codex-conf
 # 17a. Sync Claude Code plugin agents → Codex .toml format
 # Converts ~/.claude/plugins/cache/*/agents/*.md to ~/.codex/agents/*.toml
 # so Codex can natively discover the same agents as Claude Code.
+# chmod as root (modifies /opt/); run as vscode so output files under
+# ~/.codex/ are owned by vscode, not root.
 # hadolint ignore=DL3059
-RUN chmod +x /opt/codex-config/sync-agents.sh \
-    && /opt/codex-config/sync-agents.sh
+RUN chmod +x /opt/codex-config/sync-agents.sh
+USER $USERNAME
+# hadolint ignore=DL3059
+RUN /opt/codex-config/sync-agents.sh
+USER root
 COPY --chown=${USERNAME}:${USERNAME} pi-config/settings.json /home/${USERNAME}/.pi/agent/settings.json
 COPY --chown=${USERNAME}:${USERNAME} omp-config/settings.json /home/${USERNAME}/.omp/agent/settings.json
 COPY --chown=${USERNAME}:${USERNAME} omp-config/config.yml /home/${USERNAME}/.omp/agent/config.yml
@@ -1680,7 +1684,10 @@ COPY --chown=${USERNAME}:${USERNAME} crush-config/crush.json /home/${USERNAME}/.
 # to eliminate the ~13.5 s first-run npm download delay.
 #   Phase 1: reify ~/.config/opencode/package.json
 #   Phase 2: pre-install oh-my-openagent plugin into cache
+# Runs as vscode so node_modules under ~/.config and ~/.cache
+# are owned by vscode, not root.
 # ────────────────────────────────────────────────────────────
+USER $USERNAME
 # hadolint ignore=DL3059
 RUN printf '{"dependencies":{"@opencode-ai/plugin":"^1.4.3"}}\n' \
        > /home/${USERNAME}/.config/opencode/package.json \
@@ -1691,13 +1698,16 @@ RUN printf '{"dependencies":{"@opencode-ai/plugin":"^1.4.3"}}\n' \
     && npm install --no-audit --no-fund --prefix /home/${USERNAME}/.cache/opencode/packages/oh-my-openagent
 
 # Map CLAUDE_CODE_OAUTH_TOKEN → ANTHROPIC_OAUTH_TOKEN for tools
-# that read the Anthropic-native env var (e.g. Pi).
+# that read the Anthropic-native env var (e.g. Pi). Writes the bridge
+# into vscode's ~/.profile (bash login) and ~/.zshenv (all zsh shells);
+# equivalent to /etc/profile.d + /etc/zsh/zshenv for a single-user
+# container and requires no root-owned config files.
 # hadolint ignore=SC2016
-RUN printf '#!/bin/bash\nif [ -n "$CLAUDE_CODE_OAUTH_TOKEN" ] && [ -z "$ANTHROPIC_OAUTH_TOKEN" ]; then\n  export ANTHROPIC_OAUTH_TOKEN="$CLAUDE_CODE_OAUTH_TOKEN"\nfi\n' \
-      > /etc/profile.d/anthropic-oauth.sh \
-    && chmod +x /etc/profile.d/anthropic-oauth.sh \
+RUN printf 'if [ -n "$CLAUDE_CODE_OAUTH_TOKEN" ] && [ -z "$ANTHROPIC_OAUTH_TOKEN" ]; then\n  export ANTHROPIC_OAUTH_TOKEN="$CLAUDE_CODE_OAUTH_TOKEN"\nfi\n' \
+      >> "$HOME/.profile" \
     && printf 'if [ -n "$CLAUDE_CODE_OAUTH_TOKEN" ] && [ -z "$ANTHROPIC_OAUTH_TOKEN" ]; then\n  export ANTHROPIC_OAUTH_TOKEN="$CLAUDE_CODE_OAUTH_TOKEN"\nfi\n' \
-      >> /etc/zsh/zshenv
+      >> "$HOME/.zshenv"
+USER root
 
 # ============================================================
 # 18. Build fingerprint — bake commit SHA + date into the image


### PR DESCRIPTION
## Summary

Finishes the rootless-container audit started in c1f228a and partially landed in #1047. `docker-publish.yml` was still failing at Dockerfile:1568 (`/etc/zsh/zshenv: Permission denied`). A systematic audit of every `RUN` after the USER switch at line 1385 found four root-only operations that were previously root-executed under the old layering; this PR moves each effect into vscode-owned space so they simply work as vscode.

- **Line 1568 deleted** — `/etc/zsh/zshenv` append is redundant; the identical `entrypoint-env.sh` sourcing is already written to `$HOME/.zshenv` on the preceding line. Single-user container, identical runtime effect.
- **sync-agents.sh** — `chmod +x` stays as root (modifies `/opt/`); execution now runs as vscode so `~/.codex/agents/*.toml` is owned by vscode instead of relying on a post-hoc `chown -R` sweep.
- **opencode npm pre-warm** — wrapped in `USER $USERNAME` / `USER root` so `node_modules` under `~/.config/opencode` and `~/.cache/opencode` is vscode-owned.
- **OAuth token bridge** — writes to `$HOME/.profile` (bash login) and `$HOME/.zshenv` (zsh all-shell) instead of `/etc/profile.d/anthropic-oauth.sh` + `/etc/zsh/zshenv`. Identical sourcing semantics for a single-user container and removes another pair of root-owned config files.

Net diff: **+18 / −8** in `Dockerfile` only. Two surgical `USER $USERNAME` switches added, one matching switch back to root afterwards for the remaining root-legitimate steps (`/etc/devcontainer-version`, `chown -R /home/vscode`).

Closes #1050

## Test plan

- [x] `hadolint Dockerfile` — clean
- [x] Pre-commit lint gate (hadolint + checkov + gitleaks + editorconfig + governance) — all green
- [ ] Required CI checks pass on this PR
- [ ] `docker-publish.yml` on the merge SHA completes both amd64 and arm64 past `[final 71/118]` with no permission-denied errors (the payoff step)

## Notes for reviewers

- `lint / Shell Unit Tests` is expected red (tracked upstream at docs-control#376) and is non-required for merge.
- No changes to anything outside `Dockerfile`.