### PR TITLE
fix: detect container crash during smoke-test entrypoint wait

### DIFF
--- a/tests/smoke-test.sh
+++ b/tests/smoke-test.sh
@@ -197,10 +197,17 @@ if ! _compose_out=$("$RT" compose -f "$COMPOSE_DIR/docker-compose.yml" up -d 2>&
 fi
 
 echo "Waiting for entrypoint ..."
-for _ in $(seq 1 90); do
+for _wait in $(seq 1 90); do
   if run test -f /run/entrypoint-env.sh; then break; fi
+  if ! "$RT" inspect "$CONTAINER" --format '{{.State.Running}}' 2>/dev/null | grep -q true; then
+    echo "ERROR: container exited before entrypoint completed" >&2
+    echo "--- container logs ---" >&2
+    "$RT" logs "$CONTAINER" 2>&1 | tail -30 >&2
+    exit 1
+  fi
   sleep 1
 done
+unset _wait
 sleep 5
 
 # ============================================================


### PR DESCRIPTION
## Summary

The smoke-test entrypoint wait loop (90 seconds) silently times out when the container crashes before writing `/run/entrypoint-env.sh`. The `docker exec` exit code 1 is indistinguishable from "file not found yet", so the actual crash reason is never surfaced.

This adds a container health check inside the wait loop. If the container is no longer running, it immediately dumps the last 30 lines of container logs and exits, surfacing the actual crash reason instead of a silent timeout.

Closes #1132

## Test plan

- [ ] CI checks pass
- [ ] Verify that when a container crashes during entrypoint, the smoke-test exits immediately with container logs
- [ ] Verify normal (non-crashing) entrypoint wait behavior is unchanged