### PR TITLE
fix: add maki-config/ to .dockerignore allowlist

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,6 +8,7 @@
 !xcsh-config/
 !opencode-config/
 !crush-config/
+!maki-config/
 !.devcontainer/scripts/
 !scripts/
 !configs/


### PR DESCRIPTION
## Summary

Restores `Docker Publish` green on main after PR #1061.

`.dockerignore` is an allowlist (`*` followed by per-entry `!foo/`). PR #1061 added `maki-config/litellm` plus a `COPY` of it in the Dockerfile, but did not add `!maki-config/` to the allowlist, so buildx stripped the directory from the build context. The post-merge `Docker Publish` failed with:

```
failed to calculate checksum of ref: /maki-config/litellm: not found
```

on both `linux/amd64` and `linux/arm64`.

One-line fix: allowlist `maki-config/` in the same block as the other per-tool config directories, placed next to `!crush-config/` to match the spatial order of the `COPY maki-config/litellm …` line in the Dockerfile.

Closes #1062
Refs: #1060
Fixes: e01a957 (post-merge Docker Publish failure)

## Priority

Hotfix — the `ghcr.io/f5xc-salesdemos/devcontainer:latest` image from `main` is currently broken.

## Test plan

- [ ] `Check linked issues` CI passes
- [ ] `Lint Code Base` CI passes
- [ ] Post-merge `Docker Publish` turns green on both `linux/amd64` and `linux/arm64`