### PR TITLE
chore: sync managed files from governance template

### DIFF
--- a/.github/workflows/enforce-repo-settings.yml
+++ b/.github/workflows/enforce-repo-settings.yml
@@ -9,6 +9,12 @@ on:
     paths:
       - '.github/config/**'
   workflow_dispatch:
+    inputs:
+      source_sha:
+        description: 'Commit SHA of the docs-control push that triggered this run. Forwarded to sync-managed-files for Pages staleness check.'
+        required: false
+        type: string
+        default: ''
 
 permissions:
   contents: read
@@ -20,10 +26,14 @@ concurrency:
 jobs:
   enforce-settings:
     uses: f5xc-salesdemos/docs-control/.github/workflows/enforce-repo-settings.yml@main
+    with:
+      source_sha: ${{ inputs.source_sha || '' }}
     secrets:
       repo-settings-token: ${{ secrets.REPO_SETTINGS_TOKEN }}
 
   sync-files:
     uses: f5xc-salesdemos/docs-control/.github/workflows/sync-managed-files.yml@main
+    with:
+      source_sha: ${{ inputs.source_sha || '' }}
     secrets:
       repo-sync-token: ${{ secrets.REPO_SYNC_TOKEN }}


### PR DESCRIPTION
Closes #1220

Synced managed files from `f5xc-salesdemos/docs-control` canonical source:

- .github/workflows/enforce-repo-settings.yml
- CLAUDE.md
- .editorconfig
- .gitignore
- .pre-commit-config.yaml
- .yamllint.yaml
- .markdownlint.json
- .github/workflows/dependabot-auto-merge.yml
- biome.json
- .jscpd.json
- .textlintrc
- .checkov.yaml
- zizmor.yaml
- .shellcheckrc
- .codespellrc
- .prettierignore
- trivy.yaml
- .ruff.toml
- ruff.toml
- .isort.cfg
- .python-lint
- .mypy.ini
- .claude/governance.json
- .claude/settings.json
- .claude/hooks/protect-managed-files.sh
- .claude/hooks/enforce-git-delegation.sh