### PR TITLE
feat: add Salesforce CLI, afv-library skills, and enable marketplace plugins

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1023,6 +1023,7 @@ RUN retry npm install -g \
     opencode-ai \
     @charmland/crush \
     @kilocode/cli \
+    @salesforce/cli \
     opencode-claude-auth \
     js-deobfuscator
 
@@ -1375,6 +1376,11 @@ RUN PLUGIN_BASE="/home/${USERNAME}/.claude/plugins" \
 RUN retry git clone --depth=1 --single-branch --branch main \
       https://github.com/zarazhangrui/frontend-slides.git \
       "/home/${USERNAME}/.claude/skills/frontend-slides" \
+    && retry git clone --depth=1 --single-branch --branch main \
+      https://github.com/forcedotcom/afv-library.git \
+      "/tmp/afv-library" \
+    && cp -r /tmp/afv-library/skills/* "/home/${USERNAME}/.claude/skills/" \
+    && rm -rf /tmp/afv-library \
     && chown -R ${USERNAME}:${USERNAME} "/home/${USERNAME}/.claude" \
     && mkdir -p "/home/${USERNAME}/.agents" \
     && ln -s "/home/${USERNAME}/.claude/skills" "/home/${USERNAME}/.agents/skills" \

--- a/claude-config/settings.json
+++ b/claude-config/settings.json
@@ -58,6 +58,9 @@
     "f5xc-devcontainer@f5xc-salesdemos-marketplace": true,
     "f5xc-platform@f5xc-salesdemos-marketplace": true,
     "f5xc-meddpicc@f5xc-salesdemos-marketplace": true,
+    "f5xc-firecrawl@f5xc-salesdemos-marketplace": true,
+    "osint-framework@f5xc-salesdemos-marketplace": true,
+    "salesforce@f5xc-salesdemos-marketplace": true,
     "codex@openai-codex": true
   },
   "extraKnownMarketplaces": {

--- a/tests/smoke-test.sh
+++ b/tests/smoke-test.sh
@@ -368,6 +368,7 @@ assert_bin_ver "opencode" "opencode --version" "."
 assert_bin_ver "codex" "codex --version" "codex"
 assert_bin_ver "maki" "maki --version" "maki"
 assert_bin_ver "kilo" "kilo --version" "[0-9]"
+assert_bin_ver "sf" "sf --version" "[0-9]"
 
 # ============================================================
 # 5b. AI functional tests (LIVE mode only)


### PR DESCRIPTION
## Summary

- Add `@salesforce/cli` to the npm global install and clone `forcedotcom/afv-library` at build time to provide 30+ Salesforce development skills in `~/.claude/skills/`
- Enable three `f5xc-salesdemos-marketplace` plugins that were available but not yet activated: `salesforce`, `f5xc-firecrawl`, and `osint-framework`
- Add `sf --version` assertion to `smoke-test.sh`

Closes #1182

## Test plan

- [ ] CI checks pass (Lint Code Base, Check linked issues)
- [ ] Docker build succeeds with `@salesforce/cli` installed
- [ ] `sf --version` smoke-test assertion passes
- [ ] AFV-library skills are present in `~/.claude/skills/`
- [ ] All three marketplace plugins are enabled in `settings.json`