### PR TITLE
feat: add GitLab Claude Code plugin to container default settings

### DIFF
--- a/claude-config/settings.json
+++ b/claude-config/settings.json
@@ -21,6 +21,7 @@
     "superpowers@claude-plugins-official": true,
     "code-review@claude-plugins-official": true,
     "code-simplifier@claude-plugins-official": true,
+    "gitlab@claude-plugins-official": true,
     "feature-dev@claude-plugins-official": true,
     "ralph-loop@claude-plugins-official": true,
     "typescript-lsp@claude-plugins-official": false,


### PR DESCRIPTION
## Summary

- Enable the official GitLab plugin (`gitlab@claude-plugins-official`) in `claude-config/settings.json` so all devcontainer sessions have GitLab integration available out of the box
- Complements the `glab` CLI added in #1199

Closes #1200

## Test plan

- [ ] CI checks pass
- [ ] Verify `claude-config/settings.json` is valid JSON with the new plugin entry
- [ ] Confirm no other settings are modified