### PR TITLE
revert: PR #1088 — image fails to start despite layer reduction

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1624,59 +1624,60 @@ RUN chmod +x /home/${USERNAME}/.lessfilter
 # ============================================================
 USER root
 
-# Stage the entire build context into one layer, then distribute in a single
-# RUN. Replaces 21 single-file COPY instructions (~26 layers with the chmod RUN)
-# with 3 layers total: 1 COPY (stage), 1 RUN (distribute), 1 RUN (sync-agents
-# as vscode). Brings the image under overlay2's 128-layer mount ceiling.
-# File ownership under /home/${USERNAME} is repaired by the final chown -R in
-# section 19, so we omit -o/-g on install(1). File mode 755 is set for all
-# shell scripts, 644 for static configs; install(1) -D creates leading dirs.
-# .dockerignore already allowlists every source referenced below, so the
-# staging layer contains only the expected payload (< a few MB).
-# hadolint ignore=DL3059
-COPY . /tmp/cfg
+# --- System-wide scripts and managed policy ---
+COPY claude-config/self-test.sh /opt/claude-config/self-test.sh
+COPY claude-config/CLAUDE.md /etc/claude-code/CLAUDE.md
 
-# hadolint ignore=DL3059
-RUN set -e \
-    # --- System-wide scripts (mode 755, root-owned) ---
-    && install -D -m 755 /tmp/cfg/claude-config/self-test.sh        /opt/claude-config/self-test.sh \
-    && install -D -m 755 /tmp/cfg/claude-config/statusline.sh       /opt/claude-config/statusline.sh \
-    && install -D -m 755 /tmp/cfg/claude-config/api-key-helper.sh   /opt/claude-config/api-key-helper.sh \
-    && install -D -m 755 /tmp/cfg/claude-config/install-plugins.sh  /opt/claude-config/install-plugins.sh \
-    && install -D -m 755 /tmp/cfg/claude-config/neutralize-hooks.sh /opt/claude-config/neutralize-hooks.sh \
-    && install -D -m 755 /tmp/cfg/claude-config/chrome-browser.sh   /usr/local/lib/chrome-browser.sh \
-    && install -D -m 755 /tmp/cfg/.devcontainer/scripts/post-start.sh /opt/devcontainer/post-start.sh \
-    && install -D -m 755 /tmp/cfg/scripts/nightly-update.sh         /opt/devcontainer/nightly-update.sh \
-    && install -D -m 755 /tmp/cfg/codex-config/sync-agents.sh       /opt/codex-config/sync-agents.sh \
-    # --- Managed policy (root-owned, mode 644) ---
-    && install -D -m 644 /tmp/cfg/claude-config/CLAUDE.md           /etc/claude-code/CLAUDE.md \
-    # --- Home-scoped configs (vscode via later chown -R in section 19) ---
-    && install -D -m 644 /tmp/cfg/claude-config/settings.json                 /home/${USERNAME}/.claude/settings.json \
-    && install -D -m 644 /tmp/cfg/claude-config/claude.json                   /home/${USERNAME}/.claude.json \
-    && install -D -m 644 /tmp/cfg/claude-config/user-CLAUDE.md                /home/${USERNAME}/.claude/CLAUDE.md \
-    && install -D -m 644 /tmp/cfg/codex-config/config.toml                    /home/${USERNAME}/.codex/config.toml \
-    && install -D -m 644 /tmp/cfg/pi-config/settings.json                     /home/${USERNAME}/.pi/agent/settings.json \
-    && install -D -m 644 /tmp/cfg/omp-config/settings.json                    /home/${USERNAME}/.omp/agent/settings.json \
-    && install -D -m 644 /tmp/cfg/omp-config/config.yml                       /home/${USERNAME}/.omp/agent/config.yml \
-    && install -D -m 644 /tmp/cfg/opencode-config/opencode.json               /home/${USERNAME}/.config/opencode/opencode.json \
-    && install -D -m 644 /tmp/cfg/opencode-config/oh-my-openagent.json        /home/${USERNAME}/.config/opencode/oh-my-openagent.json \
-    && install -D -m 644 /tmp/cfg/opencode-config/opencode-permissions.json   /home/${USERNAME}/.config/opencode/opencode-permissions.json \
-    && install -D -m 644 /tmp/cfg/hermes-config/config.yaml                   /home/${USERNAME}/.hermes/config.yaml \
-    && install -D -m 644 /tmp/cfg/crush-config/crush.json                     /home/${USERNAME}/.config/crush/crush.json \
-    && install -D -m 755 /tmp/cfg/maki-config/litellm                         /home/${USERNAME}/.maki/providers/litellm \
-    # --- Misc system setup previously in the chmod-RUN ---
+COPY claude-config/chrome-browser.sh /usr/local/lib/chrome-browser.sh
+COPY claude-config/statusline.sh /opt/claude-config/statusline.sh
+COPY claude-config/api-key-helper.sh /opt/claude-config/api-key-helper.sh
+COPY claude-config/install-plugins.sh /opt/claude-config/install-plugins.sh
+COPY claude-config/neutralize-hooks.sh /opt/claude-config/neutralize-hooks.sh
+COPY .devcontainer/scripts/post-start.sh /opt/devcontainer/post-start.sh
+COPY scripts/nightly-update.sh /opt/devcontainer/nightly-update.sh
+RUN chmod +x /opt/claude-config/self-test.sh \
+      /usr/local/lib/chrome-browser.sh \
+      /opt/claude-config/statusline.sh /opt/claude-config/api-key-helper.sh \
+      /opt/claude-config/install-plugins.sh \
+      /opt/claude-config/neutralize-hooks.sh \
+      /opt/devcontainer/post-start.sh \
+      /opt/devcontainer/nightly-update.sh \
     && ln -s /opt/claude-config/self-test.sh /usr/local/bin/claude-self-test \
     && mkdir -p /etc/claude-code/.claude/rules \
-    && echo "0 3 * * * /opt/devcontainer/nightly-update.sh" | crontab -u ${USERNAME} - \
-    # --- Remove staging dir so its contents do not bloat the image ---
-    && rm -rf /tmp/cfg
+    && echo "0 3 * * * /opt/devcontainer/nightly-update.sh" \
+      | crontab -u ${USERNAME} -
 
-# 17a. Sync Claude Code plugin agents → Codex .toml format.
-# Runs as vscode so output files under ~/.codex/ are vscode-owned.
+# --- Claude Code: settings.json + claude.json → final $HOME paths ---
+COPY --chown=${USERNAME}:${USERNAME} claude-config/settings.json /home/${USERNAME}/.claude/settings.json
+COPY --chown=${USERNAME}:${USERNAME} claude-config/claude.json /home/${USERNAME}/.claude.json
+COPY --chown=${USERNAME}:${USERNAME} claude-config/user-CLAUDE.md /home/${USERNAME}/.claude/CLAUDE.md
+
+
+
+# --- Codex + Pi + Hermes: bake static defaults ---
+COPY --chown=${USERNAME}:${USERNAME} codex-config/config.toml /home/${USERNAME}/.codex/config.toml
+COPY --chown=${USERNAME}:${USERNAME} codex-config/sync-agents.sh /opt/codex-config/sync-agents.sh
+
+# 17a. Sync Claude Code plugin agents → Codex .toml format
+# Converts ~/.claude/plugins/cache/*/agents/*.md to ~/.codex/agents/*.toml
+# so Codex can natively discover the same agents as Claude Code.
+# chmod as root (modifies /opt/); run as vscode so output files under
+# ~/.codex/ are owned by vscode, not root.
+# hadolint ignore=DL3059
+RUN chmod +x /opt/codex-config/sync-agents.sh
 USER $USERNAME
 # hadolint ignore=DL3059
 RUN /opt/codex-config/sync-agents.sh
 USER root
+COPY --chown=${USERNAME}:${USERNAME} pi-config/settings.json /home/${USERNAME}/.pi/agent/settings.json
+COPY --chown=${USERNAME}:${USERNAME} omp-config/settings.json /home/${USERNAME}/.omp/agent/settings.json
+COPY --chown=${USERNAME}:${USERNAME} omp-config/config.yml /home/${USERNAME}/.omp/agent/config.yml
+COPY --chown=${USERNAME}:${USERNAME} opencode-config/opencode.json /home/${USERNAME}/.config/opencode/opencode.json
+COPY --chown=${USERNAME}:${USERNAME} opencode-config/oh-my-openagent.json /home/${USERNAME}/.config/opencode/oh-my-openagent.json
+COPY --chown=${USERNAME}:${USERNAME} opencode-config/opencode-permissions.json /home/${USERNAME}/.config/opencode/opencode-permissions.json
+COPY --chown=${USERNAME}:${USERNAME} hermes-config/config.yaml /home/${USERNAME}/.hermes/config.yaml
+COPY --chown=${USERNAME}:${USERNAME} crush-config/crush.json /home/${USERNAME}/.config/crush/crush.json
+COPY --chown=${USERNAME}:${USERNAME} maki-config/litellm /home/${USERNAME}/.maki/providers/litellm
 
 # ────────────────────────────────────────────────────────────
 # OpenCode npm pre-warm: pre-install base SDK and plugin deps


### PR DESCRIPTION
Closes #1092

Reverts #1088 because the published image at `ghcr.io/.../devcontainer@sha256:af805bc...` (from #1088's merge) pulls successfully (114 layers, under the 128 cap — so the layer reduction itself worked) but **fails to start at runtime**: `docker compose up -d` returns non-zero in [run 24877130988](https://github.com/f5xc-salesdemos/devcontainer/actions/runs/24877130988) immediately after "Starting container …".

The actual docker error was masked by `>/dev/null 2>&1` redirection in `tests/smoke-test.sh` at line 187, so we cannot yet identify the exact failure.

Restoring the pre-#1088 Dockerfile returns `:latest` to a runtime-working image (same structure as the known-good `c29d2ef` build). The layer-depth regression from #1087 returns, so CI's smoke-test step will still fail at the `docker pull` step — but the published image will be runnable under `podman run` for users who already have it locally.

#1087 re-opened for continued investigation. Follow-up PR will:
1. Remove stderr suppression in `tests/smoke-test.sh` so the actual docker error is visible.
2. Re-attempt layer reduction with a safer per-directory COPY pattern instead of `COPY . /tmp/cfg`.

## Test plan

- [ ] CI builds both arch images (should continue to succeed — structure unchanged from last working build)
- [ ] Published `:latest` on merge is usable at runtime (manifest merge completes, image pulls and starts via `podman run`)
- [ ] Smoke-test still fails at `docker pull` step with `max depth exceeded` — expected, this is the known pre-existing issue #1087

🤖 Generated with [Claude Code](https://claude.com/claude-code)