### PR TITLE
test: unmask docker compose errors in smoke-test

### DIFF
--- a/tests/smoke-test.sh
+++ b/tests/smoke-test.sh
@@ -184,7 +184,14 @@ GIT_AUTHOR_EMAIL=smoke@test.local
 EOF
 
 echo "Starting container ..."
-"$RT" compose -f "$COMPOSE_DIR/docker-compose.yml" up -d >/dev/null 2>&1
+# Emit stderr so a failed create/start surfaces the runtime error
+# (previously `>/dev/null 2>&1` hid the reason — set -e would then exit
+# the script with only "Starting container ..." visible in CI logs).
+if ! _compose_out=$("$RT" compose -f "$COMPOSE_DIR/docker-compose.yml" up -d 2>&1); then
+  echo "ERROR: container start failed — $RT compose output:" >&2
+  echo "$_compose_out" >&2
+  exit 1
+fi
 
 echo "Waiting for entrypoint ..."
 for _ in $(seq 1 90); do


### PR DESCRIPTION
Closes #1094
Refs #1087

Establishes diagnostics for the NEXT layer-reduction attempt by surfacing the docker error that was hidden by stderr suppression during the #1088 investigation.

## Problem

\`tests/smoke-test.sh:187\` redirected both stdout and stderr of \`docker compose up -d\` to \`/dev/null\`. When PR #1088's image failed to start, CI logs showed only:

\`\`\`
Starting container ...
##[error]Process completed with exit code 1.
\`\`\`

The actual error message from docker/podman was lost.

## Fix

Capture the compose output, test the exit status, emit the output on failure, then exit with status 1. On success, behave identically to before.

## Why this PR isn't combined with the layer-reduction retry

The previous attempt (#1088) was a single commit that both reduced layers AND broke runtime, leaving no way to tell which change caused what. This PR establishes diagnostics FIRST. The next layer-reduction PR can then be evaluated cleanly — if it regresses, we'll see exactly why.

## Test plan

- [ ] CI pre-merge checks pass (shell unit tests, super-linter, linked-issue)
- [ ] (Not exercised in this PR) next time a runtime regression happens in \`smoke-test\`, the actual docker error is visible in the job log

🤖 Generated with [Claude Code](https://claude.com/claude-code)