### PR TITLE
fix: set jansi.tmpdir for Maven smoke-test (noexec tmpfs)

### DIFF
--- a/tests/smoke-test.sh
+++ b/tests/smoke-test.sh
@@ -496,7 +496,7 @@ assert_bin_ver "npm" "npm --version" "."
 assert_bin_ver "pnpm" "pnpm --version" "."
 assert_bin_ver "pip" "pip --version" "pip"
 assert_bin_ver "uv" "uv --version" "uv"
-assert_bin_ver "mvn" "MAVEN_OPTS='-Xmx256m' mvn --version 2>&1 | head -1" "Maven"
+assert_bin_ver "mvn" "MAVEN_OPTS='-Xmx256m -Djansi.tmpdir=/home/vscode/.cache' mvn --version 2>&1 | head -1" "Maven"
 assert_bin_ver "gradle" "gradle --version 2>&1 | grep Gradle" "Gradle"
 assert_bin_ver "gem" "gem --version" "."
 


### PR DESCRIPTION
## Summary

- Set `-Djansi.tmpdir=/home/vscode/.cache` in `MAVEN_OPTS` for the Maven version assertion in `tests/smoke-test.sh`
- Fixes Maven's Jansi native library failing to execute from `/tmp` when mounted as noexec tmpfs
- Resolves the last remaining smoke-test failure (194/205 passed, 1 failed, 10 skipped)

Closes #1152

## Test plan

- [ ] CI checks pass
- [ ] Smoke-test passes the `mvn` version assertion without noexec errors