### PR TITLE
fix: update Codex CLI download URL from gnu to musl binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -537,8 +537,8 @@ RUN true \
     # codex (latest — version-free asset name, self-updates at runtime)
     && if [ "$DPKG_ARCH" = "amd64" ]; then CODEX_ARCH="x86_64"; else CODEX_ARCH="aarch64"; fi \
     && install-release codex \
-        "https://github.com/openai/codex/releases/latest/download/codex-${CODEX_ARCH}-unknown-linux-gnu.tar.gz" \
-        tgz-bin codex "codex-${CODEX_ARCH}-unknown-linux-gnu" \
+        "https://github.com/openai/codex/releases/latest/download/codex-${CODEX_ARCH}-unknown-linux-musl.tar.gz" \
+        tgz-bin codex "codex-${CODEX_ARCH}-unknown-linux-musl" \
     && chmod +x /usr/local/bin/codex \
     && chown ${USERNAME}:${USERNAME} /usr/local/bin/codex \
     # gogcli (resolve version — asset name contains version)


### PR DESCRIPTION
## Summary

- Update Codex CLI download URL from `linux-gnu` to `linux-musl` binary
- Fixes HTTP 404 errors during Docker image build caused by OpenAI renaming release artifacts

OpenAI renamed the Codex CLI Linux release binaries from `codex-{ARCH}-unknown-linux-gnu.tar.gz` to `codex-{ARCH}-unknown-linux-musl.tar.gz`. The old `gnu` URLs now return 404, breaking the Docker Publish CI build on both amd64 and arm64.

Closes #1176

## Test plan

- [ ] CI checks pass (Docker Publish workflow builds successfully)
- [ ] Both amd64 and arm64 images build without 404 errors