### PR TITLE
fix: add kilocode-config to .dockerignore allowlist

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,6 +9,7 @@
 !opencode-config/
 !crush-config/
 !maki-config/
+!kilocode-config/
 !.devcontainer/scripts/
 !scripts/
 !configs/


### PR DESCRIPTION
## Summary

The Docker Publish CI failed after merging #1171 because `.dockerignore` uses a deny-all pattern (`*`) with an explicit allowlist, and `kilocode-config/` was missing from it. The `COPY` instruction for `kilocode-config/kilo.jsonc` in the Dockerfile failed with "not found".

This adds `!kilocode-config/` to the `.dockerignore` allowlist so the Docker build context includes the directory.

Closes #1172

## Test plan

- [ ] CI checks pass
- [ ] Docker Publish workflow succeeds (kilocode-config/kilo.jsonc is included in the build context)