### PR TITLE
fix: update dalfox download URL for versioned release naming

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -810,9 +810,11 @@ RUN true \
         zip-bin feroxbuster; \
     fi \
     # --- XSS scanner ---
+    && if [ "$DPKG_ARCH" = "amd64" ]; then DALFOX_ARCH="x86_64"; else DALFOX_ARCH="aarch64"; fi \
+    && DALFOX_VERSION=$(ghlatest hahwul/dalfox) \
     && install-release dalfox \
-        "https://github.com/hahwul/dalfox/releases/latest/download/dalfox-linux-${DPKG_ARCH}.tar.gz" \
-        tgz-bin dalfox "dalfox-linux-${DPKG_ARCH}" \
+        "https://github.com/hahwul/dalfox/releases/download/v${DALFOX_VERSION}/dalfox-v${DALFOX_VERSION}-linux-${DALFOX_ARCH}.tar.gz" \
+        tgz-bin dalfox \
     # --- Domain & URL enumeration ---
     && install-release amass \
         "https://github.com/owasp-amass/amass/releases/latest/download/amass_linux_${DPKG_ARCH}.tar.gz" \


### PR DESCRIPTION
## Summary
dalfox v3.x changed their release asset naming convention:
- Old: `dalfox-linux-arm64.tar.gz` (latest redirect)
- New: `dalfox-v3.1.0-linux-aarch64.tar.gz` (versioned + different arch name)

This caused a 404 on every Docker build for 10+ days. Fix uses `ghlatest` to resolve the version and maps `arm64`→`aarch64`, `amd64`→`x86_64`.

Closes #1394

🤖 Generated with [Claude Code](https://claude.com/claude-code)