### PR TITLE
fix: add connect timeout to LiteLLM proxy sanity probe curl

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -372,7 +372,7 @@ fi
 # regression surfaces immediately instead of at first tool invocation.
 # ============================================================
 if [ -n "$LITELLM_BASE_URL" ] && [ -n "$LITELLM_API_KEY" ] && command -v curl >/dev/null 2>&1; then
-  _probe_status=$(curl -sS -o /dev/null -w '%{http_code}' \
+  _probe_status=$(curl -sS --connect-timeout 5 --max-time 10 -o /dev/null -w '%{http_code}' \
     -X POST "${LITELLM_BASE_URL}/anthropic/v1/messages" \
     -H "x-api-key: ${LITELLM_API_KEY}" \
     -H 'content-type: application/json' \


### PR DESCRIPTION
## Summary

- Add `--connect-timeout 5 --max-time 10` to the LiteLLM proxy sanity probe `curl` in `entrypoint.sh`
- Prevents curl from hanging for ~120s when `LITELLM_BASE_URL` points to an unreachable host (e.g., during smoke-tests)
- Bounds the probe to 10 seconds max, preventing smoke-test timeouts

Closes #1130

## Test plan

- [ ] CI checks pass
- [ ] Smoke-test completes within its 90-second timeout when `LITELLM_BASE_URL` is set to a dummy URL
- [ ] Normal entrypoint behavior is unchanged when `LITELLM_BASE_URL` points to a reachable proxy