### PR TITLE
feat: auto-authenticate Salesforce CLI from SFDX_AUTH_URL env var

### DIFF
--- a/.devcontainer/scripts/post-start.sh
+++ b/.devcontainer/scripts/post-start.sh
@@ -72,5 +72,15 @@ else
   echo "    Create a token at https://github.com/settings/tokens"
 fi
 
+# Salesforce CLI authentication status
+echo ""
+echo "  Salesforce CLI:"
+if sf org list auth 2>&1 | grep -q "Username"; then
+  sf org list auth 2>&1 | head -5 | sed 's/^/    /'
+else
+  echo "    Not authenticated (SFDX_AUTH_URL not set)"
+  echo "    To enable: add SFDX_AUTH_URL=force://... to .env"
+fi
+
 echo ""
 echo "Ready! Start coding in /workspace"

--- a/.env.example
+++ b/.env.example
@@ -120,6 +120,17 @@ GIT_AUTHOR_NAME="Example Name"
 # GH_TOKEN=ghp_example-token-here
 
 # =============================================================================
+# Salesforce CLI — OPTIONAL (for sf commands)
+# =============================================================================
+# A Salesforce sfdx auth URL for automatic org authentication.
+# The entrypoint runs `sf org login sfdx-url` at startup.
+# @auto-detect: sf org display --verbose --json 2>/dev/null | jq -r '.result.sfdxAuthUrl // empty'
+# @requires: sf CLI authenticated (sf org login web)
+# @check: sf org list auth 2>/dev/null | grep -q Username
+
+# SFDX_AUTH_URL=force://PlatformCLI::YOUR_TOKEN_HERE@instance.my.salesforce.com
+
+# =============================================================================
 # Google CLI Tools — OPTIONAL (gogcli + gws)
 # =============================================================================
 # Shared OAuth client credentials used by both gog (gogcli) and gws

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -69,6 +69,16 @@ if [ -n "$GH_TOKEN" ]; then
   gh auth setup-git 2>/dev/null || true
 fi
 
+# ============================================================
+# Salesforce CLI — authenticate from SFDX auth URL
+# ============================================================
+if [ -n "$SFDX_AUTH_URL" ]; then
+  _sf_tmp="$(mktemp)"
+  echo "$SFDX_AUTH_URL" >"$_sf_tmp"
+  sf org login sfdx-url --sfdx-url-file "$_sf_tmp" --set-default --alias SFDC >/dev/null 2>&1 || true
+  rm -f "$_sf_tmp"
+fi
+
 # Ensure Homebrew npm global directory exists (issue #677)
 mkdir -p "${HOME}/.npm-global/lib" 2>/dev/null || true
 


### PR DESCRIPTION
## Summary

- Add env-var-driven auto-authentication for Salesforce CLI at container startup, following the same pattern used for GitHub CLI (GH_TOKEN) and Google CLIs
- When `SFDX_AUTH_URL` is set in `.env`, the entrypoint writes it to a temp file and runs `sf org login sfdx-url` to authenticate automatically
- Document the new variable in `.env.example` with extraction and verification instructions
- Add Salesforce CLI health check to the post-start status report

Closes #1212

## Test plan

- [ ] CI checks pass
- [ ] Container starts without error when `SFDX_AUTH_URL` is unset (no regression)
- [ ] Container auto-authenticates when `SFDX_AUTH_URL` is set with a valid auth URL
- [ ] Post-start script reports Salesforce auth status correctly in both cases
- [ ] Temp file containing auth URL is deleted after use

🤖 Generated with [Claude Code](https://claude.com/claude-code)