### PR TITLE
fix: dump container logs when entrypoint env file is missing in smoke-test

### DIFF
--- a/tests/smoke-test.sh
+++ b/tests/smoke-test.sh
@@ -216,8 +216,13 @@ sleep 5
 echo ""
 echo "Entrypoint env derivation"
 echo "-------------------------"
-ENV_FILE=$(run cat /run/entrypoint-env.sh)
-assert_file "/run/entrypoint-env.sh exists" "/run/entrypoint-env.sh"
+ENV_FILE=$(run cat /run/entrypoint-env.sh 2>/dev/null || true)
+if [ -z "$ENV_FILE" ]; then
+  fail "/run/entrypoint-env.sh missing or empty — dumping container logs:"
+  "$RT" logs "$CONTAINER" 2>&1 | tail -50
+else
+  ok "/run/entrypoint-env.sh exists"
+fi
 assert_contains "ANTHROPIC_API_KEY derived" "$ENV_FILE" "ANTHROPIC_API_KEY=$TEST_KEY"
 assert_contains "ANTHROPIC_BASE_URL derived" "$ENV_FILE" "ANTHROPIC_BASE_URL=${TEST_URL}/anthropic"
 assert_contains "ANTHROPIC_API_ENDPOINT derived" "$ENV_FILE" "ANTHROPIC_API_ENDPOINT=${TEST_URL}/anthropic"


### PR DESCRIPTION
## Summary

- Tolerate a missing `/run/entrypoint-env.sh` by suppressing stderr and using `|| true` on the `run cat` command substitution
- When the file is missing or empty, call `fail` and dump the last 50 lines of container logs for full entrypoint diagnostics
- When the file exists, call `ok` instead of the previous `assert_file` (which was redundant after a successful `cat`)

Closes #1136

## Test plan

- [ ] CI checks pass
- [ ] Verify smoke-test still passes when `/run/entrypoint-env.sh` exists (happy path)
- [ ] Verify smoke-test produces container log output when `/run/entrypoint-env.sh` is missing