### PR TITLE
chore: switch opus to claude-opus-4-6, enable 1M context

### DIFF
--- a/claude-config/settings.json
+++ b/claude-config/settings.json
@@ -72,8 +72,8 @@
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
     "ANTHROPIC_SMALL_FAST_MODEL": "claude-haiku-4-5",
     "ANTHROPIC_DEFAULT_HAIKU_MODEL": "claude-haiku-4-5",
-    "ANTHROPIC_DEFAULT_SONNET_MODEL": "claude-sonnet-4-6",
-    "ANTHROPIC_DEFAULT_OPUS_MODEL": "pd-claude-opus-4-7",
+    "ANTHROPIC_DEFAULT_SONNET_MODEL": "claude-sonnet-4-6[1m]",
+    "ANTHROPIC_DEFAULT_OPUS_MODEL": "claude-opus-4-6[1m]",
     "DEBIAN_FRONTEND": "noninteractive"
   },
   "preferences": {

--- a/crush-config/crush.json
+++ b/crush-config/crush.json
@@ -9,8 +9,8 @@
       "api_key": "$LITELLM_API_KEY",
       "models": [
         {
-          "id": "pd-claude-opus-4-7",
-          "name": "Claude Opus 4.7 (PD)",
+          "id": "claude-opus-4-6",
+          "name": "Claude Opus 4.6",
           "cost_per_1m_in": 5,
           "cost_per_1m_out": 25,
           "cost_per_1m_in_cached": 6.25,
@@ -24,7 +24,7 @@
     }
   },
   "models": {
-    "large": { "model": "pd-claude-opus-4-7", "provider": "anthropic" },
-    "small": { "model": "pd-claude-opus-4-7", "provider": "anthropic" }
+    "large": { "model": "claude-opus-4-6", "provider": "anthropic" },
+    "small": { "model": "claude-opus-4-6", "provider": "anthropic" }
   }
 }

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -133,14 +133,14 @@ fi
 if [ -n "$LITELLM_BASE_URL" ]; then
   export ANTHROPIC_SMALL_FAST_MODEL="claude-haiku-4-5"
   export ANTHROPIC_DEFAULT_HAIKU_MODEL="claude-haiku-4-5"
-  export ANTHROPIC_DEFAULT_SONNET_MODEL="claude-sonnet-4-6"
-  export ANTHROPIC_DEFAULT_OPUS_MODEL="pd-claude-opus-4-7"
+  export ANTHROPIC_DEFAULT_SONNET_MODEL="claude-sonnet-4-6[1m]"
+  export ANTHROPIC_DEFAULT_OPUS_MODEL="claude-opus-4-6[1m]"
   export ANTHROPIC_API_ENDPOINT="${LITELLM_BASE_URL}/anthropic"
   # xcsh/pi/omp model defaults (PI_* env vars)
   export PI_DEFAULT_MODEL="anthropic/claude-sonnet-4-6"
   export PI_SMOL_MODEL="anthropic/claude-haiku-4-5"
-  export PI_SLOW_MODEL="anthropic/pd-claude-opus-4-7"
-  export PI_PLAN_MODEL="anthropic/pd-claude-opus-4-7"
+  export PI_SLOW_MODEL="anthropic/claude-opus-4-6"
+  export PI_PLAN_MODEL="anthropic/claude-opus-4-6"
 fi
 
 # ============================================================
@@ -163,7 +163,7 @@ fi
 HERMES_HOME_DIR="$HOME/.hermes"
 mkdir -p "$HERMES_HOME_DIR"
 if [ -n "$LITELLM_API_KEY" ]; then
-  printf 'OPENAI_BASE_URL=%s\nOPENAI_API_KEY=%s\nLLM_MODEL=pd-claude-opus-4-7\n' \
+  printf 'OPENAI_BASE_URL=%s\nOPENAI_API_KEY=%s\nLLM_MODEL=claude-opus-4-6\n' \
     "$OPENAI_BASE_URL" "$OPENAI_API_KEY" \
     >"$HERMES_HOME_DIR/.env"
 elif [ -n "$CLAUDE_CODE_OAUTH_TOKEN" ]; then
@@ -182,14 +182,14 @@ if [ -n "$LITELLM_BASE_URL" ]; then
 fi
 
 # ============================================================
-# Pi & Oh-My-Pi — write models.json registering pd-claude-opus-4-7
+# Pi & Oh-My-Pi — write models.json registering claude-opus-4-6
 # as a custom model under the anthropic provider.
 #
 # Pi-ai (both @mariozechner/pi-ai and @oh-my-pi/pi-ai forks) keep a
 # built-in Anthropic model registry that does not include the custom
-# proxy ID `pd-claude-opus-4-7`. Without an explicit entry, the
+# proxy ID `claude-opus-4-6`. Without an explicit entry, the
 # resolver treats the ID as unknown, falls back to a built-in name
-# (e.g. `claude-opus-4-7` with no prefix), rewrites settings.json,
+# (e.g. `claude-opus-4-6` with no prefix), rewrites settings.json,
 # and the proxy rejects the stripped ID with 400. Declaring the
 # model here makes the resolver exact-match and stops the rewrite.
 # ============================================================
@@ -204,8 +204,8 @@ if [ -n "$LITELLM_BASE_URL" ]; then
       "api": "anthropic-messages",
       "models": [
         {
-          "id": "pd-claude-opus-4-7",
-          "name": "Claude Opus 4.7 (PD)",
+          "id": "claude-opus-4-6",
+          "name": "Claude Opus 4.6",
           "api": "anthropic-messages",
           "reasoning": true,
           "input": ["text", "image"],
@@ -225,14 +225,14 @@ EOF
   # Reset pi's defaultModel on every boot — pi-ai's fallback path
   # overwrites this file with the stripped ID; without this reset
   # the corruption survives container restart when $HOME is mounted.
-  printf '{"defaultProvider":"anthropic","defaultModel":"pd-claude-opus-4-7"}\n' \
+  printf '{"defaultProvider":"anthropic","defaultModel":"claude-opus-4-6"}\n' \
     >"$HOME/.pi/agent/settings.json"
   unset _pi_models
 fi
 
 # ============================================================
 # xcsh — write models.json + models.yml registering the custom
-# pd-claude-opus-4-7 model (same rationale as pi/omp above).
+# claude-opus-4-6 model (same rationale as pi/omp above).
 # ============================================================
 if [ -n "$LITELLM_BASE_URL" ]; then
   _xcsh_models=$(
@@ -245,8 +245,8 @@ if [ -n "$LITELLM_BASE_URL" ]; then
       "api": "anthropic-messages",
       "models": [
         {
-          "id": "pd-claude-opus-4-7",
-          "name": "Claude Opus 4.7 (PD)",
+          "id": "claude-opus-4-6",
+          "name": "Claude Opus 4.6",
           "api": "anthropic-messages",
           "reasoning": true,
           "input": ["text", "image"],
@@ -275,8 +275,8 @@ providers:
     apiKey: LITELLM_API_KEY
     api: anthropic-messages
     models:
-      - id: pd-claude-opus-4-7
-        name: "Claude Opus 4.7 (PD)"
+      - id: claude-opus-4-6
+        name: "Claude Opus 4.6"
         api: anthropic-messages
         reasoning: true
         input: [text, image]
@@ -296,7 +296,7 @@ providers:
 EOF
   unset _xcsh_models
   # Set default model roles so xcsh works without --model flag
-  xcsh config set modelRoles '{"default":"anthropic/claude-sonnet-4-6","smol":"anthropic/claude-haiku-4-5","slow":"anthropic/pd-claude-opus-4-7","plan":"anthropic/pd-claude-opus-4-7"}' >/dev/null 2>&1 || true
+  xcsh config set modelRoles '{"default":"anthropic/claude-sonnet-4-6","smol":"anthropic/claude-haiku-4-5","slow":"anthropic/claude-opus-4-6","plan":"anthropic/claude-opus-4-6"}' >/dev/null 2>&1 || true
 fi
 
 # ============================================================
@@ -321,10 +321,10 @@ fi
 #
 # crush.json also carries `options.disable_provider_auto_update: true`
 # plus a full `providers.anthropic.models[]` entry for
-# pd-claude-opus-4-7. Without the disable flag crush re-fetches the
+# claude-opus-4-6. Without the disable flag crush re-fetches the
 # upstream Catwalk catalog on every invocation, wiping custom models.
 # Without the inline models[] entry crush's embedded catalog has no
-# pd-claude-opus-4-7 and the proxy rejects the fallback ID.
+# claude-opus-4-6 and the proxy rejects the fallback ID.
 # ============================================================
 if [ -n "$LITELLM_BASE_URL" ]; then
   _crush_config="$HOME/.config/crush/crush.json"
@@ -356,7 +356,7 @@ fi
 # Proxy sanity probe.
 #
 # After all per-tool configs are rendered, POST a 1-token request
-# to the LiteLLM Anthropic passthrough to confirm pd-claude-opus-4-7
+# to the LiteLLM Anthropic passthrough to confirm claude-opus-4-6
 # is accepted. Warns (non-fatal) on any non-200 response so the next
 # regression surfaces immediately instead of at first tool invocation.
 # ============================================================
@@ -366,10 +366,10 @@ if [ -n "$LITELLM_BASE_URL" ] && [ -n "$LITELLM_API_KEY" ] && command -v curl >/
     -H "x-api-key: ${LITELLM_API_KEY}" \
     -H 'content-type: application/json' \
     -H 'anthropic-version: 2023-06-01' \
-    -d '{"model":"pd-claude-opus-4-7","max_tokens":4,"messages":[{"role":"user","content":"hi"}]}' \
+    -d '{"model":"claude-opus-4-6","max_tokens":4,"messages":[{"role":"user","content":"hi"}]}' \
     2>/dev/null || true)
   if [ "$_probe_status" != "200" ]; then
-    printf 'WARN: LiteLLM proxy probe for pd-claude-opus-4-7 returned %s (expected 200)\n' \
+    printf 'WARN: LiteLLM proxy probe for claude-opus-4-6 returned %s (expected 200)\n' \
       "${_probe_status:-no-response}" >&2
   fi
   unset _probe_status

--- a/hermes-config/config.yaml
+++ b/hermes-config/config.yaml
@@ -4,7 +4,7 @@
 # ~/.hermes/.env at container startup.
 
 model:
-  default: "pd-claude-opus-4-7"
+  default: "claude-opus-4-6"
   provider: "auto"
   base_url: "__HERMES_BASE_URL__"
 

--- a/maki-config/litellm
+++ b/maki-config/litellm
@@ -13,8 +13,8 @@ info)
 models)
   cat <<'JSON'
 [
-  {"id":"pd-claude-opus-4-7","tier":"strong","context_window":1000000,"max_output_tokens":128000},
-  {"id":"claude-sonnet-4-6","tier":"medium","context_window":200000,"max_output_tokens":64000},
+  {"id":"claude-opus-4-6","tier":"strong","context_window":1000000,"max_output_tokens":128000},
+  {"id":"claude-sonnet-4-6","tier":"medium","context_window":1000000,"max_output_tokens":64000},
   {"id":"claude-haiku-4-5","tier":"fast","context_window":200000,"max_output_tokens":8192}
 ]
 JSON

--- a/omp-config/config.yml
+++ b/omp-config/config.yml
@@ -1,7 +1,7 @@
 defaultProvider: anthropic
-defaultModel: pd-claude-opus-4-7
+defaultModel: claude-opus-4-6
 modelRoles:
   smol: anthropic/claude-haiku-4-5
-  default: anthropic/pd-claude-opus-4-7
-  slow: anthropic/pd-claude-opus-4-7
-  plan: anthropic/pd-claude-opus-4-7
+  default: anthropic/claude-opus-4-6
+  slow: anthropic/claude-opus-4-6
+  plan: anthropic/claude-opus-4-6

--- a/omp-config/settings.json
+++ b/omp-config/settings.json
@@ -1,4 +1,4 @@
 {
   "defaultProvider": "anthropic",
-  "defaultModel": "pd-claude-opus-4-7"
+  "defaultModel": "claude-opus-4-6"
 }

--- a/opencode-config/oh-my-openagent.json
+++ b/opencode-config/oh-my-openagent.json
@@ -1,20 +1,20 @@
 {
   "$schema": "https://raw.githubusercontent.com/code-yeongyu/oh-my-openagent/dev/assets/oh-my-opencode.schema.json",
   "agents": {
-    "sisyphus": { "model": "anthropic-proxy/pd-claude-opus-4-7" },
-    "oracle": { "model": "anthropic-proxy/pd-claude-opus-4-7" },
-    "librarian": { "model": "anthropic-proxy/pd-claude-opus-4-7" },
+    "sisyphus": { "model": "anthropic-proxy/claude-opus-4-6" },
+    "oracle": { "model": "anthropic-proxy/claude-opus-4-6" },
+    "librarian": { "model": "anthropic-proxy/claude-opus-4-6" },
     "explore": { "model": "openai-proxy/grok-code-fast-1" },
-    "multimodal-looker": { "model": "anthropic-proxy/pd-claude-opus-4-7" },
-    "prometheus": { "model": "anthropic-proxy/pd-claude-opus-4-7" },
-    "metis": { "model": "anthropic-proxy/pd-claude-opus-4-7" },
+    "multimodal-looker": { "model": "anthropic-proxy/claude-opus-4-6" },
+    "prometheus": { "model": "anthropic-proxy/claude-opus-4-6" },
+    "metis": { "model": "anthropic-proxy/claude-opus-4-6" },
     "hephaestus": { "model": "openai-proxy/gpt-5.4" },
-    "momus": { "model": "anthropic-proxy/pd-claude-opus-4-7" },
+    "momus": { "model": "anthropic-proxy/claude-opus-4-6" },
     "atlas": { "model": "anthropic-proxy/claude-sonnet-4-6" },
     "frontend-ui-ux-engineer": { "model": "openai-proxy/gpt-5.4" },
-    "document-writer": { "model": "anthropic-proxy/pd-claude-opus-4-7" },
-    "build": { "model": "anthropic-proxy/pd-claude-opus-4-7" },
-    "plan": { "model": "anthropic-proxy/pd-claude-opus-4-7" },
+    "document-writer": { "model": "anthropic-proxy/claude-opus-4-6" },
+    "build": { "model": "anthropic-proxy/claude-opus-4-6" },
+    "plan": { "model": "anthropic-proxy/claude-opus-4-6" },
     "sisyphus-junior": { "model": "anthropic-proxy/claude-sonnet-4-6" }
   },
   "categories": {
@@ -24,9 +24,9 @@
     "deep": { "model": "openai-proxy/gpt-5.4" },
     "artistry": { "model": "openai-proxy/gpt-5.4" },
     "quick": { "model": "anthropic-proxy/claude-sonnet-4-6" },
-    "unspecified-low": { "model": "anthropic-proxy/pd-claude-opus-4-7" },
-    "unspecified-high": { "model": "anthropic-proxy/pd-claude-opus-4-7" },
-    "writing": { "model": "anthropic-proxy/pd-claude-opus-4-7" }
+    "unspecified-low": { "model": "anthropic-proxy/claude-opus-4-6" },
+    "unspecified-high": { "model": "anthropic-proxy/claude-opus-4-6" },
+    "writing": { "model": "anthropic-proxy/claude-opus-4-6" }
   },
   "background_task": {
     "providerConcurrency": {

--- a/opencode-config/opencode.json
+++ b/opencode-config/opencode.json
@@ -9,8 +9,8 @@
         "apiKey": "{env:ANTHROPIC_API_KEY}"
       },
       "models": {
-        "pd-claude-opus-4-7": {
-          "name": "Claude Opus 4.7 (PD)",
+        "claude-opus-4-6": {
+          "name": "Claude Opus 4.6",
           "modalities": {
             "input": ["text", "image"],
             "output": ["text"]
@@ -69,7 +69,7 @@
       }
     }
   },
-  "model": "anthropic-proxy/pd-claude-opus-4-7",
+  "model": "anthropic-proxy/claude-opus-4-6",
   "small_model": "anthropic-proxy/claude-sonnet-4-6",
   "plugin": ["oh-my-openagent"],
   "mcp": {},

--- a/pi-config/settings.json
+++ b/pi-config/settings.json
@@ -1,4 +1,4 @@
 {
   "defaultProvider": "anthropic",
-  "defaultModel": "pd-claude-opus-4-7"
+  "defaultModel": "claude-opus-4-6"
 }

--- a/tests/smoke-test.sh
+++ b/tests/smoke-test.sh
@@ -209,14 +209,14 @@ assert_contains "OPENAI_BASE_URL derived" "$ENV_FILE" "OPENAI_BASE_URL=${TEST_UR
 assert_contains "ANTHROPIC_SMALL_FAST_MODEL" "$ENV_FILE" "claude-haiku-4-5"
 assert_contains "ANTHROPIC_DEFAULT_HAIKU_MODEL" "$ENV_FILE" "claude-haiku-4-5"
 assert_contains "ANTHROPIC_DEFAULT_SONNET_MODEL" "$ENV_FILE" "claude-sonnet-4-6"
-assert_contains "ANTHROPIC_DEFAULT_OPUS_MODEL" "$ENV_FILE" "pd-claude-opus-4-7"
+assert_contains "ANTHROPIC_DEFAULT_OPUS_MODEL" "$ENV_FILE" "claude-opus-4-6"
 assert_contains "GIT_COMMITTER_NAME derived" "$ENV_FILE" "GIT_COMMITTER_NAME="
 assert_contains "GIT_COMMITTER_EMAIL derived" "$ENV_FILE" "GIT_COMMITTER_EMAIL=smoke@test.local"
 
 assert_contains "PI_DEFAULT_MODEL set" "$ENV_FILE" "PI_DEFAULT_MODEL=anthropic/claude-sonnet-4-6"
 assert_contains "PI_SMOL_MODEL set" "$ENV_FILE" "PI_SMOL_MODEL=anthropic/claude-haiku-4-5"
-assert_contains "PI_SLOW_MODEL set" "$ENV_FILE" "PI_SLOW_MODEL=anthropic/pd-claude-opus-4-7"
-assert_contains "PI_PLAN_MODEL set" "$ENV_FILE" "PI_PLAN_MODEL=anthropic/pd-claude-opus-4-7"
+assert_contains "PI_SLOW_MODEL set" "$ENV_FILE" "PI_SLOW_MODEL=anthropic/claude-opus-4-6"
+assert_contains "PI_PLAN_MODEL set" "$ENV_FILE" "PI_PLAN_MODEL=anthropic/claude-opus-4-6"
 
 # Verify shell inheritance of PI_* model vars (xcsh/pi/omp read these)
 SHELL_PI_DEFAULT=$(zrun 'echo $PI_DEFAULT_MODEL')
@@ -224,7 +224,7 @@ assert_eq "zsh inherits PI_DEFAULT_MODEL" "$SHELL_PI_DEFAULT" "anthropic/claude-
 SHELL_PI_SMOL=$(zrun 'echo $PI_SMOL_MODEL')
 assert_eq "zsh inherits PI_SMOL_MODEL" "$SHELL_PI_SMOL" "anthropic/claude-haiku-4-5"
 SHELL_PI_SLOW=$(zrun 'echo $PI_SLOW_MODEL')
-assert_eq "zsh inherits PI_SLOW_MODEL" "$SHELL_PI_SLOW" "anthropic/pd-claude-opus-4-7"
+assert_eq "zsh inherits PI_SLOW_MODEL" "$SHELL_PI_SLOW" "anthropic/claude-opus-4-6"
 
 # ============================================================
 # 2. Shell sourcing
@@ -264,7 +264,7 @@ echo "--------------------"
 # Claude Code
 CS=$(run cat /home/vscode/.claude/settings.json)
 assert_contains "Claude: sonnet model in settings" "$CS" "claude-sonnet-4-6"
-assert_contains "Claude: opus model in settings" "$CS" "pd-claude-opus-4-7"
+assert_contains "Claude: opus model in settings" "$CS" "claude-opus-4-6"
 assert_contains "Claude: haiku model in settings" "$CS" "claude-haiku-4-5"
 CJ=$(run cat /home/vscode/.claude.json)
 assert_contains "Claude: auto-approve key" "$CJ" "customApiKeyResponses"
@@ -273,21 +273,21 @@ assert_contains "Claude: auto-approve key" "$CJ" "customApiKeyResponses"
 CRUSH=$(run cat /home/vscode/.config/crush/crush.json)
 assert_not_contains "Crush: no __CRUSH_BASE_URL__ placeholder" "$CRUSH" "__CRUSH_BASE_URL__"
 assert_contains "Crush: base_url rendered" "$CRUSH" "${TEST_URL}/anthropic"
-assert_contains "Crush: opus model" "$CRUSH" "pd-claude-opus-4-7"
+assert_contains "Crush: opus model" "$CRUSH" "claude-opus-4-6"
 assert_contains "Crush: auto-update disabled" "$CRUSH" "disable_provider_auto_update"
 
 # Pi
 PI=$(run cat /home/vscode/.pi/agent/settings.json)
 assert_contains "Pi: provider=anthropic" "$PI" "anthropic"
-assert_contains "Pi: model=opus" "$PI" "pd-claude-opus-4-7"
+assert_contains "Pi: model=opus" "$PI" "claude-opus-4-6"
 
 # OMP
 OMP_S=$(run cat /home/vscode/.omp/agent/settings.json)
 assert_contains "OMP: provider=anthropic" "$OMP_S" "anthropic"
-assert_contains "OMP: model=opus" "$OMP_S" "pd-claude-opus-4-7"
+assert_contains "OMP: model=opus" "$OMP_S" "claude-opus-4-6"
 OMP_C=$(run cat /home/vscode/.omp/agent/config.yml)
 assert_contains "OMP: haiku role" "$OMP_C" "claude-haiku-4-5"
-assert_contains "OMP: opus default role" "$OMP_C" "pd-claude-opus-4-7"
+assert_contains "OMP: opus default role" "$OMP_C" "claude-opus-4-6"
 
 # Codex
 CODEX=$(run cat /home/vscode/.codex/config.toml)
@@ -298,7 +298,7 @@ assert_contains "Codex: reads OPENAI_API_KEY" "$CODEX" 'env_key = "OPENAI_API_KE
 # OpenCode
 OC=$(run cat /home/vscode/.config/opencode/opencode.json)
 assert_contains "OpenCode: anthropic-proxy provider" "$OC" "anthropic-proxy"
-assert_contains "OpenCode: opus model" "$OC" "pd-claude-opus-4-7"
+assert_contains "OpenCode: opus model" "$OC" "claude-opus-4-6"
 assert_contains "OpenCode: sonnet model" "$OC" "claude-sonnet-4-6"
 assert_contains "OpenCode: openai-proxy provider" "$OC" "openai-proxy"
 
@@ -307,7 +307,7 @@ assert_file "xcsh models.json" "/home/vscode/.xcsh/agent/models.json"
 assert_file "xcsh models.yml" "/home/vscode/.xcsh/agent/models.yml"
 XCSH_ROLES=$(zrun 'xcsh config get modelRoles 2>/dev/null')
 assert_contains "xcsh: default role = sonnet" "$XCSH_ROLES" "claude-sonnet-4-6"
-assert_contains "xcsh: slow role = opus" "$XCSH_ROLES" "pd-claude-opus-4-7"
+assert_contains "xcsh: slow role = opus" "$XCSH_ROLES" "claude-opus-4-6"
 assert_contains "xcsh: smol role = haiku" "$XCSH_ROLES" "claude-haiku-4-5"
 
 # Maki: dynamic provider script staged, executable, base URL substituted
@@ -318,7 +318,7 @@ MAKI_SCRIPT=$(run cat /home/vscode/.maki/providers/litellm)
 assert_not_contains "Maki: no __MAKI_BASE_URL__ placeholder" "$MAKI_SCRIPT" "__MAKI_BASE_URL__"
 assert_contains "Maki: base URL rendered" "$MAKI_SCRIPT" "${TEST_URL}/anthropic/v1/messages"
 MAKI_MODELS=$(run /home/vscode/.maki/providers/litellm models)
-assert_contains "Maki: opus in models list" "$MAKI_MODELS" "pd-claude-opus-4-7"
+assert_contains "Maki: opus in models list" "$MAKI_MODELS" "claude-opus-4-6"
 
 # ============================================================
 # 5. AI assistant CLIs


### PR DESCRIPTION
Closes #1086

## Summary

- Rename `pd-claude-opus-4-7` → `claude-opus-4-6` across all agent configs (Claude Code, Crush, Hermes, Pi, OMP, OpenCode, xcsh, Maki) plus smoke-test assertions. The previous ID is no longer served by the LiteLLM proxy.
- Append `[1m]` to `ANTHROPIC_DEFAULT_OPUS_MODEL` and `ANTHROPIC_DEFAULT_SONNET_MODEL` to enable the 1M context window for the `opus`/`sonnet` aliases in Claude Code. Per the [Claude Code model-config docs](https://code.claude.com/docs/en/model-config), the suffix is stripped before the provider call, so LiteLLM still receives the bare model ID. Both models support 1M on API / pay-as-you-go with full access.
- Fix `maki-config/litellm`'s sonnet `context_window` from 200000 → 1000000 to match Sonnet 4.6's actual capability (verified empirically: 991,188 unique tokens processed in live testing).

## Test plan

- [ ] CI build passes (`.github/workflows/*`)
- [ ] Smoke test assertions all green — every Opus/Sonnet model-ID assertion uses substring match, so the `[1m]` suffix does not break existing checks
- [ ] Container boot: `ANTHROPIC_DEFAULT_OPUS_MODEL=claude-opus-4-6[1m]` and `ANTHROPIC_DEFAULT_SONNET_MODEL=claude-sonnet-4-6[1m]` visible in shell env
- [ ] Claude Code `/status` reports 1M context window active
- [ ] Non-Claude-Code tools (pi/omp/crush/opencode/hermes/maki/xcsh) route prompts through LiteLLM using bare `claude-opus-4-6` / `claude-sonnet-4-6` IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)