### PR TITLE
feat: support rootless Podman socket for DooD (no sudo required)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -177,6 +177,26 @@ GIT_AUTHOR_NAME="Example Name"
 # GWS_TOKEN_CACHE=
 
 # =============================================================================
+# Docker / Podman Socket (DooD) — OPTIONAL
+# =============================================================================
+# Mount the host container runtime socket so Docker CLI inside the container
+# can build images and manage containers on your workstation.
+#
+# Docker Desktop / Docker Engine (default — no .env entry needed):
+#   The socket at /var/run/docker.sock is used automatically.
+#
+# Rootless Podman (no sudo required):
+#   Set DOCKER_SOCK to your Podman user socket.
+#   First enable the socket: systemctl --user start podman.socket
+#   Then set DOCKER_SOCK below (replace 1000 with your UID: id -u).
+#
+# @auto-detect: echo "${XDG_RUNTIME_DIR:-/run/user/$(id -u)}/podman/podman.sock"
+# @requires: rootless Podman with socket enabled (systemctl --user start podman.socket)
+# @check: test -S "${XDG_RUNTIME_DIR:-/run/user/$(id -u)}/podman/podman.sock"
+
+# DOCKER_SOCK=/run/user/1000/podman/podman.sock
+
+# =============================================================================
 # VNC Remote Desktop — OPTIONAL
 # =============================================================================
 # Start the VNC stack (Xvfb + fluxbox + x11vnc + noVNC) for GUI access.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
     cpus: 2
     pids_limit: 4096
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
+      - ${DOCKER_SOCK:-/var/run/docker.sock}:/var/run/docker.sock
     tmpfs:
       - /tmp:size=256m
     stdin_open: true

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,13 +15,14 @@ if [ -d /usr/local/rustup ] && [ ! -w /usr/local/rustup ]; then
   echo 'WARNING: /usr/local/rustup is not writable — Rust toolchain updates will fail' >&2
 fi
 
-# Docker-outside-of-Docker: detect host container runtime socket.
-# Supports Docker (/var/run/docker.sock) and Podman (rootless socket).
+# Docker-outside-of-Docker: set DOCKER_HOST to the mounted socket.
+# The host socket (Docker or Podman) is always mounted to /var/run/docker.sock
+# inside the container via the DOCKER_SOCK compose variable.
+# Rootless Podman users: set DOCKER_SOCK in .env to their socket path,
+# e.g. DOCKER_SOCK=/run/user/1000/podman/podman.sock  (no sudo needed).
 if [ -z "$DOCKER_HOST" ]; then
   if [ -S /var/run/docker.sock ]; then
     export DOCKER_HOST="unix:///var/run/docker.sock"
-  elif [ -S "${XDG_RUNTIME_DIR:-/run/user/$(id -u)}/podman/podman.sock" ]; then
-    export DOCKER_HOST="unix://${XDG_RUNTIME_DIR:-/run/user/$(id -u)}/podman/podman.sock"
   fi
 fi
 


### PR DESCRIPTION
## Summary

- Make the Docker/Podman socket path configurable via `DOCKER_SOCK` env var (defaults to `/var/run/docker.sock`)
- Simplify entrypoint.sh socket detection since the compose variable handles the host-side path mapping
- Add documentation and auto-detect hints in `.env.example` for rootless Podman users

Closes #1118

## Test plan

- [ ] CI checks pass
- [ ] Docker Desktop users: verify no change needed — default socket works as before
- [ ] Rootless Podman users: set `DOCKER_SOCK=/run/user/<UID>/podman/podman.sock` in `.env` and verify `docker ps` works inside the container
- [ ] Verify `DOCKER_HOST` is correctly set inside the container when socket is present