### PR TITLE
fix: add kilocode-config and .dockerignore to Docker Publish paths filter

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -15,6 +15,8 @@ on:
       - opencode-config/**
       - pi-config/**
       - omp-config/**
+      - kilocode-config/**
+      - .dockerignore
       - scripts/**
       - docker-compose.yml
       - tests/**


### PR DESCRIPTION
## Summary

- Add `kilocode-config/**` and `.dockerignore` to the Docker Publish workflow's `paths` filter so that changes to kilo configuration or the Docker build context correctly trigger an image rebuild.

Closes #1174

## Test plan

- [ ] CI checks pass
- [ ] Verify the `paths` filter in `docker-publish.yml` includes `kilocode-config/**` and `.dockerignore`