### PR TITLE
fix: prevent tar pipefail from killing devcontainer.sh when optional Azure files are missing

### DIFF
--- a/devcontainer.sh
+++ b/devcontainer.sh
@@ -407,7 +407,7 @@ if [ -z "${AZURE_CONFIG_BASE64:-}" ]; then
       export AZURE_CONFIG_BASE64
       AZURE_CONFIG_BASE64=$( (cd "$HOME/.azure" && tar czf - \
         azureProfile.json msal_token_cache.json msal_token_cache.bin \
-        clouds.config service_principal_entries.json az.json 2>/dev/null) | base64)
+        clouds.config service_principal_entries.json az.json 2>/dev/null || true) | base64)
       ok "Azure CLI: authenticated${_az_user:+ ($_az_user)} (auto-detected)"
       unset _az_user
     else


### PR DESCRIPTION
Closes #1240

## Summary

- `tar` exits non-zero when optional files (`msal_token_cache.bin`, `service_principal_entries.json`) don't exist in `~/.azure/`
- With `set -o pipefail`, this propagates through `(tar ...) | base64`
- `set -e` then silently kills the script — no error message, no further auto-detect (Azure, Salesforce, Claude OAuth, Google), no container start
- Fix: add `|| true` after the tar command in the subshell

## Verified

- `./devcontainer.sh` now completes all 10 auto-detect blocks and starts the container
- `sf org list auth` inside the container confirms Salesforce auth works

## Test plan

- [x] `./devcontainer.sh` exits 0 and starts container
- [x] All auto-detect blocks print status (TZ, Git, SSH, GitHub, GitLab, Azure, Salesforce, Podman)
- [x] `sf org list auth` inside container shows authenticated org

🤖 Generated with [Claude Code](https://claude.com/claude-code)