### PR TITLE
fix: replace ambiguous .env.example placeholders with obvious YOUR-...-HERE pattern

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,7 +15,7 @@
 #
 #   1. Check if .env already exists. If yes, read it and enhance in-place —
 #      only update variables that are missing or still have placeholder values
-#      (e.g., "sk-example-api-key-here", "you@example.com", "Example Name").
+#      (e.g., "sk-YOUR-API-KEY-HERE", "you@example.com", "Your Name").
 #      If no .env exists, start with: cp .env.example .env
 #
 #   2. For each @auto-detect marker, run the @check command first. If it
@@ -43,7 +43,7 @@
 #   OAuth mode:   Set CLAUDE_CODE_OAUTH_TOKEN only (see Claude Max section below).
 # @manual: get the shared LiteLLM API key from your proxy administrator
 
-LITELLM_API_KEY=sk-example-api-key-here
+LITELLM_API_KEY=sk-YOUR-API-KEY-HERE
 
 # =============================================================================
 # Claude Max (OAuth) — OPTIONAL (alternative to API key)
@@ -56,7 +56,7 @@ LITELLM_API_KEY=sk-example-api-key-here
 # @check: security find-generic-password -s "Claude Code-credentials" -w 2>/dev/null | python3 -c "import sys,json; json.load(sys.stdin)['claudeAiOauth']['accessToken']"
 # @manual: get a token from Claude Code settings or https://console.anthropic.com/
 
-# CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-example-token-here
+# CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-YOUR-OAUTH-TOKEN-HERE
 
 # =============================================================================
 # LiteLLM Proxy — REQUIRED (for OpenCode and Claude Code proxy mode)
@@ -66,7 +66,7 @@ LITELLM_API_KEY=sk-example-api-key-here
 # Set the domain only — the script appends the required path suffixes.
 # @manual: get the base URL from your proxy administrator
 
-LITELLM_BASE_URL=https://proxy.example.com
+LITELLM_BASE_URL=https://YOUR-LITELLM-PROXY.example.com
 
 # =============================================================================
 # Timezone — OPTIONAL
@@ -88,12 +88,12 @@ LITELLM_BASE_URL=https://proxy.example.com
 # @auto-detect: git config user.email
 # @requires: git with user.email configured
 # @check: git config user.email
-GIT_AUTHOR_EMAIL=you@example.com
+GIT_AUTHOR_EMAIL=YOUR-EMAIL@example.com
 
 # @auto-detect: git config user.name
 # @requires: git with user.name configured
 # @check: git config user.name
-GIT_AUTHOR_NAME="Example Name"
+GIT_AUTHOR_NAME="YOUR NAME"
 
 # =============================================================================
 # SSH Key (optional — for git clone over SSH)
@@ -117,7 +117,7 @@ GIT_AUTHOR_NAME="Example Name"
 # @manual: create a token at https://github.com/settings/tokens
 # Fine-grained tokens (recommended) or classic tokens (requires "repo" scope).
 
-# GH_TOKEN=ghp_example-token-here
+# GH_TOKEN=ghp_YOUR-GITHUB-TOKEN-HERE
 
 # =============================================================================
 # GitLab CLI — OPTIONAL (for glab commands and HTTPS git clone)
@@ -131,7 +131,7 @@ GIT_AUTHOR_NAME="Example Name"
 # @manual: create a token at https://gitlab.com/-/user_settings/personal_access_tokens
 # Required scopes: api, read_user, read_repository, write_repository
 
-# GITLAB_TOKEN=glpat-example-token-here
+# GITLAB_TOKEN=glpat-YOUR-GITLAB-TOKEN-HERE  # gitleaks:allow
 
 # =============================================================================
 # Salesforce CLI — OPTIONAL (for sf commands)
@@ -142,7 +142,7 @@ GIT_AUTHOR_NAME="Example Name"
 # @requires: sf CLI authenticated (sf org login web)
 # @check: sf org list auth 2>/dev/null | grep -q Username
 
-# SFDX_AUTH_URL=force://PlatformCLI::YOUR_TOKEN_HERE@instance.my.salesforce.com
+# SFDX_AUTH_URL=force://PlatformCLI::YOUR-SFDX-TOKEN-HERE@YOUR-INSTANCE.my.salesforce.com
 
 # =============================================================================
 # Azure CLI — OPTIONAL (for az commands)
@@ -177,7 +177,7 @@ GIT_AUTHOR_NAME="Example Name"
 # @requires: gog CLI installed and authenticated (gog auth add)
 # @check: gog auth list --plain 2>/dev/null | head -1
 
-# GOG_ACCOUNT=you@gmail.com
+# GOG_ACCOUNT=YOUR-EMAIL@gmail.com
 
 # @auto-detect: base64 < "$(gog auth status --plain 2>/dev/null | grep credentials_path | cut -f2)"
 # @requires: gog CLI with stored credentials
@@ -268,4 +268,4 @@ GIT_AUTHOR_NAME="Example Name"
 
 # ENABLE_TAILSCALE=true
 # @manual: generate at https://login.tailscale.com/admin/settings/keys
-# TAILSCALE_AUTHKEY=tskey-auth-example-key-here
+# TAILSCALE_AUTHKEY=tskey-auth-YOUR-TAILSCALE-KEY-HERE


### PR DESCRIPTION
## Summary

- Replaced all `.env.example` placeholder values with uppercase `YOUR-...-HERE` pattern so users immediately recognize they must supply their own values
- Added `gitleaks:allow` inline comment on the `GITLAB_TOKEN` placeholder to prevent false positive secret detection

Closes #1246

## Test plan

- [x] Pre-commit hooks pass (including gitleaks secrets detection)
- [ ] CI checks pass
- [ ] Verify no gitleaks false positives on the GITLAB_TOKEN placeholder