### PR TITLE
fix: rename ghlatest.sh and install-release.sh after multi-source COPY

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,9 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # ghlatest + install-release: resolve latest GitHub release versions and
 # atomic download-then-extract for GitHub release assets.
 COPY scripts/ghlatest.sh scripts/install-release.sh /usr/local/bin/
-RUN chmod +x /usr/local/bin/ghlatest /usr/local/bin/install-release
+RUN mv /usr/local/bin/ghlatest.sh /usr/local/bin/ghlatest \
+    && mv /usr/local/bin/install-release.sh /usr/local/bin/install-release \
+    && chmod +x /usr/local/bin/ghlatest /usr/local/bin/install-release
 
 # ============================================================
 # 1. APT repository setup


### PR DESCRIPTION
## Summary

The COPY consolidation in #1105 used multi-source COPY to `/usr/local/bin/`, which preserves the `.sh` extension. All downstream references expect the files without `.sh` (as `/usr/local/bin/ghlatest` and `/usr/local/bin/install-release`). Added `mv` commands to the existing `chmod` RUN instruction to rename the files, keeping the layer count unchanged.

Closes #1108

## Test plan

- [ ] CI checks pass
- [ ] Docker build succeeds with ghlatest and install-release available at expected paths