### PR TITLE
fix(ci): scope GHCR write to the jobs that publish

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -26,9 +26,11 @@ on:
     - cron: "0 5 * * *"
   workflow_dispatch:
 
+# Least privilege by default. `packages: write` is granted only on the two jobs that
+# actually publish to GHCR (`build` pushes per-arch images by digest, `merge` pushes the
+# multi-arch manifest). `smoke-test` only pulls, so it gets `packages: read`.
 permissions:
   contents: read
-  packages: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -41,6 +43,10 @@ jobs:
   # ── Main image: build each arch natively in parallel ──
   build:
     runs-on: ${{ matrix.runner }}
+    # Pushes per-arch images to GHCR by digest.
+    permissions:
+      contents: read
+      packages: write
     strategy:
       fail-fast: false
       matrix:
@@ -88,10 +94,12 @@ jobs:
           outputs: type=image,push-by-digest=true,name-canonical=true,push=true
 
       - name: Export digest
+        env:
+          RUNNER_TEMP_DIR: ${{ runner.temp }}
+          BUILD_DIGEST: ${{ steps.build.outputs.digest }}
         run: |
-          mkdir -p ${{ runner.temp }}/digests
-          digest="${{ steps.build.outputs.digest }}"
-          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+          mkdir -p "${RUNNER_TEMP_DIR}/digests"
+          touch "${RUNNER_TEMP_DIR}/digests/${BUILD_DIGEST#sha256:}"
 
       - name: Upload digest
         uses: actions/upload-artifact@v7
@@ -105,6 +113,10 @@ jobs:
   merge:
     runs-on: ubuntu-latest
     needs: build
+    # Pushes the multi-arch manifest to GHCR.
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Download digests
         uses: actions/download-artifact@v8
@@ -146,6 +158,10 @@ jobs:
   smoke-test:
     runs-on: ubuntu-24.04-arm
     needs: merge
+    # Only pulls the published image; no write scope needed.
+    permissions:
+      contents: read
+      packages: read
     steps:
       - name: Checkout
         uses: actions/checkout@v7


### PR DESCRIPTION
## Problem

The scheduled Workflow Security Audit (docs-control#775) fails on this repo:

```
error[excessive-permissions] @ .github/workflows/docker-publish.yml:31:3   packages: write
info[template-injection]     @ .github/workflows/docker-publish.yml:93:23  steps.build.outputs.digest
```

## Change

**Permissions** — the workflow granted `packages: write` to all three jobs; only two
publish. `build` (pushes per-arch images by digest) and `merge` (pushes the multi-arch
manifest) keep it. `smoke-test` only logs in and `docker pull`s the published image, so it
drops to `packages: read`. Workflow default is now `contents: read`.

**Template injection** — the digest-export step takes `runner.temp` and
`steps.build.outputs.digest` through `env:` instead of interpolating them into the `run:`
body. Both are workflow-internal rather than attacker-controlled, so this is
defence-in-depth, not a live vector — but the gate requires it (see below), and binding
them also fixed a genuine latent bug: `mkdir -p ${{ runner.temp }}/digests` was unquoted,
so a runner temp path containing a space would have split into two arguments.

## Verification

Run with zizmor **1.25.2**, the version super-linter pins.

| | exit | findings |
|---|---|---|
| before | 14 | 1 high, 1 informational |
| after | **0** | **none, any severity** |

`actionlint` clean.

Why the informational one had to be fixed rather than ignored: super-linter fails the job
on zizmor's non-zero exit, and zizmor exits non-zero for findings of *any* severity. It
also lints only the files a PR changes — so touching this file surfaces every pre-existing
finding in it, informational included. A local run at `--min-severity medium` looks clean
and still fails CI.

This is a publish path. The reasoning is that `build` and `merge` retain exactly the scope
they had, so pushes should be unaffected — but that is worth confirming by checking the
next run actually publishes an image, rather than trusting a green check.

Closes #1548
