### PR TITLE
feat: add subagent statusline for Claude Code agent activity indicators

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1660,6 +1660,7 @@ USER root
 # --- System-wide scripts and managed policy ---
 COPY claude-config/self-test.sh \
      claude-config/statusline.sh \
+     claude-config/subagent-statusline.sh \
      claude-config/api-key-helper.sh \
      claude-config/install-plugins.sh \
      claude-config/neutralize-hooks.sh \
@@ -1669,7 +1670,8 @@ COPY claude-config/chrome-browser.sh /usr/local/lib/chrome-browser.sh
 COPY .devcontainer/scripts/post-start.sh scripts/nightly-update.sh /opt/devcontainer/
 RUN chmod +x /opt/claude-config/self-test.sh \
       /usr/local/lib/chrome-browser.sh \
-      /opt/claude-config/statusline.sh /opt/claude-config/api-key-helper.sh \
+      /opt/claude-config/statusline.sh /opt/claude-config/subagent-statusline.sh \
+      /opt/claude-config/api-key-helper.sh \
       /opt/claude-config/install-plugins.sh \
       /opt/claude-config/neutralize-hooks.sh \
       /opt/devcontainer/post-start.sh \

--- a/claude-config/settings.json
+++ b/claude-config/settings.json
@@ -3,6 +3,10 @@
     "type": "command",
     "command": "/opt/claude-config/statusline.sh"
   },
+  "subagentStatusLine": {
+    "type": "command",
+    "command": "/opt/claude-config/subagent-statusline.sh"
+  },
   "model": "opus",
   "spinnerTipsEnabled": false,
   "terminalProgressBarEnabled": false,

--- a/claude-config/subagent-statusline.sh
+++ b/claude-config/subagent-statusline.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+input=$(cat)
+
+CYAN='\033[96m'
+GREEN='\033[32m'
+YELLOW='\033[33m'
+DIM='\033[2m'
+RESET='\033[0m'
+
+TASKS=$(echo "$input" | jq -r '.tasks // [] | length')
+[ "$TASKS" -eq 0 ] && exit 0
+
+RUNNING=$(echo "$input" | jq -r '[.tasks[] | select(.status == "running")] | length')
+PENDING=$(echo "$input" | jq -r '[.tasks[] | select(.status == "pending")] | length')
+DONE=$(echo "$input" | jq -r '[.tasks[] | select(.status == "completed" or .status == "done")] | length')
+
+NAMES=$(echo "$input" | jq -r '[.tasks[] | select(.status == "running") | .name // .label // .description // "agent"] | join(", ")')
+
+PARTS=""
+[ "$RUNNING" -gt 0 ] && PARTS="${CYAN}${RUNNING} running${RESET}"
+[ "$PENDING" -gt 0 ] && PARTS="${PARTS:+${PARTS} }${YELLOW}${PENDING} queued${RESET}"
+[ "$DONE" -gt 0 ] && PARTS="${PARTS:+${PARTS} }${GREEN}${DONE} done${RESET}"
+
+if [ -n "$NAMES" ] && [ "$NAMES" != "null" ]; then
+  echo -e "${DIM}agents:${RESET} ${PARTS} ${DIM}[${NAMES}]${RESET}"
+else
+  echo -e "${DIM}agents:${RESET} ${PARTS}"
+fi


### PR DESCRIPTION
## Summary

- Add `subagentStatusLine` command to show running/queued/done agent counts with color-coded indicators and agent names when subagents are active
- The script outputs nothing when no agents are running, keeping the statusline clean
- Wire the new script into the container image via Dockerfile COPY and chmod

Closes #1250

## Test plan

- [ ] CI checks pass (Lint Code Base, Check linked issues)
- [ ] Verify script outputs nothing when given empty/zero tasks JSON
- [ ] Verify script shows correct counts and names for active agents
- [ ] Verify Dockerfile builds successfully with the new script