### PR TITLE
docs: add missing index description for llms.txt hierarchy

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Dev Container
+description: Portable Docker-based development environment with programming languages, cloud CLIs, DevOps tooling, and AI-powered coding assistants.
 hero:
   tagline: A portable development environment that runs inside Docker. It comes pre-loaded with programming languages, cloud CLIs, DevOps tooling, and AI-powered coding assistants — all isolated from your host machine.
   image:


### PR DESCRIPTION
## Summary

Refs f5xc-salesdemos/xcsh#223

Adds the missing `description:` field to the devcontainer hero index page. This field is required by the starlight-llms-txt plugin to properly generate the llms.txt hierarchy (Step 5c of xcsh#223).

Closes #1126

## Test plan

- [ ] CI checks pass
- [ ] Verify the docs site builds successfully with the new frontmatter field