### PR TITLE
feat: add Docker-outside-of-Docker (DooD) support for host container control

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -97,6 +97,11 @@ RUN echo 'APT::Acquire::Retries "3";' > /etc/apt/apt.conf.d/99retries \
       && printf 'Package: *\nPin: origin packages.mozilla.org\nPin-Priority: 1000\n' \
         > /etc/apt/preferences.d/mozilla; \
     fi \
+    # Docker CE (CLI-only — no daemon; DooD via host socket)
+    && curl ${CURL_RETRY} -fsSL https://download.docker.com/linux/ubuntu/gpg \
+      | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" \
+      > /etc/apt/sources.list.d/docker.list \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # ============================================================
@@ -140,6 +145,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     # Locale
     locales \
     locales-all \
+    # Docker CLI (DooD — no daemon; talks to host via mounted socket)
+    docker-ce-cli \
+    docker-buildx-plugin \
+    docker-compose-plugin \
     # Additional tools
     dos2unix \
     eza \
@@ -1346,6 +1355,8 @@ RUN retry git clone --depth=1 --single-branch --branch main \
 # 13. Playwright system dependencies + fix ownership of dirs created by root
 # hadolint ignore=DL3059
 RUN npx playwright install-deps \
+    && groupadd -f docker \
+    && usermod -aG docker ${USERNAME} \
     && chown -R ${USERNAME}:${USERNAME} /home/${USERNAME}
 
 # ============================================================

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,8 @@ services:
     memswap_limit: 30g
     cpus: 2
     pids_limit: 4096
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
     tmpfs:
       - /tmp:size=256m
     stdin_open: true

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,6 +15,16 @@ if [ -d /usr/local/rustup ] && [ ! -w /usr/local/rustup ]; then
   echo 'WARNING: /usr/local/rustup is not writable — Rust toolchain updates will fail' >&2
 fi
 
+# Docker-outside-of-Docker: detect host container runtime socket.
+# Supports Docker (/var/run/docker.sock) and Podman (rootless socket).
+if [ -z "$DOCKER_HOST" ]; then
+  if [ -S /var/run/docker.sock ]; then
+    export DOCKER_HOST="unix:///var/run/docker.sock"
+  elif [ -S "${XDG_RUNTIME_DIR:-/run/user/$(id -u)}/podman/podman.sock" ]; then
+    export DOCKER_HOST="unix://${XDG_RUNTIME_DIR:-/run/user/$(id -u)}/podman/podman.sock"
+  fi
+fi
+
 if [ -n "$GIT_AUTHOR_NAME" ]; then
   git config --global user.name "$GIT_AUTHOR_NAME"
   export GIT_COMMITTER_NAME="${GIT_COMMITTER_NAME:-$GIT_AUTHOR_NAME}"


### PR DESCRIPTION
## Summary

- Add Docker CLI (docker-ce-cli), Buildx, and Compose plugins to the devcontainer via DooD pattern — no daemon inside the container
- Mount host Docker/Podman socket in docker-compose.yml for container runtime access
- Auto-detect DOCKER_HOST in entrypoint.sh supporting both Docker and Podman rootless sockets

Closes #1116

## Test plan

- [ ] CI checks pass (Lint Code Base, Check linked issues)
- [ ] Container builds successfully with Docker CLI packages
- [ ] `docker version` works inside container when host socket is mounted
- [ ] `docker compose version` and `docker buildx version` report installed plugins
- [ ] DOCKER_HOST auto-detection respects pre-set environment variable
- [ ] Podman socket fallback works when Docker socket is absent