### PR TITLE
chore: sync managed files from governance template

### DIFF
--- a/.claude/governance.json
+++ b/.claude/governance.json
@@ -61,6 +61,8 @@
     ".python-lint",
     ".mypy.ini",
     "scripts/locale-lint.sh",
+    "scripts/check-repo-hygiene.sh",
+    "tests/test-check-repo-hygiene.sh",
     "trivy.yaml",
     ".claude/settings.json",
     ".claude/governance.json",

--- a/.gitignore
+++ b/.gitignore
@@ -203,3 +203,7 @@ pi-*.html
 packages/coding-agent/src/internal-urls/docs-index.generated.ts
 packages/coding-agent/src/internal-urls/build-info.generated.ts
 packages/typescript-edit-benchmark/runs/
+
+# Verified-review working artifacts (findings and verification evidence).
+# No trailing slash, so a symlink of this name is matched too.
+.codex-review

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,6 +39,23 @@ repos:
         pass_filenames: false
 
   # ===========================================================================
+  # Repository hygiene — rejects tracked symlinks with absolute targets and
+  # hardcoded home directories. A `.gitignore` pattern ending in `/` matches
+  # only directories, so a symlink of an ignored name is still staged.
+  # ===========================================================================
+  - repo: local
+    hooks:
+      - id: check-repo-hygiene
+        name: Repository hygiene
+        entry: >-
+          bash -c
+          'if [ -f scripts/check-repo-hygiene.sh ];
+          then bash scripts/check-repo-hygiene.sh; fi'
+        language: system
+        always_run: true
+        pass_filenames: false
+
+  # ===========================================================================
   # File size guard
   # ===========================================================================
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -218,6 +235,7 @@ ci:
   # They run locally and in GitHub Actions CI where tools are pre-installed.
   skip:
     - local-hooks
+    - check-repo-hygiene
     - yamllint
     - markdownlint
     - shellcheck

--- a/scripts/check-repo-hygiene.sh
+++ b/scripts/check-repo-hygiene.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+# Rejects two classes of committed content that break on any machine but the one
+# that produced them:
+#
+#   1. Tracked symlinks with an absolute target. A clone lands a dangling link,
+#      and tooling that follows it fails in ways that look unrelated to the cause.
+#   2. A user's home directory hardcoded in a tracked file.
+#
+# Both slip past the usual gates: `.gitignore` patterns ending in `/` match only
+# directories, so a symlink of an ignored name is still staged, and CI often
+# masks a dangling link by creating the real thing (npm ci, pip install).
+#
+# The symlink check runs by default. The home-directory scan is opt-in via
+# --include-paths, because measuring it across all 38 governed repositories flagged
+# 10 of them and only 2 findings were real: the rest were API routes (/Users/1),
+# URL paths (/home/index), shell variables (/home/${USERNAME}), placeholder names,
+# and upstream-generated specification examples. A gate that is ~80% false positives
+# gets switched off, which is worse than not having it.
+#
+# Run from any repo root:
+#   bash scripts/check-repo-hygiene.sh                  # symlinks only (the gate)
+#   bash scripts/check-repo-hygiene.sh --include-paths   # also scan for home dirs
+# Exit 0 = clean, Exit 1 = violations found.
+#
+# To allow a deliberate example path, put `repo-hygiene:allow` on the same line.
+set -euo pipefail
+
+VIOLATIONS=0
+INCLUDE_PATHS=0
+
+for arg in "$@"; do
+  case "$arg" in
+  --include-paths) INCLUDE_PATHS=1 ;;
+  -h | --help)
+    sed -n '2,20p' "$0"
+    exit 0
+    ;;
+  *)
+    echo "::error::unknown argument: ${arg}" >&2
+    exit 1
+    ;;
+  esac
+done
+
+# Placeholder user names are portable documentation, not a machine-specific path.
+PLACEHOLDERS='you|user|users|username|userid|your-user|your_username|me|example|alice|bob|USERNAME|<user>|<username>|<you>|<your-user>|\.\.\.'
+
+# Any path built from a variable is portable by construction.
+VARIABLE_FORMS='^\$|^\{|\$\{|^%[A-Za-z_]+%$'
+
+# Home directories owned by a CI runner are the same on every machine.
+CI_USERS='runner|circleci|travis|vsts|ubuntu|node|jenkins|gitpod|vscode'
+
+if ! git rev-parse --git-dir >/dev/null 2>&1; then
+  echo "::error::not a git repository — cannot inspect tracked files"
+  exit 1
+fi
+
+# Absolute targets, and relative targets that climb out of the repository, both
+# break on a fresh clone. Resolved lexically: no filesystem access, so a dangling
+# link is judged the same as a live one.
+symlink_escapes() {
+  local link_path="$1" target="$2" dir depth=0 segment
+  case "$target" in
+  /* | [A-Za-z]:[\\/]* | \\\\*) return 0 ;;
+  esac
+  dir=$(dirname "$link_path")
+  [ "$dir" = "." ] && dir=""
+  if [ -n "$dir" ]; then
+    local IFS=/
+    for segment in $dir; do
+      [ -n "$segment" ] && depth=$((depth + 1))
+    done
+  fi
+  local IFS=/
+  for segment in $target; do
+    case "$segment" in
+    "" | .) ;;
+    ..)
+      depth=$((depth - 1))
+      [ "$depth" -lt 0 ] && return 0
+      ;;
+    *) depth=$((depth + 1)) ;;
+    esac
+  done
+  return 1
+}
+
+# ---------------------------------------------------------------------------
+# 1. Tracked symlinks with an absolute target (git mode 120000; the blob's
+#    contents are the link target).
+#
+#    `git ls-files -s -z` emits "<mode> <sha> <stage>\t<path>\0", so the path is
+#    everything after the first tab and survives spaces verbatim. Splitting on
+#    whitespace instead would corrupt such a path, and the lookup would then fail
+#    silently — reporting a real violation as clean.
+# ---------------------------------------------------------------------------
+while IFS= read -r -d '' entry; do
+  [ -n "$entry" ] || continue
+  case "$entry" in 120000\ *) ;; *) continue ;; esac
+  path=${entry#*$'\t'}
+  if ! target=$(git cat-file blob ":${path}" 2>/dev/null); then
+    # Fail closed: a symlink we cannot read is not a symlink we can clear.
+    echo "::error file=${path}::tracked symlink could not be read — cannot verify its target"
+    VIOLATIONS=$((VIOLATIONS + 1))
+    continue
+  fi
+  if symlink_escapes "$path" "$target"; then
+    echo "::error file=${path}::tracked symlink points outside the repository: ${target}"
+    echo "  A clone lands a dangling link here. Remove it (git rm --cached '${path}') and"
+    echo "  ignore it with a pattern that has no trailing slash, so a symlink is matched too."
+    VIOLATIONS=$((VIOLATIONS + 1))
+  fi
+done < <(git ls-files -s -z)
+
+# ---------------------------------------------------------------------------
+# 2. Home directories hardcoded in tracked files.
+#
+#    Each matched path is judged on its own. Judging a whole line would let an
+#    allowed path launder a real one beside it, e.g.
+#    "PATH=/home/runner/bin:/home/alice/bin".
+# ---------------------------------------------------------------------------
+CANDIDATE='(/Users/|/home/|[A-Za-z]:\\+Users\\+|\\\\+[A-Za-z0-9._-]+\\+Users\\+)[A-Za-z0-9._${}<>-]+'
+
+path_is_allowed() {
+  local candidate="$1" user
+  user=${candidate##*/}
+  user=${user##*\\}
+  # A purely numeric segment is an identifier in a URL or API path, not a person.
+  case "$user" in
+  '' | *[!0-9]*) ;;
+  *) return 0 ;;
+  esac
+  # A path built from a variable is portable by construction.
+  if printf '%s' "$user" | grep -qE "$VARIABLE_FORMS"; then
+    return 0
+  fi
+  printf '%s' "$user" | grep -qE "^(${PLACEHOLDERS}|${CI_USERS})$"
+}
+
+if [ "$INCLUDE_PATHS" -eq 1 ]; then
+  while IFS= read -r hit; do
+    [ -n "$hit" ] || continue
+    file=${hit%%:*}
+    rest=${hit#*:}
+    line=${rest%%:*}
+    text=${rest#*:}
+    case "$text" in *repo-hygiene:allow*) continue ;; esac
+
+    while IFS= read -r candidate; do
+      [ -n "$candidate" ] || continue
+      if path_is_allowed "$candidate"; then
+        continue
+      fi
+      echo "::error file=${file},line=${line}::hardcoded home directory in a tracked file: ${candidate}"
+      echo "  ${text}"
+      echo "  Use a relative path, an environment variable, or a placeholder such as /Users/you/."
+      echo "  If the literal path is intentional, add repo-hygiene:allow to that line."
+      VIOLATIONS=$((VIOLATIONS + 1))
+    done < <(printf '%s' "$text" | grep -oE "$CANDIDATE" || true)
+  done < <(
+    # --cached searches the index, so the working tree is never read: a symlink is
+    # matched on its own target text rather than dereferenced, and a dangling link
+    # cannot make the scan fail open. Pathspec exclusions keep this script and its
+    # test — which necessarily contain the patterns — out of the results.
+    git grep --cached --no-color -nIE -e "$CANDIDATE" -- \
+      ':!scripts/check-repo-hygiene.sh' \
+      ':!tests/test-check-repo-hygiene.sh' ||
+      true
+  )
+fi
+
+if [ "$VIOLATIONS" -gt 0 ]; then
+  echo "::error::repo hygiene: ${VIOLATIONS} violation(s) found."
+  exit 1
+fi
+
+if [ "$INCLUDE_PATHS" -eq 1 ]; then
+  echo "repo hygiene: clean (no escaping symlinks, no hardcoded home directories)."
+else
+  echo "repo hygiene: clean (no escaping symlinks)."
+fi

--- a/tests/test-check-repo-hygiene.sh
+++ b/tests/test-check-repo-hygiene.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+# Hermetic test for scripts/check-repo-hygiene.sh — the guard that rejects
+# committed content which only works on the machine that produced it.
+# Builds throwaway repositories, so it never inspects the repository it lives in.
+# No network.
+set -euo pipefail
+
+REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
+SCRIPT="${REPO_ROOT}/scripts/check-repo-hygiene.sh"
+
+FAIL=0
+WORK=$(mktemp -d)
+cleanup() { rm -rf "$WORK"; }
+trap cleanup EXIT
+
+new_repo() {
+  local dir="${WORK}/$1"
+  mkdir -p "$dir"
+  git -C "$dir" init -q -b main
+  git -C "$dir" config user.email hygiene@test
+  git -C "$dir" config user.name "Hygiene Test"
+  printf 'ok\n' >"${dir}/README.md"
+  git -C "$dir" add -A
+  git -C "$dir" commit -qm baseline
+  echo "$dir"
+}
+
+_run() {
+  local rc=0 dir="$1"
+  shift
+  (cd "$dir" && bash "$SCRIPT" "$@") >/dev/null 2>&1 || rc=$?
+  echo "$rc"
+}
+
+assert_clean() {
+  local label="$1" dir="$2"
+  shift 2
+  local rc
+  rc=$(_run "$dir" "$@")
+  if [ "$rc" -eq 0 ]; then echo "[OK] $label -> clean"; else
+    echo "[FAIL] $label — expected clean (0), got $rc"
+    FAIL=1
+  fi
+}
+
+assert_violation() {
+  local label="$1" dir="$2"
+  shift 2
+  local rc
+  rc=$(_run "$dir" "$@")
+  if [ "$rc" -eq 1 ]; then echo "[OK] $label -> rejected"; else
+    echo "[FAIL] $label — expected rejection (1), got $rc"
+    FAIL=1
+  fi
+}
+
+# --- a clean repository passes -------------------------------------------------
+repo=$(new_repo clean)
+assert_clean "baseline repository" "$repo"
+
+# --- the defect this check exists for: an absolute symlink named node_modules ---
+repo=$(new_repo abs-symlink)
+ln -s /some/other/checkout/node_modules "${repo}/node_modules"
+git -C "$repo" add -A --force
+assert_violation "tracked symlink with an absolute target" "$repo"
+
+# --- relative in-repo symlinks are legitimate and must not be flagged ----------
+# Note the target is resolved relative to the LINK's directory: `../docs/shared.md`
+# from a link at the repository root would resolve above the root, which is why the
+# root-level link below has no leading `../`.
+repo=$(new_repo rel-symlink)
+mkdir -p "${repo}/docs"
+printf 'shared\n' >"${repo}/docs/shared.md"
+ln -s docs/shared.md "${repo}/link.md"
+git -C "$repo" add -A
+assert_clean "relative symlink inside the repository" "$repo"
+
+repo=$(new_repo rel-symlink-updir)
+mkdir -p "${repo}/docs"
+printf 'shared\n' >"${repo}/shared.md"
+ln -s ../shared.md "${repo}/docs/link.md"
+git -C "$repo" add -A
+assert_clean "relative symlink using ../ that stays inside the repository" "$repo"
+
+# --- hardcoded home directories ------------------------------------------------
+repo=$(new_repo home-macos)
+printf 'cache=/Users/rmordasiewicz/.cache/thing\n' >"${repo}/config.ini"
+git -C "$repo" add -A
+assert_violation "hardcoded /Users/<name>/ path" "$repo" --include-paths
+
+repo=$(new_repo home-linux)
+printf 'export DATA=/home/rmordasiewicz/data\n' >"${repo}/env.sh"
+git -C "$repo" add -A
+assert_violation "hardcoded /home/<name>/ path" "$repo" --include-paths
+
+repo=$(new_repo home-windows)
+printf 'path=C:\\Users\\rmordasiewicz\\AppData\n' >"${repo}/win.ini"
+git -C "$repo" add -A
+assert_violation "hardcoded C:\\Users\\<name>\\ path" "$repo" --include-paths
+
+# --- placeholders are portable documentation, not violations -------------------
+repo=$(new_repo placeholder)
+printf 'Put the token in /Users/you/.config/token and /home/username/.netrc\n' >"${repo}/README.md"
+git -C "$repo" add -A
+assert_clean "placeholder home paths in documentation" "$repo" --include-paths
+
+# --- CI home directories are not machine-specific ------------------------------
+repo=$(new_repo ci-home)
+printf 'workspace: /home/runner/work/repo/repo\n' >"${repo}/ci.yml"
+git -C "$repo" add -A
+assert_clean "CI runner home directory" "$repo" --include-paths
+
+# --- the explicit escape hatch -------------------------------------------------
+repo=$(new_repo allow-marker)
+printf 'example=/Users/rmordasiewicz/thing  # repo-hygiene:allow\n' >"${repo}/notes.md"
+git -C "$repo" add -A
+assert_clean "line carrying repo-hygiene:allow" "$repo" --include-paths
+
+# --- untracked files are out of scope: the check gates what is committed -------
+repo=$(new_repo untracked)
+printf 'cache=/Users/rmordasiewicz/.cache\n' >"${repo}/scratch.txt"
+assert_clean "untracked file with a home path" "$repo" --include-paths
+
+# --- binary files must not produce noise ---------------------------------------
+repo=$(new_repo binary)
+printf '\x00\x01/Users/rmordasiewicz/x\x00' >"${repo}/blob.bin"
+git -C "$repo" add -A
+assert_clean "binary file is skipped" "$repo" --include-paths
+
+# --- an exact home directory, with no trailing slash ---------------------------
+repo=$(new_repo home-exact)
+printf 'HOME=/home/rmordasiewicz\n' >"${repo}/env.sh"
+git -C "$repo" add -A
+assert_violation "hardcoded /home/<name> with no trailing slash" "$repo" --include-paths
+
+repo=$(new_repo home-exact-macos)
+printf 'root=/Users/rmordasiewicz\n' >"${repo}/conf.ini"
+git -C "$repo" add -A
+assert_violation "hardcoded /Users/<name> with no trailing slash" "$repo" --include-paths
+
+# --- an allowed path must not launder a real one on the same line --------------
+repo=$(new_repo mixed-ci)
+printf 'PATH=/home/runner/bin:/home/rmordasiewicz/bin\n' >"${repo}/paths.sh"
+git -C "$repo" add -A
+assert_violation "real home alongside a CI home on one line" "$repo" --include-paths
+
+repo=$(new_repo mixed-placeholder)
+printf 'see /Users/you/notes and /Users/rmordasiewicz/notes\n' >"${repo}/README.md"
+git -C "$repo" add -A
+assert_violation "real home alongside a placeholder on one line" "$repo" --include-paths
+
+# --- a pathname containing spaces must not evade the symlink guard -------------
+repo=$(new_repo spaced-symlink)
+ln -s /some/other/checkout/x "${repo}/bad  link"
+git -C "$repo" add -A --force
+assert_violation "absolute symlink whose name contains repeated spaces" "$repo"
+
+# --- an option-like filename must not be handed to grep as an option -----------
+repo=$(new_repo dash-filename)
+printf 'cache=/Users/rmordasiewicz/.cache\n' >"${repo}/real.ini"
+printf 'placeholder\n' >"${repo}/-q"
+git -C "$repo" add -A
+assert_violation "home path still found when a file is named -q" "$repo" --include-paths
+
+# --- backslash-escaped Windows paths, as they appear inside JSON ----------------
+repo=$(new_repo json-windows)
+printf '{"path": "C:\\\\Users\\\\rmordasiewicz\\\\data"}\n' >"${repo}/settings.json"
+git -C "$repo" add -A
+assert_violation "JSON-escaped C:\\\\Users\\\\<name> path" "$repo" --include-paths
+
+# --- a relative symlink that escapes the repository ----------------------------
+repo=$(new_repo escaping-symlink)
+ln -s ../../home/rmordasiewicz/project "${repo}/outside"
+git -C "$repo" add -A --force
+assert_violation "relative symlink whose target escapes the repository" "$repo"
+
+# --- a dangling symlink must not silently disable the content scan -------------
+repo=$(new_repo dangling-symlink)
+printf 'cache=/Users/rmordasiewicz/.cache\n' >"${repo}/real.ini"
+ln -s ./nowhere-at-all "${repo}/dangling"
+git -C "$repo" add -A --force
+assert_violation "home path still found alongside a dangling symlink" "$repo" --include-paths
+
+# --- Windows profiles outside C: ------------------------------------------------
+repo=$(new_repo windows-other-drive)
+printf 'path=D:\\Users\\rmordasiewicz\\data\n' >"${repo}/d.ini"
+git -C "$repo" add -A
+assert_violation "hardcoded D:\\Users\\<name> path" "$repo" --include-paths
+
+# --- the home-directory scan is opt-in ------------------------------------------
+repo=$(new_repo opt-in)
+printf 'cache=/Users/rmordasiewicz/.cache\n' >"${repo}/config.ini"
+git -C "$repo" add -A
+assert_clean "home paths are ignored without --include-paths" "$repo"
+assert_violation "home paths are reported with --include-paths" "$repo" --include-paths
+
+# --- forms measured across the fleet that must NOT be flagged ------------------
+repo=$(new_repo fleet-false-positives)
+# A URL route such as /home/index is NOT covered: it is indistinguishable from a
+# home directory belonging to a user called "index". That is a documented limit of
+# the opt-in scan, which is why it is opt-in.
+{
+  printf 'ENV HOME=/home/${USERNAME}\n'
+  printf 'curl http://api/Users/1 http://api/Users/2\n'
+  printf 'see /Users/<you>/notes and /Users/userid/example\n'
+  printf 'win=%%USERPROFILE%%\n'
+} >"${repo}/mixed.txt"
+git -C "$repo" add -A
+assert_clean "variables, URL routes, numeric ids and placeholders" "$repo" --include-paths
+
+if [ "$FAIL" -ne 0 ]; then
+  echo "check-repo-hygiene tests FAILED"
+  exit 1
+fi
+echo "check-repo-hygiene tests passed"


### PR DESCRIPTION
Closes #1549

Synced managed files from `f5-sales-demo/docs-control` canonical source:

- .gitignore
- .pre-commit-config.yaml
- scripts/check-repo-hygiene.sh
- tests/test-check-repo-hygiene.sh
- .claude/governance.json