### PR TITLE
fix: fold Trivy DB download into adjacent RUN to avoid overlay2 layer limit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1447,12 +1447,10 @@ RUN npm exec chrome-devtools-mcp@0.20.2 -- --version 2>/dev/null || true
 # hadolint ignore=DL3059
 RUN npx -y oh-my-openagent install --no-tui \
     --claude=max20 --openai=no --gemini=no --copilot=no \
-    && rm -f ~/.config/opencode/*.bak.*
-
-# Pre-download Trivy vulnerability databases so first scan is instant.
-# Runs as vscode so cache lands in ~/.cache/trivy with correct ownership.
-# hadolint ignore=DL3059
-RUN trivy image --download-db-only --no-progress \
+    && rm -f ~/.config/opencode/*.bak.* \
+    # Pre-download Trivy vulnerability databases so first scan is instant.
+    # Runs as vscode so cache lands in ~/.cache/trivy with correct ownership.
+    && trivy image --download-db-only --no-progress \
     && trivy image --download-java-db-only --no-progress
 
 # ============================================================


### PR DESCRIPTION
## Summary

- Folds the Trivy vulnerability database download commands (added in #1100) into the preceding oh-my-openagent RUN block, eliminating an extra Docker layer
- Prevents the image from exceeding the overlay2 128-layer cap that caused "max depth exceeded" errors in the Docker Publish smoke-test

Closes #1099

## Test plan

- [ ] CI checks pass (Dockerfile lint, linked issue check)
- [ ] Docker Publish smoke-test passes without "max depth exceeded" error
- [ ] Trivy DB is still present in the built image