### PR TITLE
chore: remove review plugins from image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1370,14 +1370,10 @@ RUN PLUGIN_BASE="/home/${USERNAME}/.claude/plugins" \
     && retry git clone --depth=1 --single-branch --branch main \
         https://github.com/f5-sales-demo/marketplace.git \
         "${PLUGIN_BASE}/marketplaces/f5-sales-demo-marketplace" \
-    && retry git clone --depth=1 --single-branch --branch main \
-        https://github.com/f5-sales-demo/codex-plugin-cc.git \
-        "${PLUGIN_BASE}/marketplaces/openai-codex" \
     && TS="$(date -u +%Y-%m-%dT%H:%M:%S.000Z)" \
-    && printf '{"claude-plugins-official":{"source":{"source":"github","repo":"anthropics/claude-plugins-official"},"installLocation":"%s","lastUpdated":"%s","autoUpdate":true},"f5-sales-demo-marketplace":{"source":{"source":"github","repo":"f5-sales-demo/marketplace"},"installLocation":"%s","lastUpdated":"%s","autoUpdate":true},"openai-codex":{"source":{"source":"github","repo":"f5-sales-demo/codex-plugin-cc"},"installLocation":"%s","lastUpdated":"%s","autoUpdate":false}}' \
+    && printf '{"claude-plugins-official":{"source":{"source":"github","repo":"anthropics/claude-plugins-official"},"installLocation":"%s","lastUpdated":"%s","autoUpdate":true},"f5-sales-demo-marketplace":{"source":{"source":"github","repo":"f5-sales-demo/marketplace"},"installLocation":"%s","lastUpdated":"%s","autoUpdate":true}}' \
         "${PLUGIN_BASE}/marketplaces/claude-plugins-official" "$TS" \
         "${PLUGIN_BASE}/marketplaces/f5-sales-demo-marketplace" "$TS" \
-        "${PLUGIN_BASE}/marketplaces/openai-codex" "$TS" \
         > "${PLUGIN_BASE}/known_marketplaces.json" \
     && printf '{"fetchedAt":"%s","plugins":[]}' "$TS" \
         > "${PLUGIN_BASE}/blocklist.json" \

--- a/claude-config/self-test.sh
+++ b/claude-config/self-test.sh
@@ -217,6 +217,16 @@ check "f5xc marketplace.json in cache" \
   test -f "$HOME/.claude/plugins/marketplaces/f5-sales-demo-marketplace/.claude-plugin/marketplace.json"
 check "known_marketplaces.json exists" \
   test -f "$HOME/.claude/plugins/known_marketplaces.json"
+check "deprecated review plugins are not enabled" \
+  jq -e '
+    .enabledPlugins["code-review@claude-plugins-official"] == null and
+    .enabledPlugins["pr-review-toolkit@claude-plugins-official"] == null and
+    .enabledPlugins["codex@openai-codex"] == null
+  ' "$HOME/.claude/settings.json"
+check "deprecated Codex marketplace is absent" \
+  jq -e '.["openai-codex"] == null' "$HOME/.claude/plugins/known_marketplaces.json"
+check "no configured Claude stop gate" \
+  jq -e '(.hooks.Stop // []) | length == 0' "$HOME/.claude/settings.json"
 check "installed_plugins.json exists" \
   test -f "$HOME/.claude/plugins/installed_plugins.json"
 check "official plugin cache populated" \

--- a/claude-config/settings.json
+++ b/claude-config/settings.json
@@ -23,7 +23,6 @@
   "enabledPlugins": {
     "frontend-design@claude-plugins-official": true,
     "superpowers@claude-plugins-official": true,
-    "code-review@claude-plugins-official": true,
     "code-simplifier@claude-plugins-official": true,
     "gitlab@claude-plugins-official": true,
     "feature-dev@claude-plugins-official": true,
@@ -50,7 +49,6 @@
     "php-lsp@claude-plugins-official": true,
     "security-guidance@claude-plugins-official": true,
     "claude-md-management@claude-plugins-official": true,
-    "pr-review-toolkit@claude-plugins-official": true,
     "skill-creator@claude-plugins-official": true,
     "claude-code-setup@claude-plugins-official": true,
     "hookify@claude-plugins-official": true,
@@ -65,16 +63,7 @@
     "f5xc-meddpicc@f5-sales-demo-marketplace": true,
     "f5xc-firecrawl@f5-sales-demo-marketplace": true,
     "osint-framework@f5-sales-demo-marketplace": true,
-    "salesforce@f5-sales-demo-marketplace": true,
-    "codex@openai-codex": true
-  },
-  "extraKnownMarketplaces": {
-    "openai-codex": {
-      "source": {
-        "source": "github",
-        "repo": "f5-sales-demo/codex-plugin-cc"
-      }
-    }
+    "salesforce@f5-sales-demo-marketplace": true
   },
   "env": {
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",

--- a/tests/smoke-test.sh
+++ b/tests/smoke-test.sh
@@ -360,6 +360,12 @@ CS=$(run cat /home/vscode/.claude/settings.json)
 assert_contains "Claude: sonnet model in settings" "$CS" "claude-sonnet-4-6"
 assert_contains "Claude: opus model in settings" "$CS" "claude-opus-4-6"
 assert_contains "Claude: haiku model in settings" "$CS" "claude-haiku-4-5"
+assert_not_contains "Claude: deprecated code-review plugin absent" "$CS" "code-review@claude-plugins-official"
+assert_not_contains "Claude: deprecated PR-review plugin absent" "$CS" "pr-review-toolkit@claude-plugins-official"
+assert_not_contains "Claude: Codex bridge plugin absent" "$CS" "codex@openai-codex"
+assert_not_contains "Claude: no configured stop gate" "$CS" '"Stop"'
+KNOWN_MARKETPLACES=$(run cat /home/vscode/.claude/plugins/known_marketplaces.json)
+assert_not_contains "Claude: deprecated Codex marketplace absent" "$KNOWN_MARKETPLACES" "openai-codex"
 CJ=$(run cat /home/vscode/.claude.json)
 assert_contains "Claude: auto-approve key" "$CJ" "customApiKeyResponses"
 

--- a/tests/test-review-plugin-removal.sh
+++ b/tests/test-review-plugin-removal.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+REPO_ROOT=$(cd "${SCRIPT_DIR}/.." && pwd)
+SETTINGS="${REPO_ROOT}/claude-config/settings.json"
+DOCKERFILE="${REPO_ROOT}/Dockerfile"
+
+jq -e '
+  .enabledPlugins["code-review@claude-plugins-official"] == null and
+  .enabledPlugins["pr-review-toolkit@claude-plugins-official"] == null and
+  .enabledPlugins["codex@openai-codex"] == null and
+  .extraKnownMarketplaces["openai-codex"] == null and
+  ((.hooks.Stop // []) | length == 0)
+' "${SETTINGS}" >/dev/null
+
+if grep -Eq 'f5-sales-demo/codex-plugin-cc|marketplaces/openai-codex|"openai-codex"' "${DOCKERFILE}"; then
+  echo "Deprecated Codex marketplace remains in Dockerfile" >&2
+  exit 1
+fi
+
+echo "Deprecated Claude/Codex review plugins and stop gates are absent"


### PR DESCRIPTION
## Summary

Removes deprecated Claude and Codex review plugins from the development image while preserving implementation, debugging, language-server, rescue, and status tooling.

## Related Issue

Closes #1642
Related: f5-sales-demo/docs-control#1167

## Changes

- Removes code-review, pr-review-toolkit, and codex@openai-codex installation and enablement.
- Removes the Codex marketplace clone and configuration.
- Adds source and image assertions proving deprecated plugins and stop gates stay absent.

## Verification evidence

- bash tests/test-review-plugin-removal.sh — passed: deprecated Claude/Codex review plugins and stop gates are absent.
- bash scripts/agy-pre-push-review.sh — Antigravity exact-commit gate passed for deb1edefedabb3af57f0044fd85a73d68593990f.
- The full-tree PII precheck reports 17 pre-existing unrelated findings; the reviewed diff adds no finding.

## Checklist

- [x] Linked to a GitHub issue.
- [x] Feature-complete and verified.
- [x] Tests written first and passing; acceptance criteria met.
- [x] Verified locally with evidence above.
- [ ] Required CI pending; auto-merge will wait for green checks.
- [x] Follows project conventions.
