### PR TITLE
feat: pre-download Trivy vulnerability databases at build time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1449,6 +1449,12 @@ RUN npx -y oh-my-openagent install --no-tui \
     --claude=max20 --openai=no --gemini=no --copilot=no \
     && rm -f ~/.config/opencode/*.bak.*
 
+# Pre-download Trivy vulnerability databases so first scan is instant.
+# Runs as vscode so cache lands in ~/.cache/trivy with correct ownership.
+# hadolint ignore=DL3059
+RUN trivy image --download-db-only --no-progress \
+    && trivy image --download-java-db-only --no-progress
+
 # ============================================================
 # 14. Language formatters (GitHub binaries + source build)
 #     Replaces the previous Homebrew section. Each tool is


### PR DESCRIPTION
## Summary

- Add `trivy image --download-db-only` and `trivy image --download-java-db-only` to the Dockerfile
- Pre-caches ~2.4 GB of vulnerability databases at build time so first runtime scan is instant
- Eliminates network dependency for initial Trivy scans in ephemeral containers

Closes #1099

## Test plan

- [ ] CI checks pass
- [ ] Container builds successfully with the new Trivy DB download layer
- [ ] `trivy image --list-all-pkgs` runs without downloading databases at runtime