### PR TITLE
fix: show actual command output on version check failure in smoke-test

### DIFF
--- a/tests/smoke-test.sh
+++ b/tests/smoke-test.sh
@@ -106,7 +106,7 @@ assert_bin_ver() {
   out=$("$RT" exec -u vscode "$CONTAINER" zsh -c "$cmd" 2>&1 || true)
   if echo "$out" | grep -qi "$pattern"; then
     ok "$name"
-  else fail "$name (version check failed)"; fi
+  else fail "$name (version check failed: got '$(echo "$out" | head -1)')"; fi
 }
 
 run() { "$RT" exec -u vscode "$CONTAINER" "$@" 2>/dev/null; }


### PR DESCRIPTION
## Summary

- Improve `assert_bin_ver` failure message to include the first line of actual
  command output, making it possible to diagnose version check failures
  (OOM, missing binary, Java error, etc.) directly from CI logs

Closes #1150

## Test plan

- [ ] CI checks pass
- [ ] Next smoke-test failure will show the actual error output