### PR TITLE
fix: prefer docker over podman in smoke-test runtime detection

### DIFF
--- a/tests/smoke-test.sh
+++ b/tests/smoke-test.sh
@@ -14,13 +14,16 @@ set -euo pipefail
 #   Not set → render-only test with dummy values (functional tests skipped)
 # ============================================================
 
-# Auto-detect container runtime
-if command -v podman >/dev/null 2>&1; then
-  RT=podman
-elif command -v docker >/dev/null 2>&1; then
+# Auto-detect container runtime.
+# Prefer docker: CI runners have Docker daemon running; podman's rootless
+# socket is often not started, causing "Cannot connect to Docker daemon"
+# when podman compose delegates to the docker-compose plugin.
+if command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1; then
   RT=docker
+elif command -v podman >/dev/null 2>&1; then
+  RT=podman
 else
-  echo "Error: neither podman nor docker found" >&2
+  echo "Error: neither docker nor podman found" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

- Changed runtime detection in `tests/smoke-test.sh` to prefer docker when its daemon is responsive (`docker info` succeeds), falling back to podman
- Fixes arm64 CI runner failures where podman binary exists but its rootless socket is not started, causing "Cannot connect to Docker daemon" errors
- Docker is the active runtime on CI runners (confirmed by successful docker pull steps)

Closes #1114

## Test plan

- [ ] CI checks pass (smoke-test runs on both amd64 and arm64 runners)
- [ ] Verify docker is selected on CI where Docker daemon is running
- [ ] Verify podman fallback still works on local dev environments