### PR TITLE
fix: constrain Maven JVM heap in smoke-test to prevent OOM on CI runner

### DIFF
--- a/tests/smoke-test.sh
+++ b/tests/smoke-test.sh
@@ -496,7 +496,7 @@ assert_bin_ver "npm" "npm --version" "."
 assert_bin_ver "pnpm" "pnpm --version" "."
 assert_bin_ver "pip" "pip --version" "pip"
 assert_bin_ver "uv" "uv --version" "uv"
-assert_bin_ver "mvn" "mvn --version 2>&1 | head -1" "Maven"
+assert_bin_ver "mvn" "MAVEN_OPTS='-Xmx256m' mvn --version 2>&1 | head -1" "Maven"
 assert_bin_ver "gradle" "gradle --version 2>&1 | grep Gradle" "Gradle"
 assert_bin_ver "gem" "gem --version" "."
 


### PR DESCRIPTION
## Summary

- Added `MAVEN_OPTS='-Xmx256m'` to the Maven version check in the smoke-test to cap JVM heap allocation
- Prevents OOM failures when the CI runner has limited memory (4GB container)
- Fixes the last remaining smoke-test failure (1 of 205)

Closes #1148

## Test plan

- [ ] CI checks pass (smoke-test reports 205/205)
- [ ] `mvn --version` check passes under constrained memory