### PR TITLE
docs: ignore .devcontainer-name local state file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,6 +132,7 @@ tsconfig.tsbuildinfo
 .worktrees/
 .codex/
 playground/
+.devcontainer-name
 
 # Documentation build artifacts
 docs/_data/


### PR DESCRIPTION
## Summary

Add `.devcontainer-name` to `.gitignore` under the `# Workspace` section. `devcontainer.sh` writes this file on first run to remember the container name across invocations, so it's strictly local state — different per checkout — and should never be committed.

## Related Issue

Closes #1194

## Changes

- `.gitignore`: add `.devcontainer-name` next to `.worktrees/`, `.codex/`, `playground/` (same category of local-workspace state).

## Test Plan

- [x] `git check-ignore -v .devcontainer-name` confirms the new rule matches (`.gitignore:135:.devcontainer-name	.devcontainer-name`).
- [x] `git status` no longer shows `.devcontainer-name` as untracked after running `./devcontainer.sh`.

## Checklist

- [x] Linked to a GitHub issue (required — CI will block merge without it)
- [x] Tested locally
- [x] Follows project conventions