### PR TITLE
feat: add Kilo Code CLI (@kilocode/cli) to devcontainer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1022,6 +1022,7 @@ RUN retry npm install -g \
     sharp \
     opencode-ai \
     @charmland/crush \
+    @kilocode/cli \
     opencode-claude-auth \
     js-deobfuscator
 
@@ -1412,6 +1413,7 @@ RUN mkdir -p ~/.cache ~/.local/bin ~/.claude ~/.claude/plans ~/.config/nvim \
     ~/.hermes/image_cache \
     ~/.hermes/audio_cache \
     ~/.maki/providers \
+    ~/.config/kilo \
     ~/.ssh
 
 # Bun JavaScript runtime and package manager
@@ -1680,6 +1682,7 @@ COPY --chown=${USERNAME}:${USERNAME} opencode-config/opencode.json opencode-conf
 COPY --chown=${USERNAME}:${USERNAME} hermes-config/config.yaml /home/${USERNAME}/.hermes/config.yaml
 COPY --chown=${USERNAME}:${USERNAME} crush-config/crush.json /home/${USERNAME}/.config/crush/crush.json
 COPY --chown=${USERNAME}:${USERNAME} maki-config/litellm /home/${USERNAME}/.maki/providers/litellm
+COPY --chown=${USERNAME}:${USERNAME} kilocode-config/kilo.jsonc /home/${USERNAME}/.config/kilo/kilo.jsonc
 
 # ────────────────────────────────────────────────────────────
 # OpenCode npm pre-warm: pre-install base SDK and plugin deps

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -382,6 +382,19 @@ if [ -n "$LITELLM_BASE_URL" ]; then
 fi
 
 # ============================================================
+# Kilo Code CLI — render base URL placeholder into kilo.jsonc.
+# The @ai-sdk/anthropic SDK appends /messages to baseURL, so
+# baseURL must include /v1 (not just /anthropic).
+# ============================================================
+if [ -n "$LITELLM_BASE_URL" ]; then
+  _kilo_config="$HOME/.config/kilo/kilo.jsonc"
+  if [ -f "$_kilo_config" ]; then
+    sed -i "s|__KILO_BASE_URL__|${LITELLM_BASE_URL}/anthropic/v1|g" "$_kilo_config"
+  fi
+  unset _kilo_config
+fi
+
+# ============================================================
 # Maki — render base URL placeholder in the LiteLLM dynamic provider.
 # ~/.maki/providers/litellm carries __MAKI_BASE_URL__; resolve it at
 # container start to the LiteLLM Anthropic /v1/messages endpoint

--- a/kilocode-config/kilo.jsonc
+++ b/kilocode-config/kilo.jsonc
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://app.kilo.ai/config.json",
+  "model": "anthropic/claude-opus-4-6",
+  "provider": {
+    "anthropic": {
+      "options": {
+        "apiKey": "{env:ANTHROPIC_API_KEY}",
+        "baseURL": "__KILO_BASE_URL__"
+      }
+    }
+  }
+}

--- a/tests/smoke-test.sh
+++ b/tests/smoke-test.sh
@@ -347,6 +347,12 @@ assert_contains "Maki: base URL rendered" "$MAKI_SCRIPT" "${TEST_URL}/anthropic/
 MAKI_MODELS=$(run /home/vscode/.maki/providers/litellm models)
 assert_contains "Maki: opus in models list" "$MAKI_MODELS" "claude-opus-4-6"
 
+# Kilo Code CLI: config staged, base URL rendered
+KILO_CFG=$(run cat /home/vscode/.config/kilo/kilo.jsonc)
+assert_not_contains "Kilo: no __KILO_BASE_URL__ placeholder" "$KILO_CFG" "__KILO_BASE_URL__"
+assert_contains "Kilo: base URL rendered" "$KILO_CFG" "${TEST_URL}/anthropic/v1"
+assert_contains "Kilo: opus model" "$KILO_CFG" "claude-opus-4-6"
+
 # ============================================================
 # 5. AI assistant CLIs
 # ============================================================
@@ -361,6 +367,7 @@ assert_bin_ver "xcsh" "xcsh --version" "xcsh"
 assert_bin_ver "opencode" "opencode --version" "."
 assert_bin_ver "codex" "codex --version" "codex"
 assert_bin_ver "maki" "maki --version" "maki"
+assert_bin_ver "kilo" "kilo --version" "[0-9]"
 
 # ============================================================
 # 5b. AI functional tests (LIVE mode only)
@@ -412,6 +419,11 @@ if [ "$LIVE_API" = true ]; then
     ok "maki prompt"
   else fail "maki prompt (got: $(echo "$_out" | head -1))"; fi
 
+  _out=$(timeout 60 "$RT" exec -u vscode "$CONTAINER" zsh -c "kilo run '$PROMPT'" 2>&1 || true)
+  if echo "$_out" | grep -qi "$EXPECTED"; then
+    ok "kilo prompt"
+  else fail "kilo prompt (got: $(echo "$_out" | head -1))"; fi
+
   _out=$("$RT" exec -u vscode "$CONTAINER" zsh -c 'curl -sf "$ANTHROPIC_BASE_URL/v1/messages" -X POST -H "x-api-key: $ANTHROPIC_API_KEY" -H "content-type: application/json" -H "anthropic-version: 2023-06-01" -d "{\"model\":\"claude-sonnet-4-6\",\"max_tokens\":5,\"messages\":[{\"role\":\"user\",\"content\":\"reply only: hello\"}]}" | jq -r ".content[0].text"' 2>&1 || true)
   if echo "$_out" | grep -qi "hello"; then
     ok "API direct curl"
@@ -424,6 +436,7 @@ else
   skip "codex prompt (no live API)"
   skip "opencode prompt (no live API)"
   skip "maki prompt (no live API)"
+  skip "kilo prompt (no live API)"
   skip "API direct curl (no live API)"
 fi
 


### PR DESCRIPTION
## Summary

- Add Kilo Code CLI (`@kilocode/cli`) as a new AI assistant in the devcontainer
- Install via npm, add config template (`kilocode-config/kilo.jsonc`) with `__KILO_BASE_URL__` placeholder rendered to `${LITELLM_BASE_URL}/anthropic/v1` at container start
- Add entrypoint rendering block and smoke-test assertions (config rendering, binary version, functional prompt, skip entry)

Closes #1170

## Test plan

- [ ] CI checks pass (Check linked issues + Lint Code Base)
- [ ] Smoke test validates kilo binary version output
- [ ] Smoke test validates config template rendering at container start
- [ ] Smoke test validates functional prompt execution
- [ ] Smoke test validates skip entry in test matrix