### PR TITLE
fix: pin csharp-ls to v0.20.0, last version targeting net9.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -955,7 +955,7 @@ RUN true \
 # 10l-2. C# language server (csharp-ls via dotnet global tool)
 # ============================================================
 # hadolint ignore=DL3059
-RUN dotnet tool install csharp-ls --version 0.24.0 --tool-path /usr/local/bin
+RUN dotnet tool install csharp-ls --version 0.20.0 --tool-path /usr/local/bin
 
 # ============================================================
 # 10l. Zig cross-compilation toolchain (needed by napi-rs


### PR DESCRIPTION
Closes #1226

## Summary

- `csharp-ls v0.21.0+` NuGet packages target `net10.0` — `DotnetToolSettings.xml` lives under `tools/net10.0/any/`
- The Dockerfile installs `dotnet-sdk-9.0`, which looks for `tools/net9.0/any/` — install fails with "Settings file 'DotnetToolSettings.xml' was not found"
- Pin to `v0.20.0`, the last release targeting `net9.0`

## Test plan

- [ ] Docker Publish CI passes on both `linux/amd64` and `linux/arm64`

🤖 Generated with [Claude Code](https://claude.com/claude-code)