### PR TITLE
fix: standardize devcontainer on Podman (fixes broken `podman compose up -d` on macOS)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -177,22 +177,27 @@ GIT_AUTHOR_NAME="Example Name"
 # GWS_TOKEN_CACHE=
 
 # =============================================================================
-# Docker / Podman Socket (DooD) — OPTIONAL
+# Podman Host Socket (DooD) — OPTIONAL
 # =============================================================================
-# Mount the host container runtime socket so Docker CLI inside the container
-# can build images and manage containers on your workstation.
+# Mount the host Podman socket so the Docker CLI inside the container can
+# build images and manage containers on your workstation. The socket is
+# bind-mounted to /var/run/docker.sock inside the container — the canonical
+# path most tooling expects.
 #
-# Docker Desktop / Docker Engine (default — no .env entry needed):
-#   The socket at /var/run/docker.sock is used automatically.
+# devcontainer.sh auto-detects the host socket on both macOS and Linux,
+# so you usually don't need to set this. Only set it to override detection
+# or when running `podman compose` directly without ./devcontainer.sh.
 #
-# Rootless Podman (no sudo required):
-#   Set DOCKER_SOCK to your Podman user socket.
-#   First enable the socket: systemctl --user start podman.socket
-#   Then set DOCKER_SOCK below (replace 1000 with your UID: id -u).
+# macOS (podman machine):
+#   DOCKER_SOCK=$(podman machine inspect --format '{{.ConnectionInfo.PodmanSocket.Path}}')
 #
-# @auto-detect: echo "${XDG_RUNTIME_DIR:-/run/user/$(id -u)}/podman/podman.sock"
-# @requires: rootless Podman with socket enabled (systemctl --user start podman.socket)
-# @check: test -S "${XDG_RUNTIME_DIR:-/run/user/$(id -u)}/podman/podman.sock"
+# Linux (rootless podman, no sudo required):
+#   First enable the user socket: systemctl --user start podman.socket
+#   Then DOCKER_SOCK=/run/user/$(id -u)/podman/podman.sock
+#
+# @auto-detect: ./devcontainer.sh handles this; no manual setting needed
+# @requires: a running podman machine (macOS) or user socket (Linux)
+# @check: test -S "$DOCKER_SOCK"
 
 # DOCKER_SOCK=/run/user/1000/podman/podman.sock
 

--- a/devcontainer.sh
+++ b/devcontainer.sh
@@ -331,8 +331,8 @@ fi
 if [ -z "${DOCKER_SOCK:-}" ]; then
   if [ "$(uname)" = "Darwin" ]; then
     _detected_sock=$(podman machine ssh -- 'echo /run/user/$(id -u)/podman/podman.sock' 2>/dev/null | tr -d '\r' || true)
-    if [ -n "$_detected_sock" ] && \
-       podman machine ssh -- "test -S $_detected_sock" >/dev/null 2>&1; then
+    if [ -n "$_detected_sock" ] &&
+      podman machine ssh -- "test -S $_detected_sock" >/dev/null 2>&1; then
       export DOCKER_SOCK="$_detected_sock"
       ok "Podman socket: $DOCKER_SOCK (in machine VM)"
     else

--- a/devcontainer.sh
+++ b/devcontainer.sh
@@ -323,5 +323,39 @@ if [ ! -f .env ]; then
   warn "No .env file found. Container will start with defaults only."
 fi
 
+# Podman host socket for Docker-outside-of-Docker.
+# On macOS the container runs inside the podman-machine VM, so we use the
+# VM-internal rootless socket path (the Mac-side proxy socket lives on
+# virtiofs, where podman's statfs validation fails). On Linux we use the
+# local rootless socket directly. Override by setting DOCKER_SOCK in .env.
+if [ -z "${DOCKER_SOCK:-}" ]; then
+  if [ "$(uname)" = "Darwin" ]; then
+    _detected_sock=$(podman machine ssh -- 'echo /run/user/$(id -u)/podman/podman.sock' 2>/dev/null | tr -d '\r' || true)
+    if [ -n "$_detected_sock" ] && \
+       podman machine ssh -- "test -S $_detected_sock" >/dev/null 2>&1; then
+      export DOCKER_SOCK="$_detected_sock"
+      ok "Podman socket: $DOCKER_SOCK (in machine VM)"
+    else
+      fail "Podman socket not available in machine VM."
+      info "Start the podman machine: podman machine start"
+      info "Or set DOCKER_SOCK in .env to override detection."
+      fatal "Cannot start container without a host runtime socket."
+    fi
+    unset _detected_sock
+  else
+    _detected_sock="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}/podman/podman.sock"
+    if [ -S "$_detected_sock" ]; then
+      export DOCKER_SOCK="$_detected_sock"
+      ok "Podman socket: $DOCKER_SOCK"
+    else
+      fail "Podman socket not found at: $_detected_sock"
+      info "Start the user socket: systemctl --user start podman.socket"
+      info "Or set DOCKER_SOCK in .env to override detection."
+      fatal "Cannot start container without a host runtime socket."
+    fi
+    unset _detected_sock
+  fi
+fi
+
 echo ""
 exec podman compose up -d "$@"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,9 @@ services:
     cpus: 2
     pids_limit: 4096
     volumes:
-      - ${DOCKER_SOCK:-/var/run/docker.sock}:/var/run/docker.sock
+      # :z relabels the source for shared SELinux access (needed for the
+      # rootless podman socket inside the podman-machine VM).
+      - ${DOCKER_SOCK:-/var/run/docker.sock}:/var/run/docker.sock:z
     tmpfs:
       - /tmp:size=1g
     stdin_open: true
@@ -36,5 +38,15 @@ services:
     init: true
     restart: unless-stopped
     user: vscode
+    # Join the root group so vscode can read/write the bind-mounted host
+    # podman socket, which appears inside the container as root:root 0660.
+    group_add:
+      - "0"
+    security_opt:
+      # Disable SELinux confinement so the container (which gets MCS
+      # categories like s0:c48,c336) can connect to the bind-mounted host
+      # podman socket (labeled s0 with no categories — connect requires
+      # write, and MCS rules forbid writing to a less-categorized object).
+      - label=disable
     entrypoint: ["/usr/local/bin/entrypoint.sh"]
     command: zsh

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -22,11 +22,11 @@ if [ -d /usr/local/rustup ] && [ ! -w /usr/local/rustup ]; then
   echo 'WARNING: /usr/local/rustup is not writable — Rust toolchain updates will fail' >&2
 fi
 
-# Docker-outside-of-Docker: set DOCKER_HOST to the mounted socket.
-# The host socket (Docker or Podman) is always mounted to /var/run/docker.sock
-# inside the container via the DOCKER_SOCK compose variable.
-# Rootless Podman users: set DOCKER_SOCK in .env to their socket path,
-# e.g. DOCKER_SOCK=/run/user/1000/podman/podman.sock  (no sudo needed).
+# Docker-outside-of-Docker: point DOCKER_HOST at the mounted host runtime socket.
+# devcontainer.sh detects the host's Podman socket and bind-mounts it to
+# /var/run/docker.sock inside the container (the canonical path most tooling
+# expects, regardless of whether the host runtime is Podman or Docker).
+# To override, set DOCKER_SOCK in .env before running ./devcontainer.sh.
 if [ -z "$DOCKER_HOST" ]; then
   if [ -S /var/run/docker.sock ]; then
     export DOCKER_HOST="unix:///var/run/docker.sock"


### PR DESCRIPTION
## Summary

Make `./devcontainer.sh` and `podman compose up -d` work end-to-end with rootless Podman on macOS. The repo was already mostly Podman-standard (devcontainer.sh installs and starts `podman machine`, calls `podman compose`), but the compose file defaulted `DOCKER_SOCK` to `/var/run/docker.sock` (Docker Desktop convention) — which broke macOS users on a clean run.

## Related Issue

Closes #1192

## Changes

- **devcontainer.sh** — Auto-detect the host Podman socket before invoking compose. macOS queries the podman-machine VM via `podman machine ssh` (the Mac-side proxy socket is on virtiofs where podman's statfs validation fails, so the VM-internal rootless socket is bind-mounted directly). Linux uses `${XDG_RUNTIME_DIR:-/run/user/$(id -u)}/podman/podman.sock`. Fails fast with a remediation hint when the socket isn't reachable; respects `DOCKER_SOCK` if already set in `.env`.
- **docker-compose.yml** — Three additions so the bind-mounted rootless socket is usable inside the Fedora-CoreOS VM with SELinux enforcing:
  - `:z` on the bind (shared SELinux relabel — without it, `ls` shows `??????`).
  - `group_add: ["0"]` so vscode joins the root group inside the container — the userns-translated socket appears as `root:root 0660`.
  - `security_opt: ["label=disable"]` to bypass MCS isolation on `connect()` (container is at `s0:c48,c336`, socket at `s0`; MCS rules forbid writing to a less-categorized object).
  - Each addition has an inline comment explaining why.
- **entrypoint.sh** — Comment block at lines 25-29 reworded to lead with Podman; drops the rootless-Linux-only socket-path hint (devcontainer.sh handles detection now).
- **.env.example** — Replaced the Docker-Desktop-first `DOCKER_SOCK` section with podman-first guidance covering macOS (`podman machine inspect --format '{{.ConnectionInfo.PodmanSocket.Path}}'`) and Linux rootless. Notes that `./devcontainer.sh` auto-detects, so manually setting it is rarely needed.

## Test Plan

- [x] `./devcontainer.sh` succeeds on macOS+Podman from a clean state (no `.devcontainer-name`, container removed).
- [x] Inside the container: `docker version` connects to the host Podman daemon and returns the server section. `docker ps` lists host containers. `docker run --rm hello-world` pulls and runs a sibling container on the host.
- [x] All of the above with SELinux still `Enforcing` in the VM.
- [x] `./tests/smoke-test.sh` runs to completion (211 passed; 2 unrelated pre-existing failures: `xcsh prompt`, `opencode prompt` — both LiteLLM proxy probes, untouched by this PR).
- [x] `bash -n` and `shellcheck` clean on `devcontainer.sh` and `entrypoint.sh`.
- [ ] Reviewer to verify on Linux rootless Podman (covered by detection branch but not exercised in my test setup).

## Checklist

- [x] Linked to a GitHub issue (required — CI will block merge without it)
- [x] Tested locally
- [x] Follows project conventions