### PR TITLE
fix: disable zsh NOMATCH to prevent glob expansion of ?, *, [ characters

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1570,7 +1570,9 @@ RUN ZSH_CUSTOM="${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}" \
     # which hang automated scripts on "overwrite? (y/n)" prompts. Custom zsh files in
     # $ZSH_CUSTOM are sourced AFTER plugins, so the unalias wins.
     && echo 'unalias rm cp mv 2>/dev/null || true' > "$HOME/.oh-my-zsh/custom/disable-interactive-safety.zsh" \
+    && echo 'unsetopt NOMATCH' >> "$HOME/.zshenv" \
     && echo '[ -f "$HOME/.local/run/entrypoint-env.sh" ] && . "$HOME/.local/run/entrypoint-env.sh"' >> "$HOME/.zshenv" \
+    && echo 'unsetopt NOMATCH' >> "$HOME/.zshrc" \
     && echo '[ -d /workspace ] && cd /workspace' >> "$HOME/.zshrc"
 
 # ============================================================

--- a/tests/smoke-test.sh
+++ b/tests/smoke-test.sh
@@ -265,6 +265,8 @@ else
 fi
 SHELL_KEY=$(zrun 'echo $ANTHROPIC_API_KEY')
 assert_eq "zsh -c inherits ANTHROPIC_API_KEY" "$SHELL_KEY" "$TEST_KEY"
+NOMATCH_STATUS=$(zrun '[[ -o nomatch ]] && echo ON || echo OFF')
+assert_eq "zsh NOMATCH unset (glob safety)" "$NOMATCH_STATUS" "OFF"
 
 # ============================================================
 # 3. Environment


### PR DESCRIPTION
## Summary

- Disable zsh NOMATCH option in both `.zshenv` (all zsh invocations) and `.zshrc` (interactive, post-oh-my-zsh) to prevent glob metacharacters `?`, `*`, `[` from causing "no matches found" errors when used as literal characters in command arguments
- Add smoke-test assertion verifying NOMATCH is off in zsh sessions

Closes #1160

## Test plan

- [ ] CI checks pass (Lint Code Base, Check linked issues)
- [ ] Smoke test verifies `[[ -o nomatch ]]` reports OFF
- [ ] URLs with query strings (e.g., `curl example.com/api?key=val`) work without quoting in zsh