### PR TITLE
feat: restore trivy after upstream supply-chain remediation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -600,6 +600,8 @@ RUN true \
     && install-release editorconfig-checker \
         "https://github.com/editorconfig-checker/editorconfig-checker/releases/latest/download/ec-linux-${DPKG_ARCH}.tar.gz" \
         tgz-bin editorconfig-checker "bin/ec-linux-${DPKG_ARCH}" \
+    # trivy (install script auto-detects arch)
+    && curl ${CURL_RETRY} -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin \
     # clj-kondo (zip contains a single clj-kondo binary)
     && CLJ_KONDO_VERSION=$(ghlatest clj-kondo/clj-kondo) \
     && if [ "$DPKG_ARCH" = "amd64" ]; then CK_ARCH="amd64"; else CK_ARCH="aarch64"; fi \

--- a/claude-config/self-test.sh
+++ b/claude-config/self-test.sh
@@ -71,6 +71,7 @@ echo "5. Super-Linter Tools"
 # Binary tools
 check "shfmt installed" command -v shfmt
 check "gitleaks installed" command -v gitleaks
+check "trivy installed" command -v trivy
 check "editorconfig-checker installed" command -v editorconfig-checker
 check "golangci-lint installed" command -v golangci-lint
 check "kubeconform installed" command -v kubeconform

--- a/docs/local-development.mdx
+++ b/docs/local-development.mdx
@@ -121,7 +121,7 @@ These layers change more frequently (npm/pip updates, config changes) but rebuil
 | 9. AWS CLI v2 | Official installer |
 | 10. Binary tools | kubectl, helm, tflint, terraform-docs, act, actionlint, yt-dlp, uv |
 | 10b. Additional binaries | VS Code CLI, oc, yq, terragrunt, ibmcloud, fzf, hadolint, codex |
-| 10c. Super-linter binaries | shfmt, gitleaks, editorconfig-checker, clj-kondo, dotenv-linter, golangci-lint, goreleaser, kubeconform, protolint, scalafmt, ktlint |
+| 10c. Super-linter binaries | shfmt, gitleaks, editorconfig-checker, trivy, clj-kondo, dotenv-linter, golangci-lint, goreleaser, kubeconform, protolint, scalafmt, ktlint |
 | 10d. Java JAR tools | checkstyle, google-java-format (wrapper scripts) |
 | 10e. PHP linters | phpcs, phpstan, psalm (PHAR downloads) |
 | 10f. PowerShell modules | PSScriptAnalyzer, arm-ttk |

--- a/docs/security.mdx
+++ b/docs/security.mdx
@@ -114,7 +114,7 @@ The container includes approximately 80 pre-installed security and penetration t
 | Reverse engineering | radare2, Ghidra, gdb, binwalk, strace, ltrace |
 | Reconnaissance | subfinder, amass, httpx, nuclei, gau, waybackurls, recon-ng, spiderfoot |
 | Fuzzing and enumeration | ffuf, gobuster, SecLists |
-| Supply chain and secrets | trufflehog, grype, syft, gitleaks |
+| Supply chain and secrets | trufflehog, grype, syft, gitleaks, trivy |
 | Exploitation frameworks | Metasploit (amd64), searchsploit (ExploitDB) |
 
 Some tools (bettercap, Metasploit) are only available on amd64 due to upstream packaging constraints. Packet capture tools (tshark, bettercap) require the `NET_ADMIN` capability, which is included in the default `docker-compose.yml`.


### PR DESCRIPTION
## Summary

Reinstalls trivy across the Dockerfile (super-linter binaries RUN
block), self-test check, local-development docs, and security docs.
Matches the inverse of PR #599 verbatim, minus `INSTALL.md` which
has since been removed from the tree.

Safe to re-add because:
- The Aqua supply-chain attack (GHSA-69fq-xp46-6x23) was contained
  2026-03-19 and remediated 2026-03-20.
- Compromised releases were v0.69.4-v0.69.6; `main` branch install.sh
  was cleaned up and v0.70.0 (2026-04-17) is a fresh clean release.
- The install pattern is unchanged from pre-removal (pipe
  contrib/install.sh from main). A pinned-version + sha256 variant
  was considered but rejected in favour of verbatim restoration.

Refs: #598, #599 (original removal).

Closes #1064

## Test plan

- [ ] `Check linked issues` CI passes
- [ ] `Lint Code Base` CI passes
- [ ] Post-merge Docker Publish builds and publishes image with trivy restored
- [ ] `claude-self-test` inside the rebuilt container finds the trivy binary